### PR TITLE
Correct and update Spanish and Catalan translations

### DIFF
--- a/cas-server-webapp/src/main/resources/messages_ca.properties
+++ b/cas-server-webapp/src/main/resources/messages_ca.properties
@@ -21,91 +21,93 @@
 # under the License.
 #
 
-screen.welcome.welcome=Felicitats per engegar el CAS correctament! Per aprendre com autenticar, si us plau, repasseu la configuraci\u00f3 del gestor d'autenticaci\u00f3 per defecte.
-screen.welcome.security=Per raons de seguretat, si us plau, tanqueu la sessi\u00f3 i el vostre navegador web quan h\u00e0giu acabat d'accedir als serveis que requereixen autenticaci\u00f3.
-screen.welcome.instructions=Introdu\u00efu el vostre nom d'usuari i contrasenya.
+screen.welcome.welcome=Felicitats per engegar el CAS correctament! Per a aprendre com autenticar, si us plau, repasseu la configuració del gestor d'autenticació per defecte.
+screen.welcome.security=Per raons de seguretat, si us plau, tanqueu la sessió i el vostre navegador web quan hàgiu acabat d'accedir als serveis que requereixen autenticació.
+screen.welcome.instructions=Introduïu el vostre nom d'usuari i contrasenya.
 screen.welcome.label.netid=Nom d'<span class="accesskey">u</span>suari:
 screen.welcome.label.netid.accesskey=u
 screen.welcome.label.password=<span class="accesskey">C</span>ontrasenya:
 screen.welcome.label.password.accesskey=c
-screen.welcome.label.warn=<span class="accesskey">A</span>viseu-me abans d'obrir sessi\u00f3 en altres llocs.
+screen.welcome.label.warn=<span class="accesskey">A</span>viseu-me abans d'obrir sessió en altres llocs.
 screen.welcome.label.warn.accesskey=a
-screen.welcome.button.login=INICIA SESSI\u00d3
+screen.welcome.button.login=INICIA SESSIÓ
 screen.welcome.button.clear=NETEJA
 
-logo.title=v\u00e9s a la p\u00e0gina principal de Apereo
-copyright=Copyright &copy; 2005&ndash;2015 Apereo, Inc. Tots els drets reservats.
-screen.capslock.on = La tecla BLOQ MAJ est\u00e0 activada!
+logo.title=vés a la pàgina principal de l'Apereo
+copyright=Copyright &copy; 2005&ndash;2015 Apereo, Inc. Es reserven tots els drets.
+screen.capslock.on = La tecla BLOQ MAJ està activada!
 
 # Blocked Errors Page
-screen.blocked.header=Acc\u00e9s denegat
-screen.blocked.message=Heu introdu\u00efda una contrasenya equivocada pel usuari massa vegades. Se us ha restringit.
+screen.blocked.header=Accés denegat
+screen.blocked.message=Heu introduïda una contrasenya equivocada per al usuari massa vegades. Se us ha restringit.
 
 #Confirmation Screen Messages
-screen.confirmation.message=Feu clic <a href="{0}">aqu\u00ed</a> per a anar a l'aplicaci\u00f3.
+screen.confirmation.message=Feu clic <a href="{0}">aquí</a> per a anar a l'aplicació.
 
 #Generic Success Screen Messages
-screen.success.header=Inici de sessi\u00f3 reeixit.
-screen.success.success=Heu iniciat amb \u00e8xit la sessi\u00f3 al Servei Central d'Autenticaci\u00f3 (CAS).
-screen.success.security=Per raons de seguretat, si us plau, tanqueu la sessi\u00f3 i el vostre navegador web quan h\u00e0giu terminat.
+screen.success.header=Inici de sessió reeixit
+screen.success.success=Vós, {0}, heu iniciat amb èxit la sessió al Servei Central d''Autenticació (CAS).
+screen.success.security=Per raons de seguretat, si us plau, tanqueu la sessió i el vostre navegador web quan hàgiu terminat.
 
 #Logout Screen Messages
