### PR TITLE
log insecure authentication failures at warn level

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/HttpBasedServiceCredentialsAuthenticationHandler.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/HttpBasedServiceCredentialsAuthenticationHandler.java
@@ -60,9 +60,7 @@ public final class HttpBasedServiceCredentialsAuthenticationHandler implements A
         if (this.requireSecure
             && !serviceCredentials.getCallbackUrl().getProtocol().equals(
                 PROTOCOL_HTTPS)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Authentication failed because url was not secure.");
-            }
+            log.warn("Authentication failed because url was not secure.");
             return false;
         }
         log


### PR DESCRIPTION
Log authentication failures due to an insecure protocol at the warn level to make it more apparent. Most people have their root log level at WARN or ERROR, and if this error happens, it's hard to know what went wrong until you bring the log level down to debug.

In our case, our callback servers are behind a secure proxy so it's ok for CAS to talk to them insecurely.  But our sysadmin made a config mistake during a deployment and set the require secure property to true.  We couldn't figure out the problem until we turned our log level to debug (hours later).  This kind of issue seems like a warning situation.