### PR TITLE
Missing dependency for Tomcat 8.x causes crash

### DIFF
--- a/cas-server-webapp-support/pom.xml
+++ b/cas-server-webapp-support/pom.xml
@@ -98,6 +98,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.woodstox</groupId>
+      <artifactId>woodstox-core-asl</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -564,6 +564,12 @@
        <artifactId>javax.el</artifactId>
        <version>${javax.el-impl.version}</version>
        <scope>runtime</scope>
+       <exclusions>
+	     <exclusion>
+	       <groupId>javax.el</groupId>
+	       <artifactId>javax.el-api</artifactId>
+	     </exclusion>
+       </exclusions>
     </dependency>
 
     <dependency>
@@ -592,6 +598,12 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j.version}</version>
       <scope>runtime</scope>
+      <exclusions>
+	    <exclusion>
+	      <groupId>org.slf4j</groupId>
+	      <artifactId>slf4j-api</artifactId>
+	    </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -648,6 +660,12 @@
         <artifactId>metrics-core</artifactId>
         <version>${metrics.version}</version>
         <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>	
       </dependency>
 
       <dependency>
@@ -655,6 +673,12 @@
         <artifactId>metrics-annotation</artifactId>
         <version>${metrics.version}</version>
         <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -662,6 +686,12 @@
         <artifactId>metrics-jvm</artifactId>
         <version>${metrics.version}</version>
         <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -669,6 +699,12 @@
         <artifactId>metrics-servlets</artifactId>
         <version>${metrics.version}</version>
         <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -676,6 +712,12 @@
         <artifactId>metrics-spring</artifactId>
         <version>${metrics.spring.version}</version>
         <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -746,6 +788,10 @@
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-api</artifactId>
           </exclusion>
+          <exclusion>
+              <artifactId>validation-api</artifactId>
+              <groupId>javax.validation</groupId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -758,6 +804,10 @@
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-api</artifactId>
           </exclusion>
+          <exclusion>
+              <artifactId>validation-api</artifactId>
+              <groupId>javax.validation</groupId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -769,6 +819,10 @@
           <exclusion>
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-api</artifactId>
+          </exclusion>
+          <exclusion>
+              <artifactId>validation-api</artifactId>
+              <groupId>javax.validation</groupId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -798,6 +852,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -818,6 +876,10 @@
               <artifactId>jboss-logging-annotations</artifactId>
               <groupId>org.jboss.logging</groupId>
           </exclusion>
+          <exclusion>
+              <groupId>org.javassist</groupId>
+              <artifactId>javassist</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -826,6 +888,12 @@
         <artifactId>hibernate-entitymanager</artifactId>
         <version>${hibernate.core.version}</version>
         <type>jar</type>
+        <exclusions>
+          <exclusion>
+              <groupId>org.javassist</groupId>
+              <artifactId>javassist</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1054,6 +1122,11 @@
           <exclusion>
             <artifactId>log4j</artifactId>
             <groupId>log4j</groupId>
+          </exclusion>
+
+          <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -631,6 +631,13 @@
       </dependency>
 
       <dependency>
+		<groupId>org.codehaus.woodstox</groupId>
+		<artifactId>woodstox-core-asl</artifactId>
+		<version>${woodstox.version}</version>
+		<scope>runtime</scope>
+	  </dependency>
+
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.databind.version}</version>
@@ -1383,6 +1390,7 @@
     <javax.el-impl.version>2.2.6</javax.el-impl.version>
     <jersey.version>1.19</jersey.version>
     <jose.version>0.4.0</jose.version>
+    <woodstox.version>4.4.1</woodstox.version>
 
     <!-- Plugin Versions -->
     <coveralls-maven-plugin.version>3.0.1</coveralls-maven-plugin.version>


### PR DESCRIPTION
Deploying CAS/master on Tomcat 7.0.20, causes a crash, with the following error:

```Provider com.ctc.wstx.stax.WstxInputFactory cannot be located.``` 

This seems to be required by the hibernate validator. This pull adds the missing dependency explicitly. I have also excluded few other dependencies for logging and caching APIs to reduce conflicts. 

Tested deployment on both TC7 and 8.