### PR TITLE
Authz failure views do not show details

### DIFF
--- a/cas-management-webapp/src/main/java/org/jasig/cas/services/web/ManageRegisteredServicesMultiActionController.java
+++ b/cas-management-webapp/src/main/java/org/jasig/cas/services/web/ManageRegisteredServicesMultiActionController.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
@@ -67,14 +68,35 @@ public final class ManageRegisteredServicesMultiActionController {
         this.servicesManager = servicesManager;
         this.defaultServiceUrl = defaultServiceUrl;
     }
-    
+
+    /**
+     * Authorization failure handling. Simply returns the view name.
+     *
+     * @return the view name.
+     */
+    @RequestMapping(value="authorizationFailure.html", method={RequestMethod.GET})
+    public String authorizationFailureView() {
+        return "authorizationFailure";
+    }
+
+    /**
+     * Logout handling. Simply returns the view name.
+     *
+     * @return the view name.
+     */
+    @RequestMapping(value="loggedOut.html", method={RequestMethod.GET})
+    public String logoutView() {
+        return "logout";
+    }
+
+
     /**
      * Method to delete the RegisteredService by its ID.
      *
      * @param idAsLong the id
      * @return the Model and View to go to after the service is deleted.
      */
-    @RequestMapping(value="deleteRegisteredService.html")
+    @RequestMapping(value="deleteRegisteredService.html", method={RequestMethod.GET})
     public ModelAndView deleteRegisteredService(
             @RequestParam("id") final long idAsLong) {
         
@@ -91,7 +113,7 @@ public final class ManageRegisteredServicesMultiActionController {
      * Method to show the RegisteredServices.
      * @return the Model and View to go to after the services are loaded.
      */
-    @RequestMapping("manage.html")
+    @RequestMapping(value="manage.html", method={RequestMethod.GET})
     public ModelAndView manage() {
         final Map<String, Object> model = new HashMap<>();
 
@@ -116,7 +138,7 @@ public final class ManageRegisteredServicesMultiActionController {
      * There will also be a <code>successful</code> boolean parameter that indicates whether or not the update
      * was successful.
      */
-    @RequestMapping("updateRegisteredServiceEvaluationOrder.html")
+    @RequestMapping(value="updateRegisteredServiceEvaluationOrder.html", method={RequestMethod.GET})
     public ModelAndView updateRegisteredServiceEvaluationOrder(@RequestParam("id") final long id,
             @RequestParam("evaluationOrder") final int evaluationOrder) {
         final RegisteredService svc = this.servicesManager.findServiceBy(id);

--- a/cas-management-webapp/src/main/java/org/jasig/cas/services/web/ManageRegisteredServicesMultiActionController.java
+++ b/cas-management-webapp/src/main/java/org/jasig/cas/services/web/ManageRegisteredServicesMultiActionController.java
@@ -46,9 +46,6 @@ import org.springframework.web.servlet.view.RedirectView;
 @Controller
 public final class ManageRegisteredServicesMultiActionController {
 
-    /** View name for the Manage Services View. */
-    public static final String VIEW_NAME = "manageServiceView";
-
     /** Instance of ServicesManager. */
     @NotNull
     private final ServicesManager servicesManager;
@@ -120,10 +117,10 @@ public final class ManageRegisteredServicesMultiActionController {
         final List<RegisteredService> services = new ArrayList<>(this.servicesManager.getAllServices());
 
         model.put("services", services);
-        model.put("pageTitle", VIEW_NAME);
+        model.put("pageTitle", "Manage");
         model.put("defaultServiceUrl", this.defaultServiceUrl);
 
-        return new ModelAndView(VIEW_NAME, model);
+        return new ModelAndView("manage", model);
     }
 
     /**

--- a/cas-management-webapp/src/main/java/org/jasig/cas/services/web/RegisteredServiceSimpleFormController.java
+++ b/cas-management-webapp/src/main/java/org/jasig/cas/services/web/RegisteredServiceSimpleFormController.java
@@ -58,10 +58,9 @@ import java.util.List;
 public final class RegisteredServiceSimpleFormController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RegisteredServiceSimpleFormController.class);
-    
+
     private static final String COMMAND_NAME = "registeredService";
-    private static final String VIEW_NAME = "editServiceView";
-    
+
     /** Instance of ServiceRegistryManager. */
     @NotNull
     private final ServicesManager servicesManager;
@@ -177,7 +176,7 @@ public final class RegisteredServiceSimpleFormController {
     protected ModelAndView render(final HttpServletRequest request, final ModelMap model)
             throws Exception {
         updateModelMap(model, request);
-        return new ModelAndView(VIEW_NAME);
+        return new ModelAndView("add");
     }
     
     /**

--- a/cas-management-webapp/src/main/resources/default_views.properties
+++ b/cas-management-webapp/src/main/resources/default_views.properties
@@ -17,12 +17,7 @@
 # under the License.
 #
 
-### Services Management Views
-editServiceView.(class)=org.springframework.web.servlet.view.JstlView
-editServiceView.url=/WEB-INF/view/jsp/add.jsp
-
-manageServiceView.(class)=org.springframework.web.servlet.view.JstlView
-manageServiceView.url=/WEB-INF/view/jsp/manage.jsp
-
-serviceLogoutView.(class)=org.springframework.web.servlet.view.JstlView
-serviceLogoutView.url=/WEB-INF/view/jsp/logout.jsp
+# A placeholder for view definitions that are to be defined
+# in the format of:
+# viewName.(class)=org.jasig.cas.web.view.ViewClassName
+# This file is exclusively reserved for custom views

--- a/cas-management-webapp/src/main/resources/messages.properties
+++ b/cas-management-webapp/src/main/resources/messages.properties
@@ -21,6 +21,7 @@
 
 # Blocked Errors Page
 screen.blocked.header=Access Denied
+screen.blocked.message=You are not authorized to access this resource. Contact your CAS administrator for more info.
 
 #Logout Screen Messages
 screen.logout.header=Logout successful

--- a/cas-management-webapp/src/main/webapp/WEB-INF/cas-management-servlet.xml
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/cas-management-servlet.xml
@@ -23,13 +23,20 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:webflow="http://www.springframework.org/schema/webflow-config"
        xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:c="http://www.springframework.org/schema/c"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/webflow-config http://www.springframework.org/schema/webflow-config/spring-webflow-config-2.3.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
   <import resource="spring-configuration/propertyFileConfigurer.xml"/>
+
+  <context:component-scan base-package="org.jasig.cas.services.web" />
+  <mvc:annotation-driven />
 
   <!-- View Resolver -->
   <bean id="viewResolver" class="org.springframework.web.servlet.view.ResourceBundleViewResolver"
@@ -55,7 +62,7 @@
         p:prefix="/WEB-INF/view/jsp/"
         p:suffix=".jsp"
         p:order="2"/>
-  
+
   <bean class="org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter"/>
 
   <bean id="handlerMappingC"
@@ -63,26 +70,12 @@
         p:alwaysUseFullPath="true">
     <property name="mappings">
       <util:properties>
-        <prop key="/loggedOut.html">serviceLogoutViewController</prop>
-        <prop key="/authorizationFailure.html">passThroughController</prop>
+        <prop key="/*.html">passThroughController</prop>
       </util:properties>
     </property>
-    <!--
-     uncomment this to enable sending PageRequest events.
-     <property name="interceptors">
-       <util:list>
-         <ref bean="pageRequestHandlerInterceptorAdapter" />
-       </util:list>
-     </property>
-      -->
   </bean>
 
   <bean id="passThroughController" class="org.springframework.web.servlet.mvc.UrlFilenameViewController"/>
-
-  <bean
-      id="serviceLogoutViewController"
-      class="org.springframework.web.servlet.mvc.ParameterizableViewController"
-      p:viewName="serviceLogoutView"/>
 
   <bean id="messageInterpolator" class="org.jasig.cas.util.SpringAwareMessageMessageInterpolator"/>
 

--- a/cas-management-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
@@ -37,8 +37,7 @@
         modify this unless you know what you're doing!
     </description>
 
-    <context:component-scan base-package="org.jasig.cas.services.web" />
-    <mvc:annotation-driven />
+
     <!-- 
         Message source for this context, loaded from localized "messages_xx" files.
         

--- a/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/authorizationFailure.jsp
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/authorizationFailure.jsp
@@ -20,41 +20,12 @@
 --%>
 <jsp:directive.include file="includes/top.jsp" />
 
-<%@ page import="org.jasig.cas.web.support.WebUtils"%>
-<%@ page import="org.springframework.security.web.WebAttributes"%>
+<%@ page isErrorPage="true" %>
 
-<p />
+<p/>
 <div id="msg" class="errors">
-	<h2><spring:message code="screen.blocked.header" /></h2>
-	<%
-        // Look for details of authorization failure in well-known request attributes.
-        final String[] keys = new String[] {WebUtils.CAS_ACCESS_DENIED_REASON, WebAttributes.AUTHENTICATION_EXCEPTION};
-        Object detail = null;
-        for (String key : keys) {
-            detail = request.getAttribute(key);
-            if (detail == null) {
-                detail = request.getSession().getAttribute(key);
-                request.getSession().removeAttribute(key);
-            }
-            if (detail != null) {
-                break;
-            }
-        }
-        if (detail instanceof String) {
-            request.setAttribute("messageKey", detail);
-        } else if (detail instanceof Exception) {
-            final Exception cause = (Exception) detail;
-            final String message = String.format("%s::%s", cause.getClass().getSimpleName(), cause.getMessage());
-            request.setAttribute("message", message);
-        }
-    %>
-    <c:choose>
-        <c:when test="${not empty messageKey}">
-            <p><spring:message code="${messageKey}" /></p>
-        </c:when>
-        <c:when test="${not empty message}">
-            <p><c:out value="${message}" escapeXml="true" /></p>
-        </c:when>
-    </c:choose>
+    <h2><spring:message code="screen.blocked.header" /></h2>
+    <p><spring:message code="screen.blocked.message"/></p>
 </div>
+
 <jsp:directive.include file="includes/bottom.jsp" />

--- a/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/bottom.jsp
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/bottom.jsp
@@ -27,10 +27,10 @@
   <div>
     <h4><spring:message code="footer.links" /></h4>
     <ul id="nav-campus-sites">
-      <li><a href="http://www.apereo.org/cas" rel="_blank"><spring:message code="footer.homePage" /></a>,</li>
-      <li><a href="http://wiki.jasig.org" rel="_blank"><spring:message code="footer.wiki" /></a>,</li>
-      <li><a href="http://issues.jasig.org" rel="_blank"><spring:message code="footer.issueTracker" /></a>,</li>
-      <li><a href="http://www.apereo.org/cas/mailing-lists" rel="_blank"><spring:message code="footer.mailingLists" /></a>.</li>
+      <li><a href="https://www.apereo.org/cas" rel="_blank"><spring:message code="footer.homePage" /></a>,</li>
+      <li><a href="https://jasig.github.io/cas" rel="_blank"><spring:message code="footer.wiki" /></a>,</li>
+      <li><a href="https://github.com/Jasig/cas/issues" rel="_blank"><spring:message code="footer.issueTracker" /></a>,</li>
+      <li><a href="http://jasig.github.io/cas/Mailing-Lists.html" rel="_blank"><spring:message code="footer.mailingLists" /></a>.</li>
     </ul>
   </div>
   <div id="copyright">

--- a/cas-management-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/web.xml
@@ -19,11 +19,11 @@
     under the License.
 
 -->
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_5.xsd"
-         version="2.5">
-  <display-name>CAS Management ${project.version}</display-name>
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+  <display-name>CAS Management 4.1.0-SNAPSHOT</display-name>
 
   <context-param>
     <param-name>contextConfigLocation</param-name>
@@ -67,20 +67,20 @@
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
   </listener>
 
-  <!--
-    - This is the Spring dispatcher servlet which delegates all requests to the
-    - Spring WebMVC controllers as configured in cas-servlet.xml.
-  -->
   <servlet>
     <servlet-name>cas-management</servlet-name>
     <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+    <init-param>
+      <param-name>contextConfigLocation</param-name>
+      <param-value>/WEB-INF/cas-management-servlet.xml, /WEB-INF/cas-management-servlet-*.xml</param-value>
+    </init-param>
     <init-param>
       <param-name>publishContext</param-name>
       <param-value>false</param-value>
     </init-param>
     <load-on-startup>1</load-on-startup>
   </servlet>
-	
+
   <servlet-mapping>
     <servlet-name>cas-management</servlet-name>
     <url-pattern>*.html</url-pattern>
@@ -93,11 +93,6 @@
 
   <error-page>
     <error-code>401</error-code>
-    <location>/authorizationFailure.html</location>
-  </error-page>
-
-  <error-page>
-    <error-code>403</error-code>
     <location>/authorizationFailure.html</location>
   </error-page>
 

--- a/cas-management-webapp/src/test/java/org/jasig/cas/services/web/WebAppContextConfigurationTests.java
+++ b/cas-management-webapp/src/test/java/org/jasig/cas/services/web/WebAppContextConfigurationTests.java
@@ -116,8 +116,7 @@ public class WebAppContextConfigurationTests {
                 .andReturn().getModelAndView();
         assertNotNull(mv);
         
-        assertNotNull(mv.getModel().get("defaultServiceUrl"));    
-        assertEquals(mv.getModel().get("pageTitle"), ManageRegisteredServicesMultiActionController.VIEW_NAME);
+        assertNotNull(mv.getModel().get("defaultServiceUrl"));
         final List<?> svcs = (List<?>) mv.getModel().get("services");
         assertEquals(svcs.size(), 1);
     }

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -77,9 +77,10 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
 
         if (exceedsThreshold(request)) {
             recordThrottle(request);
+            request.setAttribute(WebUtils.CAS_ACCESS_DENIED_REASON, "screen.blocked.message");
             response.sendError(HttpStatus.SC_FORBIDDEN,
                     "Access Denied for user [" + request.getParameter(usernameParameter)
-                    + " from IP Address [" + request.getRemoteAddr() + "]");
+                    + "] from IP Address [" + request.getRemoteAddr() + "]");
             return false;
         }
 

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/view/CasReloadableMessageBundle.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/view/CasReloadableMessageBundle.java
@@ -73,7 +73,7 @@ public class CasReloadableMessageBundle extends ReloadableResourceBundleMessageS
           }       
           
           if (!foundCode) {
-              logger.warn("The code [{}] cannot be found in the language bundle for the locale [{}]",
+              logger.debug("The code [{}] cannot be found in the language bundle for the locale [{}]",
                       code, locale);
           }
         }

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -40,7 +40,8 @@ screen.capslock.on = CAPSLOCK key is turned on!
 
 # Blocked Errors Page
 screen.blocked.header=Access Denied
-screen.blocked.message=You've entered the wrong password for the user too many times.  You've been throttled.
+screen.blocked.message=You've entered the wrong password for the user too many times. You've been throttled.
+AbstractAccessDecisionManager.accessDenied=You are not authorized to access this resource. Contact your CAS administrator for more info.
 
 #Confirmation Screen Messages
 screen.confirmation.message=Click <a href="{0}">here</a> to go to the application.

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/authorizationFailure.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/authorizationFailure.jsp
@@ -20,41 +20,24 @@
 --%>
 <jsp:directive.include file="/WEB-INF/view/jsp/default/ui/includes/top.jsp" />
 
+<%@ page isErrorPage="true" %>
 <%@ page import="org.jasig.cas.web.support.WebUtils"%>
-<%@ page import="org.springframework.security.web.WebAttributes"%>
-
 
 <div id="msg" class="errors">
-	<h2><spring:message code="screen.blocked.header" /></h2>
-	<%
-        // Look for details of authorization failure in well-known request attributes.
-        final String[] keys = new String[] {WebUtils.CAS_ACCESS_DENIED_REASON, WebAttributes.AUTHENTICATION_EXCEPTION};
-        Object detail = null;
-        for (String key : keys) {
-            detail = request.getAttribute(key);
-            if (detail == null) {
-                detail = request.getSession().getAttribute(key);
-                request.getSession().removeAttribute(key);
-            }
-            if (detail != null) {
-                break;
-            }
-        }
-        if (detail instanceof String) {
-            request.setAttribute("messageKey", detail);
-        } else if (detail instanceof Exception) {
-            final Exception cause = (Exception) detail;
-            final String message = String.format("%s::%s", cause.getClass().getSimpleName(), cause.getMessage());
-            request.setAttribute("message", message);
-        }
+    <h2>${pageContext.errorData.statusCode} - <spring:message code="screen.blocked.header" /></h2>
+
+    <%
+        Object casAcessDeniedKey = request.getAttribute(WebUtils.CAS_ACCESS_DENIED_REASON);
+        request.setAttribute("casAcessDeniedKey", casAcessDeniedKey);
+
     %>
+
     <c:choose>
-        <c:when test="${not empty messageKey}">
-            <p><spring:message code="${messageKey}" /></p>
-        </c:when>
-        <c:when test="${not empty message}">
-            <p><c:out value="${message}" escapeXml="true" /></p>
+        <c:when test="${not empty casAcessDeniedKey}">
+            <p><spring:message code="${casAcessDeniedKey}" /></p>
         </c:when>
     </c:choose>
+    <p><%=request.getAttribute("javax.servlet.error.message")%></p>
+    <p><spring:message code="AbstractAccessDecisionManager.accessDenied"/></p>
 </div>
 <jsp:directive.include file="/WEB-INF/view/jsp/default/ui/includes/bottom.jsp" />


### PR DESCRIPTION
Handles https://github.com/Jasig/cas/issues/501

When throttling is enabled, the authorization failure views do not explain any details. The message key that was expected in the view could never be found. 

This pull does the following:

1. Allowed the authz failure view to explain itself when throttling is enabled
2. Added additional error messages to the authz failure view for the /status endpoint
3. Applied the same changes to the management app when user is not authorized to access resources

Given the way controllers are annotated in the management app, I had to move around the declarations of views a bit to make sure spring security does not interfere with spring webmvc. As a result, views are not automatically picked up, and there is no need to explicitly declare them, which is similar to how the cas webapp works. 