-screen.logout.header=Tancament de sessi\u00f3 reeixit.
-screen.logout.success=Heu tancat amb \u00e8xit la sessi\u00f3 al Servei Central d'Autenticaci\u00f3 (CAS).
+screen.logout.header=Tancament de sessió reeixit
+screen.logout.success=Heu tancat amb èxit la sessió al Servei Central d'Autenticació (CAS).
 screen.logout.security=Per raons de seguretat, tanqueu el vostre navegador web.
-screen.logout.redirect=El servei des del qual heu arribat ha proporcionat un <a href="{0}">enlla\u00e7 que podeu seguir per fer clic aqu\u00ed</a>.
+screen.logout.redirect=El servei des del qual heu arribat ha proporcionat un <a href="{0}">enllaç que podeu seguir per fer clic aquí</a>.
 
 screen.service.sso.error.header=Cal reautenticar per a accedir a aquest servei
-screen.service.sso.error.message=Heu intentat accedir a un servei que requereix autenticaci\u00f3 sense reautenticar. Si us plau, intenteu <a href="{0}">autenticar de nou</a>.
+screen.service.sso.error.message=Heu intentat accedir a un servei que requereix autenticació sense reautenticar. Si us plau, intenteu <a href="{0}">autenticar de nou</a>.
 
 error.invalid.loginticket=No podeu intentar reenviar un formulari que ja s'ha enviat.
-required.username=El nom d'usuari \u00e9s un camp obligatori.
-required.password=La contrasenya \u00e9s un camp obligatori.
+required.username=El nom d'usuari és un camp obligatori.
+required.password=La contrasenya és un camp obligatori.
 
 # Authentication failure messages
 authenticationFailure.AccountDisabledException=S'ha deshabilitat aquest compte.
 authenticationFailure.AccountLockedException=S'ha bloquejat aquest compte.
 authenticationFailure.CredentialExpiredException=La vostra contrasenya ha caducada.
-authenticationFailure.InvalidLoginLocationException=No podeu iniciar sessi\u00f3 des d'aquesta estaci\u00f3 de treball.
-authenticationFailure.InvalidLoginTimeException=Est\u00e0 prohibit iniciar sessi\u00f3 amb el vostre compte en aquest moment.
-authenticationFailure.AccountNotFoundException=Credencials inv\u00e0lids.
-authenticationFailure.FailedLoginException=Credencials inv\u00e0lids.
-authenticationFailure.UNKNOWN=Credencials inv\u00e0lids.
+authenticationFailure.InvalidLoginLocationException=No podeu iniciar sessió des d'aquesta estació de treball.
+authenticationFailure.InvalidLoginTimeException=Està prohibit iniciar sessió amb el vostre compte en aquest moment.
+authenticationFailure.AccountNotFoundException=Les credencials són invàlides.
+authenticationFailure.FailedLoginException=Les credencials són invàlides.
+authenticationFailure.UNKNOWN=Les credencials són invàlides.
 
-INVALID_REQUEST_PROXY=calen ambd\u00f3s dels par\u00e0metres 'pgt' i 'targetService'
-INVALID_TICKET_SPEC=El tiquet ha fallat l'especificaci\u00f3 de validaci\u00f3. Els errors possibles poden incloure intentar validar un tiquet de proxy mitjan\u00e7ant un validador de tiquets de servei, o no complir amb la petici\u00f3 de renovaci\u00f3 (renew true).
-INVALID_REQUEST=calen ambd\u00f3s dels par\u00e0metres 'service' i 'ticket'
-INVALID_TICKET=No s'ha reconegut el tiquet ''{0}''
+INVALID_REQUEST_PROXY=calen ambdós dels paràmetres 'pgt' i 'targetService'
+INVALID_TICKET_SPEC=El tiquet ha fallat l'especificació de validació. Els errors possibles poden incloure intentar validar un tiquet d'intermediari mitjançant un validador de tiquets de servei, o no complir amb la petició de renovació (renew true).
+INVALID_REQUEST=calen ambdós dels paràmetres 'service' i 'ticket'
+INVALID_TICKET=No s''ha reconegut el tiquet ''{0}''
 INVALID_SERVICE=El tiquet ''{0}'' no coincideix amb el servei proporcionat. El servei original era ''{1}'' i el servei proporcionat era ''{2}''.
