### PR TITLE
TGC encryption: fixed issue with shared secret key generation

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/util/DefaultCipherExecutor.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/util/DefaultCipherExecutor.java
@@ -23,15 +23,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwe.ContentEncryptionAlgorithmIdentifiers;
 import org.jose4j.jwe.JsonWebEncryption;
 import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers;
+import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.keys.AesKey;
-import org.jose4j.lang.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 import java.security.Key;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The {@link org.jasig.cas.util.DefaultCipherExecutor} is the default
@@ -42,66 +44,54 @@ import java.security.Key;
  * @since 4.1
  */
 public final class DefaultCipherExecutor implements CipherExecutor {
-    private static final int DEFAULT_ENCRYPTION_KEY_LENGTH = 32;
-
-    private static final int DEFAULT_SIGNING_KEY_LENGTH = 64;
-
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-    private final byte[] encryptionSeedArray;
-
-    private final byte[] signingSeedArray;
-
-    private final String keyManagementAlgorithmIdentifier;
 
     private final String contentEncryptionAlgorithmIdentifier;
 
     private final String signingAlgorithm;
 
+    private final String secretKeyEncryption;
+    private final String secretKeySigning;
+
     /**
-     * Instantiates a new cipher
-     * Uses an encryption key length of {@link #DEFAULT_ENCRYPTION_KEY_LENGTH}
-     * with {@link KeyManagementAlgorithmIdentifiers#A256KW} as the key
-     * and {@link ContentEncryptionAlgorithmIdentifiers#AES_256_CBC_HMAC_SHA_512}
-     * as the content encryption.
+     * Instantiates a new cipher.
      *
      * <p>Note that in order to customize the encryption algorithms,
      * you will need to download and install the JCE Unlimited Strength Jurisdiction
      * Policy File into your Java installation.</p>
+     * @param secretKeyEncryption the secret key encryption; must be represented as a octet sequence JSON Web Key (JWK)
+     * @param secretKeySigning the secret key signing; must be represented as a octet sequence JSON Web Key (JWK)
      */
-    public DefaultCipherExecutor() {
-        this(DEFAULT_ENCRYPTION_KEY_LENGTH, DEFAULT_SIGNING_KEY_LENGTH,
-                KeyManagementAlgorithmIdentifiers.A256KW,
-                ContentEncryptionAlgorithmIdentifiers.AES_256_CBC_HMAC_SHA_512,
+    public DefaultCipherExecutor(final String secretKeyEncryption,
+                                 final String secretKeySigning) {
+        this(secretKeyEncryption, secretKeySigning,
+                ContentEncryptionAlgorithmIdentifiers.AES_128_CBC_HMAC_SHA_256,
                 AlgorithmIdentifiers.HMAC_SHA512);
     }
 
     /**
      * Instantiates a new cipher.
      *
-     * @param keyLength the key length
-     * @param signingKeyLength the signing key length
-     * @param keyManagementAlgorithmIdentifier the key management algorithm identifier
+     * @param secretKeyEncryption the key for encryption
+     * @param secretKeySigning the key for signing
      * @param contentEncryptionAlgorithmIdentifier the content encryption algorithm identifier
      * @param signingAlgorithm the signing algorithm
      */
-    public DefaultCipherExecutor(final int keyLength,
-                                 final int signingKeyLength,
-                                 final String keyManagementAlgorithmIdentifier,
+    public DefaultCipherExecutor(final String secretKeyEncryption,
+                                 final String secretKeySigning,
                                  final String contentEncryptionAlgorithmIdentifier,
                                  final String signingAlgorithm) {
-        this.encryptionSeedArray = ByteUtil.randomBytes(keyLength);
-        this.keyManagementAlgorithmIdentifier = keyManagementAlgorithmIdentifier;
+        this.secretKeyEncryption = secretKeyEncryption;
         this.contentEncryptionAlgorithmIdentifier = contentEncryptionAlgorithmIdentifier;
 
-        logger.debug("Initialized cipher encryption sequence via [{}] and [{}]",
-                keyManagementAlgorithmIdentifier, contentEncryptionAlgorithmIdentifier);
+        logger.debug("Initialized cipher encryption sequence via [{}]",
+                 contentEncryptionAlgorithmIdentifier);
 
         this.signingAlgorithm = signingAlgorithm;
-        this.signingSeedArray = ByteUtil.randomBytes(signingKeyLength);
+        this.secretKeySigning = secretKeySigning;
 
-        logger.debug("Initialized cipher signing sequence via [{}] and key length [{}]",
-                signingAlgorithm, signingKeyLength);
+        logger.debug("Initialized cipher signing sequence via [{}]",
+                signingAlgorithm);
     }
 
     @Override
@@ -128,15 +118,17 @@ public final class DefaultCipherExecutor implements CipherExecutor {
      */
     private String encryptValue(@NotNull final String value) {
         try {
-            final Key key = new AesKey(this.encryptionSeedArray);
+            final Map<String, Object> keys = new HashMap<>(2);
+            keys.put("kty", "oct");
+            keys.put("k", this.secretKeyEncryption);
+            final JsonWebKey jwk = JsonWebKey.Factory.newJwk(keys);
             final JsonWebEncryption jwe = new JsonWebEncryption();
             jwe.setPayload(value);
-            jwe.setAlgorithmHeaderValue(this.keyManagementAlgorithmIdentifier);
+            jwe.setAlgorithmHeaderValue(KeyManagementAlgorithmIdentifiers.DIRECT);
             jwe.setEncryptionMethodHeaderParameter(this.contentEncryptionAlgorithmIdentifier);
-            jwe.setKey(key);
+            jwe.setKey(jwk.getKey());
 
-            logger.debug("Encrypting via [{}] and [{}]", this.keyManagementAlgorithmIdentifier,
-                    this.contentEncryptionAlgorithmIdentifier);
+            logger.debug("Encrypting via [{}]", this.contentEncryptionAlgorithmIdentifier);
 
             return jwe.getCompactSerialization();
         } catch (final Exception e) {
@@ -153,9 +145,13 @@ public final class DefaultCipherExecutor implements CipherExecutor {
      */
     private String decryptValue(@NotNull final String value) {
         try {
-            final Key key = new AesKey(this.encryptionSeedArray);
+            final Map<String, Object> keys = new HashMap<>(2);
+            keys.put("kty", "oct");
+            keys.put("k", this.secretKeyEncryption);
+            final JsonWebKey jwk = JsonWebKey.Factory.newJwk(keys);
+
             final JsonWebEncryption jwe = new JsonWebEncryption();
-            jwe.setKey(key);
+            jwe.setKey(jwk.getKey());
             jwe.setCompactSerialization(value);
             logger.debug("Decrypting value...");
             return jwe.getPayload();
@@ -175,7 +171,8 @@ public final class DefaultCipherExecutor implements CipherExecutor {
             final JsonWebSignature jws = new JsonWebSignature();
             jws.setPayload(value);
             jws.setAlgorithmHeaderValue(this.signingAlgorithm);
-            jws.setKey(new AesKey(this.signingSeedArray));
+            final Key key = new AesKey(this.secretKeySigning.getBytes());
+            jws.setKey(key);
             return jws.getCompactSerialization();
         } catch (final Exception e) {
             throw new RuntimeException(e);
@@ -193,7 +190,8 @@ public final class DefaultCipherExecutor implements CipherExecutor {
         try {
             final JsonWebSignature jws = new JsonWebSignature();
             jws.setCompactSerialization(value);
-            jws.setKey(new AesKey(this.signingSeedArray));
+            final Key key = new AesKey(this.secretKeySigning.getBytes());
+            jws.setKey(key);
             final boolean verified = jws.verifySignature();
             if (verified) {
                 logger.debug("Signature successfully verified. Payload is [{}]", jws.getPayload());

--- a/cas-server-core/src/test/java/org/jasig/cas/util/DefaultCipherExecutorTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/util/DefaultCipherExecutorTests.java
@@ -33,7 +33,8 @@ public class DefaultCipherExecutorTests {
 
     @Test
     public void checkEncryptionWithDefaultSettings() {
-        final CipherExecutor cipherExecutor = new DefaultCipherExecutor();
+        final CipherExecutor cipherExecutor = new DefaultCipherExecutor("1PbwSbnHeinpkZOSZjuSJ8yYpUrInm5aaV18J2Ar4rM",
+                "szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w");
         assertEquals(cipherExecutor.decode(cipherExecutor.encode("CAS Test")), "CAS Test");
     }
 }

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/DefaultCasCookieValueManager.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/DefaultCasCookieValueManager.java
@@ -88,6 +88,11 @@ public final class DefaultCasCookieValueManager implements CookieValueManager {
     public String obtainCookieValue(final Cookie cookie, final HttpServletRequest request) {
         final String cookieValue = this.cipherExecutor.decode(cookie.getValue());
         LOGGER.debug("Decoded cookie value is [{}]", cookieValue);
+        if (StringUtils.isBlank(cookieValue)) {
+            LOGGER.debug("Retrieved decoded cookie value is blank. Failed to decode cookie [{}]", cookie.getName());
+            return null;
+        }
+
         final String[] cookieParts = cookieValue.split(COOKIE_FIELD_SEPARATOR);
         if (cookieParts.length != COOKIE_FIELDS_LENGTH) {
             throw new IllegalStateException("Invalid cookie. Required fields are missing");

--- a/cas-server-webapp-support/src/test/java/org/jasig/cas/web/support/DefaultCasCookieValueManagerTests.java
+++ b/cas-server-webapp-support/src/test/java/org/jasig/cas/web/support/DefaultCasCookieValueManagerTests.java
@@ -35,18 +35,21 @@ import static org.junit.Assert.*;
  */
 public class DefaultCasCookieValueManagerTests {
 
+    private static final String ENC_KEY = "1PbwSbnHeinpkZOSZjuSJ8yYpUrInm5aaV18J2Ar4rM";
+    private static final String SIGN_KEY = "szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w";
+
     @Test(expected = IllegalStateException.class)
     public void defaultCookieWithNoRemote() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRemoteAddr(null);
-        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor());
+        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor(ENC_KEY, SIGN_KEY));
         mgmr.buildCookieValue("cas", request);
     }
 
     @Test(expected = IllegalStateException.class)
     public void defaultCookieWithNoAgent() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor());
+        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor(ENC_KEY, SIGN_KEY));
         mgmr.buildCookieValue("cas", request);
     }
 
@@ -54,7 +57,7 @@ public class DefaultCasCookieValueManagerTests {
     public void defaultCookieGood() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("user-agent", "the agent");
-        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor());
+        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor(ENC_KEY, SIGN_KEY));
         assertNotNull(mgmr.buildCookieValue("cas", request));
     }
 
@@ -62,7 +65,7 @@ public class DefaultCasCookieValueManagerTests {
     public void defaultCookieVerify() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("user-agent", "the agent");
-        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor());
+        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor(ENC_KEY, SIGN_KEY));
         final String c = mgmr.buildCookieValue("cas", request);
         assertEquals("cas", mgmr.obtainCookieValue(new Cookie("test", c), request));
     }
@@ -71,7 +74,7 @@ public class DefaultCasCookieValueManagerTests {
     public void defaultCookieVerifyNoRemote() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("user-agent", "the agent");
-        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor());
+        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor(ENC_KEY, SIGN_KEY));
         final String c = mgmr.buildCookieValue("cas", request);
         request.setRemoteAddr("another ip");
         assertEquals("cas", mgmr.obtainCookieValue(new Cookie("test", c), request));
@@ -81,7 +84,7 @@ public class DefaultCasCookieValueManagerTests {
     public void defaultCookieVerifyNoAgent() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("user-agent", "the agent");
-        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor());
+        final DefaultCasCookieValueManager mgmr = new DefaultCasCookieValueManager(new DefaultCipherExecutor(ENC_KEY, SIGN_KEY));
         final String c = mgmr.buildCookieValue("cas", request);
 
         request = new MockHttpServletRequest();

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -50,6 +50,19 @@ host.name=cas01.example.org
 # database.hibernate.dialect=org.hibernate.dialect.HSQLDialect
 
 ##
+# CAS SSO Cookie Generation & Security
+# See https://github.com/mitreid-connect/json-web-key-generator
+#
+# Do note that the following settings MUST be generated per deployment.
+#
+# Defaults at spring-configuration/ticketGrantingTicketCookieGenerator.xml
+# The encryption secret key. By default, must be a octet string of size 256.
+tgc.encryption.key=1PbwSbnHeinpkZOSZjuSJ8yYpUrInm5aaV18J2Ar4rM
+
+# The signing secret key. By default, must be a octet string of size 512.
+tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w
+
+##
 # CAS Logout Behavior
 # WEB-INF/cas-servlet.xml
 #

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketGrantingTicketCookieGenerator.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketGrantingTicketCookieGenerator.xml
@@ -37,7 +37,9 @@
 		p:cookieName="TGC"
 		p:cookiePath="/cas" />
 
-    <bean id="cookieCipherExecutor" class="org.jasig.cas.util.DefaultCipherExecutor" />
+    <bean id="cookieCipherExecutor" class="org.jasig.cas.util.DefaultCipherExecutor"
+            c:secretKeyEncryption="${tgc.encryption.key}"
+            c:secretKeySigning="${tgc.signing.key}"/>
 
     <bean id="cookieValueManager" class="org.jasig.cas.web.support.DefaultCasCookieValueManager"
           c:cipherExecutor-ref="cookieCipherExecutor" />


### PR DESCRIPTION
As I was testing the TGC encryption, I ran across the following issues:

If the server is restarted, CAS is unable to properly parse the cookie and crashes. Because secret keys for encryption and signing are only kept in memory, restarts generate new keys. Also HA deployments would also not work via in-memory keys. So this pull does the following:

1. Provide secret keys via cas.properties as JSON web tokens:
https://github.com/mitreid-connect/json-web-key-generator

2. Ensures that CAS can gracefully recover if there is an issue with the decryption (like a bad or missing value)