### PR TITLE
Default ticket cleaner throws error when removing STs

### DIFF
--- a/cas-server-core/src/test/java/org/jasig/cas/ticket/registry/support/DefaultTicketRegistryCleanerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/ticket/registry/support/DefaultTicketRegistryCleanerTests.java
@@ -51,7 +51,7 @@ public class DefaultTicketRegistryCleanerTests extends AbstractRegistryCleanerTe
                 new NeverExpiresExpirationPolicy(), new NeverExpiresExpirationPolicy(), mock(ServicesManager.class),
                 mock(LogoutManager.class));
 
-        return new DefaultTicketRegistryCleaner(this.centralAuthenticationService);
+        return new DefaultTicketRegistryCleaner(this.centralAuthenticationService, this.ticketRegistry);
     }
 
     @Override

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketRegistry.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketRegistry.xml
@@ -34,7 +34,8 @@
 	<!--Quartz -->
 	<!-- TICKET REGISTRY CLEANER -->
 	<bean id="ticketRegistryCleaner" class="org.jasig.cas.ticket.registry.support.DefaultTicketRegistryCleaner"
-		c:centralAuthenticationService-ref="centralAuthenticationService" />
+		c:centralAuthenticationService-ref="centralAuthenticationService"
+        c:ticketRegistry-ref="ticketRegistry"/>
 
 	<bean id="jobDetailTicketRegistryCleaner" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean"
 		p:targetObject-ref="ticketRegistryCleaner"

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketRegistry.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketRegistry.xml
@@ -28,14 +28,14 @@
     	Configuration for the default TicketRegistry which stores the tickets in-memory and cleans them out as specified intervals.
     </description>
        
-  <!-- Ticket Registry -->
-  <bean id="ticketRegistry" class="org.jasig.cas.ticket.registry.DefaultTicketRegistry" />
+    <!-- Ticket Registry -->
+    <bean id="ticketRegistry" class="org.jasig.cas.ticket.registry.DefaultTicketRegistry" />
 	
 	<!--Quartz -->
 	<!-- TICKET REGISTRY CLEANER -->
 	<bean id="ticketRegistryCleaner" class="org.jasig.cas.ticket.registry.support.DefaultTicketRegistryCleaner"
-		c:centralAuthenticationService-ref="centralAuthenticationService"
-        c:ticketRegistry-ref="ticketRegistry"/>
+          c:centralAuthenticationService-ref="centralAuthenticationService"
+          c:ticketRegistry-ref="ticketRegistry"/>
 
 	<bean id="jobDetailTicketRegistryCleaner" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean"
 		p:targetObject-ref="ticketRegistryCleaner"


### PR DESCRIPTION
The default ticket registry cleaner calls CAS.destroyTicketGrantingTicket() when an expired ST is found to be cleaned. The result causes an exception to be thrown because that method can only work with TGTs. Long term, the CAS interface should be revised to handle ticket registry ops better, but in the interest of keeping this pull small and not wanting to modify that interface, I simply added a PR to delete the expired ST for now. 