### PR TITLE
Improve LdapPersonAttributeDaoTest: ensure attributes are correctly renamed

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/persondir/LdapPersonAttributeDao.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/persondir/LdapPersonAttributeDao.java
@@ -211,8 +211,7 @@ public class LdapPersonAttributeDao extends AbstractQueryPersonAttributeDao<Sear
     private Map<String, List<Object>> convertLdapEntryToMap(final LdapEntry entry) {
         final Map<String, List<Object>> attributeMap = new LinkedHashMap<>(entry.size());
         for (final LdapAttribute attr : entry.getAttributes()) {
-            final String attrNewName = this.getResultAttributeMapping().get(attr.getName()).toString();
-            attributeMap.put(attrNewName, new ArrayList<Object>(attr.getStringValues()));
+            attributeMap.put(attr.getName(), new ArrayList<Object>(attr.getStringValues()));
         }
         logger.debug("Converted ldap DN entry [{}] to attribute map {}", entry.getDn(), attributeMap.toString());
         return attributeMap;

--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/persondir/LdapPersonAttributeDao.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/persondir/LdapPersonAttributeDao.java
@@ -211,7 +211,8 @@ public class LdapPersonAttributeDao extends AbstractQueryPersonAttributeDao<Sear
     private Map<String, List<Object>> convertLdapEntryToMap(final LdapEntry entry) {
         final Map<String, List<Object>> attributeMap = new LinkedHashMap<>(entry.size());
         for (final LdapAttribute attr : entry.getAttributes()) {
-            attributeMap.put(attr.getName(), new ArrayList<Object>(attr.getStringValues()));
+            final String attrNewName = this.getResultAttributeMapping().get(attr.getName()).toString();
+            attributeMap.put(attrNewName, new ArrayList<Object>(attr.getStringValues()));
         }
         logger.debug("Converted ldap DN entry [{}] to attribute map {}", entry.getDn(), attributeMap.toString());
         return attributeMap;

--- a/cas-server-support-ldap/src/test/java/org/jasig/cas/persondir/LdapPersonAttributeDaoTests.java
+++ b/cas-server-support-ldap/src/test/java/org/jasig/cas/persondir/LdapPersonAttributeDaoTests.java
@@ -54,6 +54,8 @@ public class LdapPersonAttributeDaoTests extends AbstractLdapTests {
             actual = attributeDao.getPerson(username);
             assertNotNull(actual);
             assertEquals(username, actual.getName());
+            assertEquals(actual.getAttributes().size(), 3);
+            assertTrue(actual.getAttributes().containsKey("commonName"));
             assertSameValues(entry.getAttribute("mail").getStringValues(), actual.getAttributes().get("mail"));
         }
     }

--- a/cas-server-support-ldap/src/test/resources/ldap-persondir-test.xml
+++ b/cas-server-support-ldap/src/test/resources/ldap-persondir-test.xml
@@ -43,7 +43,7 @@
                 <!--
                    | Key is LDAP attribute name, value is principal attribute name.
                    -->
-                <entry key="member" value="member" />
+                <entry key="cn" value="commonName" />
                 <entry key="mail" value="mail" />
                 <entry key="displayName" value="displayName" />
             </map>


### PR DESCRIPTION
~~Discovered a bug with the LdapPersonAttributeDao where the result attribute map is not taken into account when renaming retrieved attributes. The value-set should be used when prepping person attributes.~~

Improved tests to ensure we are getting back the retrieved attributes and that they are properly renamed.