### PR TITLE
Update ICLA Link

### DIFF
--- a/developer/Contributor-Guidelines.md
+++ b/developer/Contributor-Guidelines.md
@@ -6,8 +6,8 @@ title: CAS - Contributor Guidelines
 # Contributor Guidelines
 
 ## Licensing
-All developers that contribute source to CAS must complete and file a Jasig
-[Individual Contributor License Agreement](https://wiki.jasig.org/x/u4WcAQ) (ICLA). This agreement provides legal
+All developers that contribute source to CAS must complete and file a Apereo
+[Individual Contributor License Agreement](https://www.apereo.org/licensing/agreements) (ICLA). This agreement provides legal
 protection to both the CAS project and to individual developers while preserving copyright ownership of the author.
 Any patch or pull request submitted by a developer will only be accepted if there is an ICLA on file for the
 developer.


### PR DESCRIPTION
Point new contributors to the Apereo agreement rather than the Jasig agreement to fix #847.