-INVALID_PROXY_CALLBACK=L'adre\u00e7a de retrotrucada del intermediari prove\u00efda ''{0}'' no s'ha poguda autenticar.
-UNAUTHORIZED_SERVICE_PROXY=El servei proporcionat ''{0}'' no est\u00e0 autoritzat a utilitzar l'autenticaci\u00f3 intermedi\u00e0ria del CAS.
+INVALID_PROXY_CALLBACK=L''adreça de retrotrucada d''intermediari proveïda ''{0}'' no s''ha pogut autenticar.
+UNAUTHORIZED_SERVICE_PROXY=El servei proporcionat ''{0}'' no està autoritzat a utilitzar l''autenticació intermediària del CAS.
 
-screen.service.error.header=Aplicaci\u00f3 no autoritzada a utilitzar el CAS
-screen.service.error.message=L'aplicaci\u00f3 a que heu intentat autenticar no est\u00e0 autoritzada a utilitzar el CAS.
-screen.service.empty.error.message=El registre de serveis del CAS est\u00e0 buit i no t\u00e9 definicions de servei. \
-Les aplicacions que volen autenticar amb el CAS han de ser expl\u00edcitament definides en el registre de serveis.
+screen.service.error.header=Aplicació no autoritzada a utilitzar el CAS
+service.not.authorized.missing.attr=No esteu autoritzat a accedir a l'aplicació perquè al vostre compte \
+li manquen els privilegis que el servidor CAS requereix per a autenticar a aquest servei. Si us plau, notifiqueu al vostre suport tècnic.
+screen.service.error.message=L'aplicació a que heu intentat autenticar no està autoritzada a utilitzar el CAS.
+screen.service.empty.error.message=El registre de serveis del CAS està buit i no té definicions de servei. \
+Les aplicacions que volen autenticar amb el CAS han de ser explícitament definides en el registre de serveis.
 
 # Password policy
 password.expiration.warning=La vostra contrasenya caduca en {0} dies. Si us plau, <a href="{1}">canvieu la vostra contrasenya</a> ara.
-password.expiration.loginsRemaining=Teniu {0} inicis de sessi\u00f3 restant abans que <strong>HEU</strong> de canviar la vostra contrasenya.
+password.expiration.loginsRemaining=Teniu {0} inicis de sessió restant abans que <strong>HEU</strong> de canviar la vostra contrasenya.
 screen.accountdisabled.heading=S'ha deshabilitat aquest compte.
-screen.accountdisabled.message=Si us plau, contacteu a l'administrador de sistema per a recobrar l'acc\u00e9s.
+screen.accountdisabled.message=Si us plau, contacteu a l'administrador de sistema per a recobrar accés.
 screen.accountlocked.heading=S'ha bloquejat aquest compte.
-screen.accountlocked.message=Si us plau, contacteu a l'administrador de sistema per a recobrar l'acc\u00e9s.
+screen.accountlocked.message=Si us plau, contacteu a l'administrador de sistema per a recobrar accés.
 screen.expiredpass.heading=La vostra contrasenya ha caducada.
 screen.expiredpass.message=Si us plau, <a href="{0}">canvieu la vostra contrasenya</a>.
 screen.mustchangepass.heading=Heu de canviar la vostra contrasenya.
 screen.mustchangepass.message=Si us plau, <a href="{0}">canvieu la vostra contrasenya</a>.
