### PR TITLE
CAS-1368: Support POST response to service after password warning check

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/classes/default_views.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/classes/default_views.properties
@@ -88,3 +88,6 @@ casBadWorkstationView.url=/WEB-INF/view/jsp/default/ui/casBadWorkstationView.jsp
 casWarnPassView.(class)=org.springframework.web.servlet.view.JstlView
 casWarnPassView.url=/WEB-INF/view/jsp/default/ui/casWarnPassView.jsp
 
+### Password Expiration Warning message (logged in, PasswordWarningCheck=true, POST)
+casWarnPostView.(class)=org.springframework.web.servlet.view.JstlView
+casWarnPostView.url=/WEB-INF/view/jsp/default/ui/casWarnPostView.jsp

--- a/cas-server-webapp/src/main/webapp/WEB-INF/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/login-webflow.xml
@@ -87,28 +87,45 @@
 	</action-state>
 
 	<decision-state id="passwordPostCheck">
-		<if test="flowScope.service != null" then="warnPassRedirect" else="pwdWarningPostView" />
+		<if test="flowScope.service != null" then="warnPassRedirect" else="pwdWarningView" />
 	</decision-state>
 
 	<action-state id="warnPassRedirect">
 		<evaluate expression="generateServiceTicketAction" />
-		<transition on="success" to="pwdWarningPostView" />
+		<transition on="success" to="warnGetResponse" />
 		<transition on="error" to="generateLoginTicket" />
 		<transition on="gateway" to="gatewayServicesManagementCheck" />
 	</action-state>
+
+  <action-state id="warnGetResponse">
+    <evaluate expression="flowScope.service.getResponse(requestScope.serviceTicketId)" result-type="org.jasig.cas.authentication.principal.Response" result="requestScope.response" />
+    <transition to="warnPostRedirectDecision" />
+  </action-state>
+
+  <decision-state id="warnPostRedirectDecision">
+    <if test="requestScope.response.responseType.name() == 'POST'" then="pwdWarningPostView" else="pwdWarningView" />
+  </decision-state>
 
 	<end-state id="pwdWarningAbstractView">
 		<on-entry>
 			<set name="flowScope.passwordPolicyUrl" value="passwordPolicyAction.getPasswordPolicyUrl()" />
 		</on-entry>
 	</end-state>
-	<end-state id="pwdWarningPostView" view="casWarnPassView" parent="#pwdWarningAbstractView" />
+	<end-state id="pwdWarningView" view="casWarnPassView" parent="#pwdWarningAbstractView" />
 	<end-state id="casExpiredPassView" view="casExpiredPassView" parent="#pwdWarningAbstractView" />
 	<end-state id="casMustChangePassView" view="casMustChangePassView" parent="#pwdWarningAbstractView" />
 	<end-state id="casAccountDisabledView" view="casAccountDisabledView" />
 	<end-state id="casAccountLockedView" view="casAccountLockedView" />
 	<end-state id="casBadHoursView" view="casBadHoursView" />
 	<end-state id="casBadWorkstationView" view="casBadWorkstationView" />
+
+  <end-state id="pwdWarningPostView" view="casWarnPostView">
+    <on-entry>
+        <set name="requestScope.parameters" value="requestScope.response.attributes" />
+        <set name="requestScope.originalUrl" value="flowScope.service.id" />
+        <set name="flowScope.passwordPolicyUrl" value="passwordPolicyAction.getPasswordPolicyUrl()" />
+    </on-entry>
+  </end-state>
 	<!-- LPPE transitions end here... -->
 	
 	<action-state id="generateLoginTicket">

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casWarnPostView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casWarnPostView.jsp
@@ -1,0 +1,56 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<jsp:directive.include file="includes/top.jsp" />
+<c:set var="ticketArg"  value="${serviceTicketId}" scope="page"/>
+<c:if test="${fn:length(ticketArg) > 0}">
+  <c:set var="ticketArg"  value="ticket=${serviceTicketId}"/>
+</c:if>
+
+<div id="msg" class="errors">
+  <c:if test="${expireDays == 0}">
+    <h2><spring:message code="screen.warnpass.heading.today" /></h2>
+  </c:if>
+  <c:if test="${expireDays == 1}">
+    <h2><spring:message code="screen.warnpass.heading.tomorrow" /></h2>
+  </c:if>
+  <c:if test="${expireDays > 1}">
+    <h2><spring:message code="screen.warnpass.heading.other" arguments="${expireDays}" /></h2>
+  </c:if>
+  <form name="acsForm" action="<c:out value="${originalUrl}" escapeXml="true" />" method="post">
+    <p>
+    <spring:message code="screen.warnpass.message.line1" arguments="${passwordPolicyUrl}"  />
+    </p>
+    <p>
+    <spring:message code="screen.warnpass.message.line2" arguments="javascript:document.acsForm.submit();" />
+    </p>
+     <div style="display: none">
+       <c:forEach items="${parameters}" var="entry">
+         <textarea rows=10 cols=80 name="${entry.key}"><c:out value="${entry.value}" escapeXml="true" /></textarea>
+       </c:forEach>
+     </div>
+     <noscript>
+       <p><input type="submit" value="Continue" /></p>
+     </noscript>
+   </form>
+</div>
+<script type="text/javascript">
+  setTimeout("document.acsForm.submit()", 10000);
+</script>


### PR DESCRIPTION
This adds a new view to display the LPPE password warning message and submit the authentication response to the requested service in a POST.  This is required for services using SAML 2 such as GoogleApps. 
JIRA issue: https://issues.jasig.org/browse/CAS-1368