### PR TITLE
CAS-1429 Escape inputs into LDAP filter expressions.

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
@@ -76,7 +76,7 @@ public final class LdapUtils {
         }
 
         for (final String key : properties.keySet()) {
-            final String value = LdapEncoder.nameEncode(properties.get(key));
+            final String value = LdapEncoder.filterEncode(properties.get(key));
             newFilter = newFilter.replaceAll(key, Matcher.quoteReplacement(value));
         }
 


### PR DESCRIPTION
This prevents LDAP injection attacks. Note this patch is only relevant for the 3.5.x branch since master is based on ldaptive, which properly handles character escaping.