### PR TITLE
Allow Ldap AuthN handler to specify attributes as a list

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
@@ -18,6 +18,9 @@
  */
 package org.jasig.cas.authentication;
 
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.collect.Maps;
 import org.jasig.cas.Message;
 import org.jasig.cas.authentication.handler.support.AbstractUsernamePasswordAuthenticationHandler;
 import org.jasig.cas.authentication.principal.Principal;
@@ -135,6 +138,17 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
      */
     public void setPrincipalAttributeMap(final Map<String, String> attributeNameMap) {
         this.principalAttributeMap = attributeNameMap;
+    }
+
+    /**
+     * Sets the mapping of additional principal attributes where the key and value is the LDAP attribute
+     * name. Note that the principal ID attribute
+     * should not be listed among these attributes.
+     *
+     * @param attributeList List of LDAP attribute names
+     */
+    public void setPrincipalAttributeList(final List<String> attributeList) {
+        this.principalAttributeMap = Maps.uniqueIndex(attributeList, Functions.toStringFunction());
     }
 
     /**

--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
@@ -18,7 +18,6 @@
  */
 package org.jasig.cas.authentication;
 
-import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.Maps;
 import org.jasig.cas.Message;

--- a/cas-server-support-ldap/src/test/resources/authn-context.xml
+++ b/cas-server-support-ldap/src/test/resources/authn-context.xml
@@ -38,18 +38,12 @@
           p:principalIdAttribute-ref="usernameAttribute"
 
           c:authenticator-ref="authenticator">
-        <property name="principalAttributeMap">
-            <map>
-                <!--
-                   | This map provides a simple attribute resolution mechanism.
-                   | Keys are LDAP attribute names, values are CAS attribute names.
-                   | Use this facility instead of a PrincipalResolver if LDAP is
-                   | the only attribute source.
-                   -->
-                <entry key="displayName" value="displayName" />
-                <entry key="mail" value="mail" />
-                <entry key="givenName" value="givenName" />
-            </map>
+        <property name="principalAttributeList">
+            <list>
+                <value>displayName</value>
+                <value>mail</value>
+                <value>givenName</value>
+            </list>
         </property>
     </bean>
 


### PR DESCRIPTION
For the majority of deployments, the ldap authn handler can be used to retrieve attributes. While these attributes are now supported as a map, this pull adds support for lists as well. Most deployments would simply just define the list of attributes returned and have no need for a mapping. 