### PR TITLE
Fix Nullpointer exception in Saml10ObjectBuilder.newAttributeStatement.

### DIFF
--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/Saml10ObjectBuilder.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/Saml10ObjectBuilder.java
@@ -220,23 +220,25 @@ public final class Saml10ObjectBuilder extends AbstractSamlObjectBuilder {
         final AttributeStatement attrStatement = newSamlObject(AttributeStatement.class);
         attrStatement.setSubject(subject);
         for (final Map.Entry<String, Object> e : attributes.entrySet()) {
-            if (e.getValue() instanceof Collection<?> && ((Collection<?>) e.getValue()).isEmpty()) {
-                // bnoordhuis: don't add the attribute, it causes a org.opensaml.MalformedException
-                logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
-                continue;
-            }
-            if (e.getValue() instanceof Collection<?> && ((Collection<?>) e.getValue()).size() == 1
-                    && ((Collection<?>) e.getValue()).contains(null)) {
-                logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
-                continue;
-            }
+            //            if (e.getValue() instanceof Collection<?> && ((Collection<?>) e.getValue()).isEmpty()) {
+            //                // bnoordhuis: don't add the attribute, it causes a org.opensaml.MalformedException
+            //                logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
+            //                continue;
+            //            }
+            //            if (e.getValue() instanceof Collection<?> && ((Collection<?>) e.getValue()).size() == 1
+            //                    && ((Collection<?>) e.getValue()).contains(null)) {
+            //                logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
+            //                continue;
+            //            }
             final Attribute attribute = newSamlObject(Attribute.class);
             attribute.setAttributeName(e.getKey());
             attribute.setAttributeNamespace(attributeNamespace);
             if (e.getValue() instanceof Collection<?>) {
                 final Collection<?> c = (Collection<?>) e.getValue();
                 for (final Object value : c) {
-                    attribute.getAttributeValues().add(newAttributeValue(value, AttributeValue.DEFAULT_ELEMENT_NAME));
+                    if (value != null) {
+                        attribute.getAttributeValues().add(newAttributeValue(value, AttributeValue.DEFAULT_ELEMENT_NAME));
+                    }
                 }
             } else {
                 attribute.getAttributeValues().add(newAttributeValue(e.getValue(), AttributeValue.DEFAULT_ELEMENT_NAME));

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/Saml10ObjectBuilder.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/Saml10ObjectBuilder.java
@@ -55,6 +55,7 @@ import java.util.Map;
  * This is the response builder for Saml1 Protocol.
  *
  * @author Misagh Moayyed mmoayyed@unicon.net
+ * @author Martin Baumgartner
  * @since 4.1
  */
 public final class Saml10ObjectBuilder extends AbstractSamlObjectBuilder {
@@ -224,6 +225,10 @@ public final class Saml10ObjectBuilder extends AbstractSamlObjectBuilder {
                 logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
                 continue;
             }
+            if (e.getValue() instanceof Collection<?> && ((Collection<?>) e.getValue()).size() == 1 && ((Collection<?>) e.getValue()).contains(null) ) {
+                logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
+                continue;
+            }          
             final Attribute attribute = newSamlObject(Attribute.class);
             attribute.setAttributeName(e.getKey());
             attribute.setAttributeNamespace(attributeNamespace);

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/Saml10ObjectBuilder.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/Saml10ObjectBuilder.java
@@ -225,10 +225,11 @@ public final class Saml10ObjectBuilder extends AbstractSamlObjectBuilder {
                 logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
                 continue;
             }
-            if (e.getValue() instanceof Collection<?> && ((Collection<?>) e.getValue()).size() == 1 && ((Collection<?>) e.getValue()).contains(null) ) {
+            if (e.getValue() instanceof Collection<?> && ((Collection<?>) e.getValue()).size() == 1
+                    && ((Collection<?>) e.getValue()).contains(null)) {
                 logger.info("Skipping attribute {} because it does not have any values.", e.getKey());
                 continue;
-            }          
+            }
             final Attribute attribute = newSamlObject(Attribute.class);
             attribute.setAttributeName(e.getKey());
             attribute.setAttributeNamespace(attributeNamespace);

--- a/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
+++ b/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
@@ -52,6 +52,8 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Scott Battaglia
  * @author Marvin S. Addison
+ * @author Martin Baumgartner
+
  * @since 3.1
  *
  */
@@ -87,6 +89,7 @@ public class Saml10SuccessResponseViewTests {
         attributes.put("testAttribute", "testValue");
         attributes.put("testEmptyCollection", Collections.emptyList());
         attributes.put("testAttributeCollection", Arrays.asList(new String[] {"tac1", "tac2"}));
+        attributes.put("testEmptyAttribute", null);
         final SimplePrincipal principal = new SimplePrincipal("testPrincipal", attributes);
 
         final Map<String, Object> authAttributes = new HashMap<String, Object>();
@@ -115,6 +118,7 @@ public class Saml10SuccessResponseViewTests {
         assertTrue(written.contains(SamlAuthenticationMetaDataPopulator.AUTHN_METHOD_SSL_TLS_CLIENT));
         assertTrue(written.contains("AuthenticationMethod"));
         assertTrue(written.contains("AssertionID"));
+        assertFalse(written.contains("testEmptyAttribute"));
     }
 
     @Test


### PR DESCRIPTION
Attention: 
Due to the changes from 4.0 -> 4.1, Saml10SuccessResponseView:93, now
converts all attributes to collections, even if the values are null.