-screen.badhours.heading=Est\u00e0 prohibit iniciar sessi\u00f3 amb el vostre compte en aquest moment.
-screen.badhours.message=Si us plau, intenteu m\u00e9s tard.
-screen.badworkstation.heading=No podeu iniciar sessi\u00f3 des d'aquesta estaci\u00f3 de treball.
-screen.badworkstation.message=Si us plau, contacteu a l'administrador de sistema per a recobrar l'acc\u00e9s.
+screen.badhours.heading=Està prohibit iniciar sessió amb el vostre compte en aquest moment.
+screen.badhours.message=Si us plau, intenteu més tard.
+screen.badworkstation.heading=No podeu iniciar sessió des d'aquesta estació de treball.
+screen.badworkstation.message=Si us plau, contacteu a l'administrador de sistema per a recobrar accés.
 
 # OAuth
-screen.oauth.confirm.header=Autoritzaci\u00f3
-screen.oauth.confirm.message=Voleu concedir acc\u00e9s al vostre perfil complet a "{0}"?
+screen.oauth.confirm.header=Autorització
+screen.oauth.confirm.message=Voleu concedir accés al vostre perfil complet a "{0}"?
 screen.oauth.confirm.allow=Permet
 
 # Unavailable
-screen.unavailable.heading=El CAS no est\u00e0 disponible
-screen.unavailable.message=Ha hagu\u00e9s un error al intentar complir amb la vostra petici\u00f3. Si us plau, notifiqueu al vostre servei d'assist\u00e8ncia o intenteu de nou.
+screen.unavailable.heading=El CAS no està disponible
+screen.unavailable.message=Ha hagut un error al intentar complir amb la vostra petició. Si us plau, notifiqueu al vostre suport tècnic o intenteu de nou.

--- a/cas-server-webapp/src/main/resources/messages_es.properties
+++ b/cas-server-webapp/src/main/resources/messages_es.properties
@@ -21,90 +21,93 @@
 # under the License.
 #
 
-screen.welcome.welcome=\u00a1Felicidades por iniciar CAS correctamente! Para aprender c\u00f3mo autenticar, por favor repase la configuraci\u00f3n del manejador de configuraci\u00f3n por defecto.
-screen.welcome.security=Por razones de seguridad, por favor cierre su sesi\u00f3n y su navegador web cuando haya terminado de acceder a los servicios que requieren autenticaci\u00f3n.
-screen.welcome.instructions=Introduzca su nombre de usuario y contrase\u00f1a.
+screen.welcome.welcome=¡Felicidades por iniciar CAS correctamente! Para aprender cómo autenticar, por favor repase la configuración del gestor de configuración por defecto.
+screen.welcome.security=Por razones de seguridad, ¡por favor cierre su sesión y su navegador web cuando haya terminado de acceder a los servicios que requieren autenticación!
+screen.welcome.instructions=Introduzca su nombre de usuario y contraseña.
 screen.welcome.label.netid=Nombre de <span class="accesskey">u</span>suario:
 screen.welcome.label.netid.accesskey=u
-screen.welcome.label.password=<span class="accesskey">C</span>ontrase\u00f1a:
+screen.welcome.label.password=<span class="accesskey">C</span>ontraseña:
 screen.welcome.label.password.accesskey=c
-screen.welcome.label.warn=<span class="accesskey">A</span>visarme antes de abrir sesi\u00f3n en otros sitios.
+screen.welcome.label.warn=<span class="accesskey">A</span>visarme antes de abrir sesión en otros sitios.
 screen.welcome.label.warn.accesskey=a
-screen.welcome.button.login=INICIAR SESI\u00d3N
+screen.welcome.button.login=INICIAR SESIÓN
 screen.welcome.button.clear=LIMPIAR
 
