### PR TITLE
Disable SSO session for non-SSO-participating apps

### DIFF
--- a/cas-server-core/src/test/java/org/jasig/cas/AbstractCentralAuthenticationServiceTest.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/AbstractCentralAuthenticationServiceTest.java
@@ -19,6 +19,7 @@
 package org.jasig.cas;
 
 import org.jasig.cas.authentication.AuthenticationManager;
+import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.ticket.registry.TicketRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,9 @@ public abstract class AbstractCentralAuthenticationServiceTest extends AbstractJ
     @Autowired(required = true)
     private AuthenticationManager authenticationManager;
 
+    @Autowired(required = true)
+    private ServicesManager servicesManager;
+
     public AuthenticationManager getAuthenticationManager() {
         return this.authenticationManager;
     }
@@ -63,4 +67,7 @@ public abstract class AbstractCentralAuthenticationServiceTest extends AbstractJ
         return this.ticketRegistry;
     }
 
+    public ServicesManager getServicesManager() {
+        return this.servicesManager;
+    }
 }

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/SendTicketGrantingTicketAction.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/SendTicketGrantingTicketAction.java
@@ -139,6 +139,12 @@ public final class SendTicketGrantingTicketAction extends AbstractAction {
      * @return true if renewed
      */
     private boolean isAuthenticationRenewed(final RequestContext ctx) {
+        if (ctx.getRequestParameters().contains(CasProtocolConstants.PARAMETER_RENEW)) {
+            LOGGER.debug("[{}] is specified for the request. The authentication session will be considered renewed.",
+                    CasProtocolConstants.PARAMETER_RENEW);
+            return true;
+        }
+
         final Service service = WebUtils.getService(ctx);
         if (service != null) {
             final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
@@ -150,10 +156,6 @@ public final class SendTicketGrantingTicketAction extends AbstractAction {
             }
         }
 
-        if (ctx.getRequestParameters().contains(CasProtocolConstants.PARAMETER_RENEW)) {
-            LOGGER.debug("[{}] is specified for the request. The authentication session will be considered renewed.");
-            return true;
-        }
         return false;
     }
 }

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/SendTicketGrantingTicketAction.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/SendTicketGrantingTicketAction.java
@@ -52,22 +52,25 @@ public final class SendTicketGrantingTicketAction extends AbstractAction {
 
     /** Instance of CentralAuthenticationService. */
     @NotNull
-    private CentralAuthenticationService centralAuthenticationService;
+    private final CentralAuthenticationService centralAuthenticationService;
 
     @NotNull
-    private ServicesManager servicesManager;
+    private final ServicesManager servicesManager;
 
     /**
      * Instantiates a new Send ticket granting ticket action.
      *
      * @param ticketGrantingTicketCookieGenerator the ticket granting ticket cookie generator
      * @param centralAuthenticationService the central authentication service
+     * @param servicesManager the services manager
      */
     public SendTicketGrantingTicketAction(final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator,
-                                          final CentralAuthenticationService centralAuthenticationService) {
+                                          final CentralAuthenticationService centralAuthenticationService,
+                                          final ServicesManager servicesManager) {
         super();
         this.ticketGrantingTicketCookieGenerator = ticketGrantingTicketCookieGenerator;
         this.centralAuthenticationService = centralAuthenticationService;
+        this.servicesManager = servicesManager;
     }
 
     @Override
@@ -118,8 +121,13 @@ public final class SendTicketGrantingTicketAction extends AbstractAction {
         this.createSsoSessionCookieOnRenewAuthentications = createSsoSessionCookieOnRenewAuthentications;
     }
 
+    /**
+     * @deprecated As of 4.1, use constructors instead.
+     * @param servicesManager  the service manager
+     */
+    @Deprecated
     public void setServicesManager(final ServicesManager servicesManager) {
-        this.servicesManager = servicesManager;
+        logger.warn("setServicesManager() is deprecated and has no effect. Use constructors instead.");
     }
 
     /**

--- a/cas-server-webapp-support/src/test/java/org/jasig/cas/web/flow/SendTicketGrantingTicketActionTests.java
+++ b/cas-server-webapp-support/src/test/java/org/jasig/cas/web/flow/SendTicketGrantingTicketActionTests.java
@@ -20,7 +20,6 @@ package org.jasig.cas.web.flow;
 
 import org.jasig.cas.AbstractCentralAuthenticationServiceTest;
 import org.jasig.cas.CasProtocolConstants;
-import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.authentication.principal.WebApplicationService;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.web.support.CookieRetrievingCookieGenerator;

--- a/cas-server-webapp-support/src/test/java/org/jasig/cas/web/flow/SendTicketGrantingTicketActionTests.java
+++ b/cas-server-webapp-support/src/test/java/org/jasig/cas/web/flow/SendTicketGrantingTicketActionTests.java
@@ -43,19 +43,17 @@ import static org.mockito.Mockito.*;
  */
 public class SendTicketGrantingTicketActionTests extends AbstractCentralAuthenticationServiceTest {
     private SendTicketGrantingTicketAction action;
-
+    private CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
     private MockRequestContext context;
 
     @Before
     public void onSetUp() throws Exception {
 
-        final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator
-                = new CookieRetrievingCookieGenerator();
+        this.ticketGrantingTicketCookieGenerator = new CookieRetrievingCookieGenerator();
         ticketGrantingTicketCookieGenerator.setCookieName("TGT");
 
-        this.action = new SendTicketGrantingTicketAction(this.ticketGrantingTicketCookieGenerator,
-                getCentralAuthenticationService());
-        this.action.setTicketGrantingTicketCookieGenerator(ticketGrantingTicketCookieGenerator);
+        this.action = new SendTicketGrantingTicketAction(ticketGrantingTicketCookieGenerator,
+                getCentralAuthenticationService(), getServicesManager());
         this.action.setServicesManager(getServicesManager());
         this.action.setCreateSsoSessionCookieOnRenewAuthentications(true);
         this.action.afterPropertiesSet();

--- a/cas-server-webapp/src/main/resources/services/sample-access-strategy.json.sample
+++ b/cas-server-webapp/src/main/resources/services/sample-access-strategy.json.sample
@@ -1,0 +1,12 @@
+{
+  "@class" : "org.jasig.cas.services.RegexRegisteredService",
+  "serviceId" : "sample",
+  "name" : "sample",
+  "id" : 1984,
+  "description" : "sample",
+  "accessStrategy" : {
+    "@class" : "org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy",
+    "enabled" : true,
+    "ssoEnabled" : true
+  }
+}

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -266,7 +266,9 @@
 
   <bean id="sendTicketGrantingTicketAction" class="org.jasig.cas.web.flow.SendTicketGrantingTicketAction"
         p:centralAuthenticationService-ref="centralAuthenticationService"
-        p:ticketGrantingTicketCookieGenerator-ref="ticketGrantingTicketCookieGenerator"/>
+        p:servicesManager-ref="servicesManager"
+        p:ticketGrantingTicketCookieGenerator-ref="ticketGrantingTicketCookieGenerator"
+        p:createSsoSessionCookieOnRenewAuthentications="${create.sso.renewed.authn:true}"  />
 
   <bean id="gatewayServicesManagementCheck" class="org.jasig.cas.web.flow.GatewayServicesManagementCheck"
     c:servicesManager-ref="servicesManager" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -266,8 +266,8 @@
 
   <bean id="sendTicketGrantingTicketAction" class="org.jasig.cas.web.flow.SendTicketGrantingTicketAction"
         c:centralAuthenticationService-ref="centralAuthenticationService"
-        p:servicesManager-ref="servicesManager"
-        c:ticketGrantingTicketCookieGenerator-ref="ticketGrantingTicketCookieGenerator"/>
+        c:ticketGrantingTicketCookieGenerator-ref="ticketGrantingTicketCookieGenerator"
+        c:servicesManager-ref="servicesManager"
         p:createSsoSessionCookieOnRenewAuthentications="${create.sso.renewed.authn:true}"  />
 
   <bean id="gatewayServicesManagementCheck" class="org.jasig.cas.web.flow.GatewayServicesManagementCheck"

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -64,6 +64,12 @@ host.name=cas01.example.org
 # cas.attrs.timeToExpireInHours=2
 
 ##
+# Single Sign-On Session
+#
+# Indicates whether an SSO session should be created for renewed authentication requests.
+# create.sso.renewed.authn=true
+
+##
 # Single Sign-On Session Timeouts
 # Defaults sourced from WEB-INF/spring-configuration/ticketExpirationPolices.xml
 #


### PR DESCRIPTION
Handles #564 

Optionally, logging in via CAS to non-SSO-participating applications should not create a CAS SSO session. This pull provides an option to disable the generation of the SSO cookie, in case the authentication was forced/renewed for the service/request. 