### PR TITLE
3.5.2.1 cookie lookup while retrieving TGT-id

### DIFF
--- a/cas-server-integration-restlet/src/main/java/org/jasig/cas/integration/restlet/TicketGrantingTicketResource.java
+++ b/cas-server-integration-restlet/src/main/java/org/jasig/cas/integration/restlet/TicketGrantingTicketResource.java
@@ -18,13 +18,11 @@
  */
 package org.jasig.cas.integration.restlet;
 
-import javax.validation.constraints.NotNull;
-
 import org.apache.commons.lang.StringUtils;
 import org.jasig.cas.CentralAuthenticationService;
+import org.jasig.cas.util.HttpClient;
 import org.jasig.cas.authentication.principal.SimpleWebApplicationServiceImpl;
 import org.jasig.cas.ticket.InvalidTicketException;
-import org.jasig.cas.util.HttpClient;
 import org.restlet.Context;
 import org.restlet.data.Form;
 import org.restlet.data.MediaType;
@@ -39,6 +37,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Implementation of a Restlet resource for creating Service Tickets from a
  * TicketGrantingTicket, as well as deleting a TicketGrantingTicket.
@@ -49,13 +49,17 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  */
 public final class TicketGrantingTicketResource extends Resource {
-	private final static Logger log = LoggerFactory.getLogger(TicketGrantingTicketResource.class);
-	@Autowired
-	private CentralAuthenticationService centralAuthenticationService;
-	private String ticketGrantingTicketId;
-	@Autowired
-	@NotNull
-	private HttpClient httpClient;
+    
+    private final static Logger log = LoggerFactory.getLogger(TicketGrantingTicketResource.class);
+
+    @Autowired
+    private CentralAuthenticationService centralAuthenticationService;
+    
+    private String ticketGrantingTicketId;
+
+    @Autowired
+    @NotNull
+    private HttpClient httpClient;
 
 	public void init(final Context context, final Request request, final Response response) {
 		super.init(context, request, response);
@@ -66,34 +70,35 @@ public final class TicketGrantingTicketResource extends Resource {
 		this.getVariants().add(new Variant(MediaType.APPLICATION_WWW_FORM));
 	}
 
-	public boolean allowDelete() {
-		return true;
-	}
+    public boolean allowDelete() {
+        return true;
+    }
 
-	public boolean allowPost() {
-		return true;
-	}
+    public boolean allowPost() {
+        return true;
+    }
 
-	public void setHttpClient(final HttpClient httpClient) {
-		this.httpClient = httpClient;
-	}
+    public void setHttpClient(final HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
 
-	public void removeRepresentations() throws ResourceException {
-		this.centralAuthenticationService.destroyTicketGrantingTicket(this.ticketGrantingTicketId);
-		getResponse().setStatus(Status.SUCCESS_OK);
-	}
+    public void removeRepresentations() throws ResourceException {
+        this.centralAuthenticationService.destroyTicketGrantingTicket(this.ticketGrantingTicketId);
+        getResponse().setStatus(Status.SUCCESS_OK);
+    }
 
-	public void acceptRepresentation(final Representation entity) throws ResourceException {
-		final Form form = getRequest().getEntityAsForm();
-		final String serviceUrl = form.getFirstValue("service");
-		try {
-			final String serviceTicketId = this.centralAuthenticationService.grantServiceTicket(this.ticketGrantingTicketId, new SimpleWebApplicationServiceImpl(serviceUrl, this.httpClient));
-			getResponse().setEntity(serviceTicketId, MediaType.TEXT_PLAIN);
-		} catch (final InvalidTicketException e) {
-			getResponse().setStatus(Status.CLIENT_ERROR_NOT_FOUND, "TicketGrantingTicket could not be found.");
-		} catch (final Exception e) {
-			log.error(e.getMessage(), e);
-			getResponse().setStatus(Status.CLIENT_ERROR_BAD_REQUEST, e.getMessage());
-		}
-	}
+    public void acceptRepresentation(final Representation entity)
+        throws ResourceException {
+        final Form form = getRequest().getEntityAsForm();
+        final String serviceUrl = form.getFirstValue("service");
+        try {
+            final String serviceTicketId = this.centralAuthenticationService.grantServiceTicket(this.ticketGrantingTicketId, new SimpleWebApplicationServiceImpl(serviceUrl, this.httpClient));
+            getResponse().setEntity(serviceTicketId, MediaType.TEXT_PLAIN);
+        } catch (final InvalidTicketException e) {
+            getResponse().setStatus(Status.CLIENT_ERROR_NOT_FOUND, "TicketGrantingTicket could not be found.");
+        } catch (final Exception e) {
+            log.error(e.getMessage(),e);
+            getResponse().setStatus(Status.CLIENT_ERROR_BAD_REQUEST, e.getMessage());
+        }
+    }
 }

--- a/cas-server-integration-restlet/src/main/java/org/jasig/cas/integration/restlet/TicketGrantingTicketResource.java
+++ b/cas-server-integration-restlet/src/main/java/org/jasig/cas/integration/restlet/TicketGrantingTicketResource.java
@@ -61,14 +61,14 @@ public final class TicketGrantingTicketResource extends Resource {
     @NotNull
     private HttpClient httpClient;
 
-	public void init(final Context context, final Request request, final Response response) {
-		super.init(context, request, response);
-		this.ticketGrantingTicketId = request.getCookies().getValues("CASTGC");
-		if (StringUtils.isBlank(this.ticketGrantingTicketId)) {
-			this.ticketGrantingTicketId = (String) request.getAttributes().get("ticketGrantingTicketId");
-		}
-		this.getVariants().add(new Variant(MediaType.APPLICATION_WWW_FORM));
-	}
+    public void init(final Context context, final Request request, final Response response) {
+        super.init(context, request, response);
+        this.ticketGrantingTicketId = request.getCookies().getValues("CASTGC");
+        if (StringUtils.isBlank(this.ticketGrantingTicketId)) {
+            this.ticketGrantingTicketId = (String) request.getAttributes().get("ticketGrantingTicketId");
+        }
+        this.getVariants().add(new Variant(MediaType.APPLICATION_WWW_FORM));
+    }
 
     public boolean allowDelete() {
         return true;
@@ -89,8 +89,11 @@ public final class TicketGrantingTicketResource extends Resource {
 
     public void acceptRepresentation(final Representation entity)
         throws ResourceException {
-        final Form form = getRequest().getEntityAsForm();
-        final String serviceUrl = form.getFirstValue("service");
+        String serviceUrl = getQuery().getFirstValue("service");
+        if (StringUtils.isBlank(serviceUrl)) {
+            final Form form = getRequest().getEntityAsForm();
+            serviceUrl = form.getFirstValue("service");
+        }
         try {
             final String serviceTicketId = this.centralAuthenticationService.grantServiceTicket(this.ticketGrantingTicketId, new SimpleWebApplicationServiceImpl(serviceUrl, this.httpClient));
             getResponse().setEntity(serviceTicketId, MediaType.TEXT_PLAIN);


### PR DESCRIPTION
Here is a simple change to check the cookie while retrieving the TGT-Id ; before that, TGT-Id was only retrieved from the {ticketGrantingTicketId} mapping (/v1/tickets/{ticketGrantingTicketId}).

This change answers this matter :
- John is connecting to an application A. Very classic CAS application, John is redirected to CAS, authentifies, gets a TG Cookie, is redirected back to his application with a ST which is validated between Application A and CAS : John is authentified on application A and has a TGCookie on CAS domain.
- John go to a page on application A that use a webservice W on the front side. W is also protected by CAS. John needs a ST to get to webservice W.
- we don't want John to authenticate himself on the CAS REST API as we don't have its credential. Also, we don't want to ask John for his credential once again (this time through Application A and not through CAS)

Webservice W is called from Application A's domain through AJAX with CORS enable. To get a new ST to reach webservice W, we need to call CAS with AJAX (/v1/tickets/xxxx), but we don't have the TGT-Id information (the xxxx part of the URL). What we know is that John is authenticated on CAS and have a TGCookie on CAS domain. So that, we will enable this cookie to be send with the AJAX request on CAS (with the withCredentials feature : http://quickleft.com/blog/cookies-with-my-cors). That way, the TGT-id will be send to CAS and we can get the ST without having access to credentials on application A's domain.

Of course, we can turn our architecture to Oauth ... but it is way less easy to set up than a classic CAS server.