-logo.title=ir a la p\u00e1gina principal de Apereo
-copyright=Copyright &copy; 2005&ndash;2012 Apereo, Inc. Todos los derechos reservados.
+logo.title=ir a la página principal de Apereo
+copyright=Copyright &copy; 2005&ndash;2015 Apereo, Inc. Se reservan todos los derechos.
+screen.capslock.on = ¡La tecla BLOQ MAYÚS está activada!
 
 # Blocked Errors Page
-screen.blocked.header=Acceso Denegado
-screen.blocked.message=Ha introducido una contrase\u00f1a equivocada por el usuario demasiadas veces. Se le ha restringido.
+screen.blocked.header=Acceso denegado
+screen.blocked.message=Ha introducido una contraseña equivocada para el usuario demasiadas veces. Se le ha restringido.
 
 #Confirmation Screen Messages
-screen.confirmation.message=Haga clic <a href="{0}">aqu\u00ed</a> para ir a la aplicaci\u00f3n.
+screen.confirmation.message=Haga clic <a href="{0}">aquí</a> para ir a la aplicación.
 
 #Generic Success Screen Messages
-screen.success.header=Inicio de sesi\u00f3n exitoso.
-screen.success.success=Ha iniciado con \u00e9xito su sesi\u00f3n en el Servicio de Autenticaci\u00f3n Central.
-screen.success.security=Por razones de seguridad, por favor cierre su sesi\u00f3n y su navegador web cuando haya terminado de acceder a los servicios que requieren autenticaci\u00f3n.
+screen.success.header=Inicio de sesión exitoso
+screen.success.success=Usted, {0}, ha iniciado con éxito su sesión en el Servicio de Autenticación Central.
+screen.success.security=Por razones de seguridad, por favor cierre su sesión y su navegador web cuando haya terminado de acceder a los servicios que requieren autenticación.
 
 #Logout Screen Messages
-screen.logout.header=Cierre de sesi\u00f3n exitoso.
-screen.logout.success=Ha cerrado con \u00e9xito su sesi\u00f3n del Servicio de Autenticaci\u00f3n Central.
+screen.logout.header=Cierre de sesión exitoso
+screen.logout.success=Ha cerrado con éxito su sesión del Servicio de Autenticación Central.
 screen.logout.security=Por razones de seguridad, cierre su navegador web.
-screen.logout.redirect=El servicio desde el cual ha llegado ha proporcionado un <a href="{0}">enlace que puede seguir por hacer clic aqu\u00ed</a>.
+screen.logout.redirect=El servicio desde el cual ha llegado ha proporcionado un <a href="{0}">enlace que puede seguir por hacer clic aquí</a>.
 
-screen.service.sso.error.header=Reautenticaci\u00f3n requerida para acceder a este servicio.
-screen.service.sso.error.message=Intent\u00f3 acceder a un servicio que requiere autenticaci\u00f3n sin reautenticar. Por favor intente <a href="{0}">autenticar de nuevo</a>.
+screen.service.sso.error.header=Reautenticación requerida para acceder a este servicio
+screen.service.sso.error.message=Intentó acceder a un servicio que requiere autenticación sin reautenticar. Por favor intente <a href="{0}">autenticar de nuevo</a>.
 
 error.invalid.loginticket=No puede intentar reenviar un formulario que ya se ha enviado.
 required.username=El nombre de usuario es un campo requerido.
-required.password=La contrase\u00f1a es un campo requerido.
+required.password=La contraseña es un campo requerido.
 
 # Authentication failure messages
 authenticationFailure.AccountDisabledException=Se ha deshabilitado esta cuenta.
 authenticationFailure.AccountLockedException=Se ha bloqueado esta cuenta.
