### PR TITLE
Support Acceptable Usage Policy (AUP) workflows

### DIFF
--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/AcceptableUsagePolicyFormAction.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/AcceptableUsagePolicyFormAction.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AcceptableUsagePolicyFormAction {
 
     /** Event id to signal the policy needs to be accepted. **/
-    protected static final String EVENT_ID_MUST_ACCEPT = "musAccept";
+    protected static final String EVENT_ID_MUST_ACCEPT = "mustAccept";
 
     /** Logger instance. **/
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -58,10 +58,9 @@ public class AcceptableUsagePolicyFormAction {
         final String key = credential.getId();
         if (this.policyMap.containsKey(key)) {
             final Boolean hasAcceptedPolicy = this.policyMap.get(key);
-            return hasAcceptedPolicy ? new EventFactorySupport().success(this)
-                    : new EventFactorySupport().event(this, EVENT_ID_MUST_ACCEPT);
+            return hasAcceptedPolicy ? success() : accept();
         }
-        return new EventFactorySupport().event(this, "musAccept");
+        return accept();
     }
 
     /**
@@ -75,6 +74,24 @@ public class AcceptableUsagePolicyFormAction {
     public Event submit(final RequestContext context, final Credential credential,
                               final MessageContext messageContext)  {
         this.policyMap.put(credential.getId(), Boolean.TRUE);
+        return success();
+    }
+
+    /**
+     * Success event.
+     *
+     * @return the event
+     */
+    protected final Event success() {
         return new EventFactorySupport().success(this);
+    }
+
+    /**
+     * Accept event signaled by id {@link #EVENT_ID_MUST_ACCEPT}.
+     *
+     * @return the event
+     */
+    protected final Event accept() {
+        return new EventFactorySupport().event(this, EVENT_ID_MUST_ACCEPT);
     }
 }

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/AcceptableUsagePolicyFormAction.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/AcceptableUsagePolicyFormAction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.cas.web.flow;
+
+import org.jasig.cas.authentication.Credential;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.binding.message.MessageContext;
+import org.springframework.webflow.action.EventFactorySupport;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Webflow action to receive and record the AUP response.
+ * @author Misagh Moayyed
+ * @since 4.1
+ */
+public class AcceptableUsagePolicyFormAction {
+
+    /** Event id to signal the policy needs to be accepted. **/
+    protected static final String EVENT_ID_MUST_ACCEPT = "musAccept";
+
+    /** Logger instance. **/
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final Map<String, Boolean> policyMap = new ConcurrentHashMap<>();
+
+    /**
+     * Verify whether the policy is accepted.
+     *
+     * @param context the context
+     * @param credential the credential
+     * @param messageContext the message context
+     * @return success if policy is accepted. {@link #EVENT_ID_MUST_ACCEPT} otherwise.
+     */
+    public Event verify(final RequestContext context, final Credential credential,
+                              final MessageContext messageContext)  {
+        final String key = credential.getId();
+        if (this.policyMap.containsKey(key)) {
+            final Boolean hasAcceptedPolicy = this.policyMap.get(key);
+            return hasAcceptedPolicy ? new EventFactorySupport().success(this)
+                    : new EventFactorySupport().event(this, EVENT_ID_MUST_ACCEPT);
+        }
+        return new EventFactorySupport().event(this, "musAccept");
+    }
+
+    /**
+     * Record the fact that the policy is accepted.
+     *
+     * @param context the context
+     * @param credential the credential
+     * @param messageContext the message context
+     * @return success if policy acceptance is recorded successfully.
+     */
+    public Event submit(final RequestContext context, final Credential credential,
+                              final MessageContext messageContext)  {
+        this.policyMap.put(credential.getId(), Boolean.TRUE);
+        return new EventFactorySupport().success(this);
+    }
+}

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -103,9 +103,14 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
      * @return the cookie value
      */
     public String retrieveCookieValue(final HttpServletRequest request) {
-        final Cookie cookie = org.springframework.web.util.WebUtils.getCookie(
-                request, getCookieName());
-        return cookie == null ? null : this.casCookieValueManager.obtainCookieValue(cookie, request);
+        try {
+            final Cookie cookie = org.springframework.web.util.WebUtils.getCookie(
+                    request, getCookieName());
+            return cookie == null ? null : this.casCookieValueManager.obtainCookieValue(cookie, request);
+        } catch (final Exception e) {
+            logger.debug(e.getMessage(), e);
+        }
+        return null;
     }
 
     public void setRememberMeMaxAge(final int maxAge) {

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -31,6 +31,9 @@ screen.welcome.label.warn.accesskey=w
 screen.welcome.button.login=LOGIN
 screen.welcome.button.clear=CLEAR
 
+screen.aup.button.accept=ACCEPT
+screen.aup.button.cancel=CANCEL
+
 screen.nonsecure.title=Non-secure Connection
 screen.nonsecure.message=You are currently accessing CAS over a non-secure connection. Single Sign On WILL NOT WORK. In order to have single sign on work, you MUST log in over HTTPS.
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -299,4 +299,7 @@
         c:cas-ref="centralAuthenticationService"
         c:tgtCookieGenerator-ref="ticketGrantingTicketCookieGenerator"
         c:warnCookieGenerator-ref="warnCookieGenerator"/>
+
+  <bean id="acceptableUsagePolicyFormAction" class="org.jasig.cas.web.flow.AcceptableUsagePolicyFormAction"/>
+
 </beans>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casAcceptableUsagePolicyView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casAcceptableUsagePolicyView.jsp
@@ -1,0 +1,46 @@
+<%--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<jsp:directive.include file="includes/top.jsp" />
+<div id="login" style="width: 100%;">
+    <form:form method="post" id="fm1" htmlEscape="true">
+
+        <h2>Acceptable Usage Policy</h2>
+        <div>
+            The purpose of this policy is to establish acceptable and unacceptable use of electronic devices and network resources in conjunction with the established culture of ethical and lawful behavior, openness, trust, and integrity.
+
+            <p>
+                By using these resources, you agree to abide by the Acceptable Usage Policy.
+            </p>
+
+            <p>Click '<spring:message code="screen.aup.button.accept" />' to continue. Otherwise, click '<spring:message code="screen.aup.button.cancel" />'.</p>
+        </div>
+
+        <section class="row btn-row">
+            <input type="hidden" name="execution" value="${flowExecutionKey}" />
+            <input type="hidden" name="_eventId" value="submit" />
+            <input class="btn-submit" name="submit" accesskey="s" value="<spring:message code="screen.aup.button.accept" />"  type="submit" />
+            <input class="btn-reset" name="cancel" accesskey="c"
+                   value="<spring:message code="screen.aup.button.cancel" />" type="button"
+                   onclick="location.href = location.href;" />
+        </section>
+    </form:form>
+</div>
+<jsp:directive.include file="includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -95,11 +95,34 @@
   <action-state id="realSubmit">
     <evaluate expression="authenticationViaFormAction.submit(flowRequestContext, flowScope.credential, messageContext)" />
     <transition on="warn" to="warn" />
+    <!--
+    To enable AUP workflows, replace the 'success' transition with the following:
+    <transition on="success" to="acceptableUsagePolicyCheck" />
+    -->
     <transition on="success" to="sendTicketGrantingTicket" />
     <transition on="successWithWarnings" to="showMessages" />
     <transition on="authenticationFailure" to="handleAuthenticationFailure" />
     <transition on="error" to="generateLoginTicket" />
   </action-state>
+
+  <!-- Enable AUP flow
+  <action-state id="acceptableUsagePolicyCheck">
+    <evaluate expression="acceptableUsagePolicyFormAction.verify(flowRequestContext, flowScope.credential, messageContext)" />
+    <transition on="success" to="sendTicketGrantingTicket" />
+    <transition to="acceptableUsagePolicyView" />
+  </action-state>
+
+  <view-state id="acceptableUsagePolicyView" view="casAcceptableUsagePolicyView">
+      <transition on="submit" to="aupAcceptedAction" />
+      <transition to="generateLoginTicket" />
+  </view-state>
+
+  <action-state id="aupAcceptedAction">
+    <evaluate expression="acceptableUsagePolicyFormAction.submit(flowRequestContext, flowScope.credential, messageContext)" />
+    <transition on="error" to="generateLoginTicket" />
+    <transition on="success" to="sendTicketGrantingTicket" />
+  </action-state>
+  -->
 
   <view-state id="showMessages" view="casLoginMessageView">
     <on-entry>


### PR DESCRIPTION
Handles https://github.com/Jasig/cas/issues/467

Allow the user to accept the usage policy before moving on to the application. In this PR, the remembering of the policy acceptable is recorded per credential id into map kept in memory. Other sophisticated impls can extend the `AcceptableUsagePolicyFormAction` class to verify and record this
behavior via an external flag such as an ldap attribute, etc. 

