### PR TITLE
Missing LT error is not reported back 

### DIFF
--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/AuthenticationViaFormAction.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/flow/AuthenticationViaFormAction.java
@@ -131,7 +131,7 @@ public class AuthenticationViaFormAction {
     protected Event returnInvalidLoginTicketEvent(final RequestContext context, final MessageContext messageContext) {
         final String loginTicketFromRequest = WebUtils.getLoginTicketFromRequest(context);
         logger.warn("Invalid login ticket [{}]", loginTicketFromRequest);
-        messageContext.addMessage(new MessageBuilder().code("error.invalid.loginticket").build());
+        messageContext.addMessage(new MessageBuilder().error().code("error.invalid.loginticket").build());
         return newEvent(ERROR);
     }
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
@@ -27,7 +27,7 @@
     </div>
 </c:if>
 
-<div id="cookiesDisabled" class="errors">
+<div id="cookiesDisabled" class="errors" style="display:none;">
     <h2><spring:message code="screen.cookies.disabled.title" /></h2>
     <p><spring:message code="screen.cookies.disabled.message" /></p>
 </div>

--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -129,7 +129,6 @@ header h1 {
     padding-left: 100px;
     padding-top:5px;
     margin-bottom:5px;
-    display: none;
     background: url(../images/error.png) no-repeat 20px center;
 }
 


### PR DESCRIPTION
Handles https://github.com/Jasig/cas/issues/907

I also noticed that none of the other error messages are actually displayed on the page, because the css class `errors` is/was set to hide them all by default. I made sure the class is back to normal, and only added specific style info to the block that wanted off the screen initially.