-authenticationFailure.CredentialExpiredException=Su contrase\u00f1a ha caducado.
-authenticationFailure.InvalidLoginLocationException=No puede iniciar sesi\u00f3n desde esta estaci\u00f3n de trabajo.
-authenticationFailure.InvalidLoginTimeException=Est\u00e1 prohibido iniciar sesi\u00f3n con su cuenta en este momento.
-authenticationFailure.AccountNotFoundException=Credenciales inv\u00e1lidos.
-authenticationFailure.FailedLoginException=Credenciales inv\u00e1lidos.
-authenticationFailure.UNKNOWN=Credenciales inv\u00e1lidos.
+authenticationFailure.CredentialExpiredException=Su contraseña ha caducado.
+authenticationFailure.InvalidLoginLocationException=No puede iniciar sesión desde esta estación de trabajo.
+authenticationFailure.InvalidLoginTimeException=Está prohibido iniciar sesión con su cuenta en este momento.
+authenticationFailure.AccountNotFoundException=Credenciales inválidas.
+authenticationFailure.FailedLoginException=Credenciales inválidas.
+authenticationFailure.UNKNOWN=Credenciales inválidas.
 
-INVALID_REQUEST_PROXY=ambos de los par\u00e1metros 'pgt' y 'targetService' se requieren
-INVALID_TICKET_SPEC=El ticket fall\u00f3 la especificaci\u00f3n de validaci\u00f3n. Los errores posibles pueden incluir intentar validar un ticket de proxy mediante un validador de tickets de servei, o no cumplir con la petici\u00f3n de renovaci\u00f3n (renew true).
-INVALID_REQUEST=ambos de los par\u00e1metros 'service' y 'ticket' se requieren
-INVALID_TICKET=No se ha reconocido el ticket ''{0}''
-INVALID_SERVICE=Ticket ''{0}'' no coincide con el servicio proporcionado. El servicio original era ''{1}'' y el servicio proporcionado era ''{2}''.
-INVALID_PROXY_CALLBACK=La direcci\u00f3n web de retrollamada de proxy ''{0}'' no se pudo autenticar.
-UNAUTHORIZED_SERVICE_PROXY=El servicio proporcionado ''{0}'' no est\u00e1 autorizado a usar la autenticaci\u00f3n de proxy CAS.
+INVALID_REQUEST_PROXY=ambos de los parámetros 'pgt' y 'targetService' se requieren
+INVALID_TICKET_SPEC=El tique falló la especificación de validación. Los errores posibles pueden incluir intentar validar un tique de proxy mediante un validador de tiques de servicio, o no cumplir con la petición de renovación (renew true).
+INVALID_REQUEST=ambos de los parámetros 'service' y 'ticket' se requieren
+INVALID_TICKET=No se ha reconocido el tique ''{0}''
+INVALID_SERVICE=El tique ''{0}'' no coincide con el servicio proporcionado. El servicio original era ''{1}'' y el servicio proporcionado era ''{2}''.
+INVALID_PROXY_CALLBACK=La dirección web de retrollamada de proxy ''{0}'' no se pudo autenticar.
+UNAUTHORIZED_SERVICE_PROXY=El servicio proporcionado ''{0}'' no está autorizado a usar la autenticación de proxy CAS.
 
-screen.service.error.header=Aplicaci\u00f3n no autorizada a usar CAS
-screen.service.error.message=La aplicaci\u00f3n que usted ha intentado autenticar no est\u00e1 autorizada a usar CAS.
-screen.service.empty.error.message=El registro de servicios del CAS est\u00e1 vac\u00edo y no tiene definiciones de servicio. \
-Las aplicaciones que quieren autenticar con CAS deben ser explic\u00edtamente definidas en el registro de servcios.
+screen.service.error.header=Aplicación no autorizada a usar CAS
+service.not.authorized.missing.attr=No está autorizado a accedir a la aplicación porque a su cuenta \
+le faltan privilegios que el servidor CAS requiere para autenticar a este servicio. Por favor, notifique a su soporte técnico.
+screen.service.error.message=La aplicación que usted ha intentado autenticar no está autorizada a usar CAS.
+screen.service.empty.error.message=El registro de servicios del CAS está vacío y no tiene definiciones de servicio. \
+Las aplicaciones que quieren autenticar con CAS deben ser explícitamente definidas en el registro de servicios.
 
 # Password policy
