### PR TITLE
Check service eligibility before asking for ST

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -395,7 +395,10 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
     public Assertion validateServiceTicket(final String serviceTicketId, final Service service) throws TicketException {
         Assert.notNull(serviceTicketId, "serviceTicketId cannot be null");
         Assert.notNull(service, "service cannot be null");
- 
+
+        final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
+        verifyRegisteredServiceProperties(registeredService, service);
+
         final ServiceTicket serviceTicket =  this.serviceTicketRegistry.getTicket(serviceTicketId, ServiceTicket.class);
 
         if (serviceTicket == null) {
@@ -403,10 +406,6 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
             throw new InvalidTicketException(serviceTicketId);
         }
 
-        final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
-
-        verifyRegisteredServiceProperties(registeredService, serviceTicket.getService());
-        
         try {
             synchronized (serviceTicket) {
                 if (serviceTicket.isExpired()) {

--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -392,10 +392,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
     @Profiled(tag="VALIDATE_SERVICE_TICKET", logFailuresSeparately = false)
     @Transactional(readOnly = false)
     @Override
-    public Assertion validateServiceTicket(final String serviceTicketId, final Service service) throws TicketException {
-        Assert.notNull(serviceTicketId, "serviceTicketId cannot be null");
-        Assert.notNull(service, "service cannot be null");
-
+    public Assertion validateServiceTicket(@NotNull final String serviceTicketId, @NotNull final Service service) throws TicketException {
         final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
         verifyRegisteredServiceProperties(registeredService, service);
 


### PR DESCRIPTION
This pull request attempts to verify that a service request is eligible for authentication and more, before locating its ST from the ticket registry. This should help reduce the burden that is put on the ticket registry. 