-password.expiration.warning=Su contrase\u00f1a caduca en {0} d\u00edas. Por favor <a href="{1}">cambie su contrase\u00f1a</a> ahora.
-password.expiration.loginsRemaining=Tiene {0} inicios de sesi\u00f3n restantes antes que <strong>DEBE</strong> cambiar su contrase\u00f1a.
+password.expiration.warning=Su contraseña caduca en {0} días. Por favor <a href="{1}">cambie su contraseña</a> ahora.
+password.expiration.loginsRemaining=Tiene {0} inicios de sesión restantes antes que <strong>DEBE</strong> cambiar su contraseña.
 screen.accountdisabled.heading=Se ha deshabilitado esta cuenta.
-screen.accountdisabled.message=Por favor contacte al administrador de sistema para recobrar el acceso.
+screen.accountdisabled.message=Por favor contacte al administrador de sistema para recobrar acceso.
 screen.accountlocked.heading=Se ha bloqueado esta cuenta.
-screen.accountlocked.message=Por favor contacte al administrador de sistema para recobrar el acceso.
-screen.expiredpass.heading=Su contrase\u00f1a ha caducado.
-screen.expiredpass.message=Por favor <a href="{0}">cambie su contrase\u00f1a</a>.
-screen.mustchangepass.heading=Debe cambiar su contrase\u00f1a.
-screen.mustchangepass.message=Por favor <a href="{0}">cambie su contrase\u00f1a</a>.
-screen.badhours.heading=Est\u00e1 prohibido iniciar sesi\u00f3n con su cuenta en este momento.
-screen.badhours.message=Por favor intente m\u00e1s tarde.
-screen.badworkstation.heading=No puede iniciar sesi\u00f3n desde esta estaci\u00f3n de trabajo.
-screen.badworkstation.message=Por favor contacte al administrador de sistema para recobrar el acceso.
+screen.accountlocked.message=Por favor contacte al administrador de sistema para recobrar acceso.
+screen.expiredpass.heading=Su contraseña ha caducado.
+screen.expiredpass.message=Por favor <a href="{0}">cambie su contraseña</a>.
+screen.mustchangepass.heading=Debe cambiar su contraseña.
+screen.mustchangepass.message=Por favor <a href="{0}">cambie su contraseña</a>.
+screen.badhours.heading=Está prohibido iniciar sesión con su cuenta en este momento.
+screen.badhours.message=Por favor intente más tarde.
+screen.badworkstation.heading=No puede iniciar sesión desde esta estación de trabajo.
+screen.badworkstation.message=Por favor contacte al administrador de sistema para recobrar acceso.
 
 # OAuth
-screen.oauth.confirm.header=Autorizaci\u00f3n
-screen.oauth.confirm.message=\u00bfQuiere conceder acceso a su perfil completo a "{0}"?
+screen.oauth.confirm.header=Autorización
+screen.oauth.confirm.message=¿Quiere conceder acceso a su perfil completo a "{0}"?
 screen.oauth.confirm.allow=Permitir
 
 # Unavailable
-screen.unavailable.heading=CAS no est\u00e1 disponible
-screen.unavailable.message=Hubo un error al intentar cumplir con su petici\u00f3n. Por favor notifique a su servicio de asistencia o intente otra vez.
+screen.unavailable.heading=CAS no está disponible
+screen.unavailable.message=Hubo un error al intentar cumplir con su petición. Por favor notifique a su soporte técnico o intente otra vez.


### PR DESCRIPTION
This will probably be the last translation update I submit to CAS, for a few reasons:
* Converting accented characters to Unicode escape sequences is tedious, cumbersome, and error-prone.
* Unlike PO files, the original English string is not displayed next to the translated string.
* Strings that have changed in the original English are not marked for review in the translation file.
* In a few months I will no longer be using CAS.

Nevertheless, I hope that my efforts to provide accurate and up-to-date translations will help other CAS users in the future.