### PR TITLE
Issue #904 Fix scope of allowedToProxy flag.

### DIFF
--- a/cas-server-compatibility/pom.xml
+++ b/cas-server-compatibility/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.4.1-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-core/pom.xml
+++ b/cas-server-core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cas-server</artifactId>
     <groupId>org.jasig.cas</groupId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jasig.cas</groupId>

--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -25,12 +25,7 @@ import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.AuthenticationManager;
 import org.jasig.cas.authentication.MutableAuthentication;
 import org.jasig.cas.authentication.handler.AuthenticationException;
-import org.jasig.cas.authentication.principal.Credentials;
-import org.jasig.cas.authentication.principal.PersistentIdGenerator;
-import org.jasig.cas.authentication.principal.Principal;
-import org.jasig.cas.authentication.principal.Service;
-import org.jasig.cas.authentication.principal.ShibbolethCompatiblePersistentIdGenerator;
-import org.jasig.cas.authentication.principal.SimplePrincipal;
+import org.jasig.cas.authentication.principal.*;
 import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.services.UnauthorizedProxyingException;
@@ -211,11 +206,11 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
             throw new UnauthorizedSsoServiceException();
         }
 
-        //CAS-1019
-        final List<Authentication> authns = ticketGrantingTicket.getChainedAuthentications();
-        if(authns.size() > 1) {
-            if (!registeredService.isAllowedToProxy()) {
-                final String message = String.format("ServiceManagement: Service Attempted to Proxy, but is not allowed. Service: [%s] | Registered Service: [%s]", service.getId(), registeredService.toString());
+        final String proxiedBy = ticketGrantingTicket.getProxiedBy();
+        if(proxiedBy != null) {
+            final RegisteredService proxyingService = servicesManager.findServiceBy(new SimpleWebApplicationServiceImpl(proxiedBy));
+            if (proxyingService == null || !proxyingService.isAllowedToProxy()) {
+                final String message = String.format("ServiceManagement: Service Attempted to Proxy, but is not allowed. Service: [%s] | Registered Service: [%s]", service.getId(), proxyingService);
                 log.warn(message);
                 throw new UnauthorizedProxyingException(message);
             }

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/ServiceTicketImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/ServiceTicketImpl.java
@@ -110,8 +110,7 @@ public final class ServiceTicketImpl extends AbstractTicket implements
             this.grantedTicketAlready = true;
         }
 
-        return new TicketGrantingTicketImpl(id, (TicketGrantingTicketImpl) this.getGrantingTicket(),
-            authentication, expirationPolicy);
+        return new TicketGrantingTicketImpl(id, service.getId(), (TicketGrantingTicketImpl) this.getGrantingTicket(), authentication, expirationPolicy);
     }
     
     public Authentication getAuthentication() {

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
@@ -77,4 +77,12 @@ public interface TicketGrantingTicket extends Ticket {
      * @return the list of principals
      */
     List<Authentication> getChainedAuthentications();
+
+    /**
+     * Gets the service that produced a proxy-granting ticket.
+     *
+     * @return  Service that produced proxy-granting ticket or null if this is
+     * not a proxy-granting ticket.
+     */
+    String getProxiedBy();
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
@@ -68,7 +68,12 @@ public final class TicketGrantingTicketImpl extends AbstractTicket implements
     @Lob
     @Column(name="SERVICES_GRANTED_ACCESS_TO", nullable=false)
     private final HashMap<String,Service> services = new HashMap<String, Service>();
-    
+
+    /** Service that produced a proxy-granting ticket. */
+    @Column(name="PROXIED_BY", nullable=true)
+    private String proxiedBy;
+
+
     public TicketGrantingTicketImpl() {
         // nothing to do
     }
@@ -77,19 +82,24 @@ public final class TicketGrantingTicketImpl extends AbstractTicket implements
      * Constructs a new TicketGrantingTicket.
      * 
      * @param id the id of the Ticket
+     * @param proxiedBy Service that produced this proxy ticket.
      * @param ticketGrantingTicket the parent ticket
      * @param authentication the Authentication request for this ticket
      * @param policy the expiration policy for this ticket.
      * @throws IllegalArgumentException if the Authentication object is null
      */
     public TicketGrantingTicketImpl(final String id,
-        final TicketGrantingTicketImpl ticketGrantingTicket,
+        final String proxiedBy, final TicketGrantingTicketImpl ticketGrantingTicket,
         final Authentication authentication, final ExpirationPolicy policy) {
         super(id, ticketGrantingTicket, policy);
 
         Assert.notNull(authentication, "authentication cannot be null");
 
         this.authentication = authentication;
+        if (ticketGrantingTicket != null && proxiedBy == null) {
+            throw new IllegalArgumentException("Must specify proxiedBy when providing parent TGT");
+        }
+        this.proxiedBy = proxiedBy;
     }
 
     /**
@@ -102,11 +112,15 @@ public final class TicketGrantingTicketImpl extends AbstractTicket implements
      */
     public TicketGrantingTicketImpl(final String id,
         final Authentication authentication, final ExpirationPolicy policy) {
-        this(id, null, authentication, policy);
+        this(id, null, null, authentication, policy);
     }
 
     public Authentication getAuthentication() {
         return this.authentication;
+    }
+
+    public String getProxiedBy() {
+        return proxiedBy;
     }
 
     public synchronized ServiceTicket grantServiceTicket(final String id,

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
@@ -83,20 +83,20 @@ public final class TicketGrantingTicketImpl extends AbstractTicket implements
      * 
      * @param id the id of the Ticket
      * @param proxiedBy Service that produced this proxy ticket.
-     * @param ticketGrantingTicket the parent ticket
+     * @param parentTicketGrantingTicket the parent ticket
      * @param authentication the Authentication request for this ticket
      * @param policy the expiration policy for this ticket.
      * @throws IllegalArgumentException if the Authentication object is null
      */
     public TicketGrantingTicketImpl(final String id,
-        final String proxiedBy, final TicketGrantingTicketImpl ticketGrantingTicket,
+        final String proxiedBy, final TicketGrantingTicketImpl parentTicketGrantingTicket,
         final Authentication authentication, final ExpirationPolicy policy) {
-        super(id, ticketGrantingTicket, policy);
+        super(id, parentTicketGrantingTicket, policy);
 
         Assert.notNull(authentication, "authentication cannot be null");
 
         this.authentication = authentication;
-        if (ticketGrantingTicket != null && proxiedBy == null) {
+        if (parentTicketGrantingTicket != null && proxiedBy == null) {
             throw new IllegalArgumentException("Must specify proxiedBy when providing parent TGT");
         }
         this.proxiedBy = proxiedBy;

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/AbstractDistributedTicketRegistry.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/AbstractDistributedTicketRegistry.java
@@ -162,6 +162,10 @@ public abstract class AbstractDistributedTicketRegistry extends AbstractTicketRe
             return getTicket().getAuthentication();
         }
 
+        public String getProxiedBy() {
+            return getTicket().getProxiedBy();
+        }
+
         public ServiceTicket grantServiceTicket(final String id, final Service service, final ExpirationPolicy expirationPolicy, final boolean credentialsProvided) {
             final ServiceTicket t = this.getTicket().grantServiceTicket(id, service, expirationPolicy, credentialsProvided);
             updateTicket();

--- a/cas-server-core/src/test/java/org/jasig/cas/CentralAuthenticationServiceImplWithMokitoTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/CentralAuthenticationServiceImplWithMokitoTests.java
@@ -54,9 +54,7 @@ public class CentralAuthenticationServiceImplWithMokitoTests {
         TicketGrantingTicket tgtMock = mock(TicketGrantingTicket.class);
         when(tgtMock.isExpired()).thenReturn(false);
         when(tgtMock.grantServiceTicket(anyString(), any(Service.class), any(ExpirationPolicy.class), anyBoolean())).thenReturn(stMock);
-        List<Authentication> authnListMock = mock(List.class);
-        when(authnListMock.size()).thenReturn(2); // <-- criteria for testing the CAS-1019 feature
-        when(tgtMock.getChainedAuthentications()).thenReturn(authnListMock);
+        when(tgtMock.getProxiedBy()).thenReturn("proxiedBy");
 
         //Mock TicketRegistry
         TicketRegistry ticketRegMock = mock(TicketRegistry.class);

--- a/cas-server-core/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
@@ -51,6 +51,8 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
     private int usageCount;
 
     private boolean expired;
+
+    private String proxiedBy;
             
 
     public MockTicketGrantingTicket(final String principal) {
@@ -106,5 +108,9 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
 
     public int getCountOfUses() {
         return usageCount;
+    }
+
+    public String getProxiedBy() {
+        return proxiedBy;
     }
 }

--- a/cas-server-core/src/test/java/org/jasig/cas/ticket/TicketGrantingTicketImplTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/ticket/TicketGrantingTicketImplTests.java
@@ -40,7 +40,7 @@ public class TicketGrantingTicketImplTests extends TestCase {
     private UniqueTicketIdGenerator uniqueTicketIdGenerator = new DefaultUniqueTicketIdGenerator();
 
     public void testEquals() {
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             TestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         assertFalse(t.equals(null));
@@ -50,7 +50,7 @@ public class TicketGrantingTicketImplTests extends TestCase {
     
     public void testNullAuthentication() {
         try {
-            new TicketGrantingTicketImpl("test", null, null,
+            new TicketGrantingTicketImpl("test", null, null, null,
                 new NeverExpiresExpirationPolicy());
             fail("Exception expected.");
         } catch (Exception e) {
@@ -61,7 +61,7 @@ public class TicketGrantingTicketImplTests extends TestCase {
     public void testGetAuthentication() {
         Authentication authentication = TestUtils.getAuthentication();
 
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             authentication, new NeverExpiresExpirationPolicy());
 
         assertEquals(t.getAuthentication(), authentication);
@@ -69,16 +69,16 @@ public class TicketGrantingTicketImplTests extends TestCase {
     }
 
     public void testIsRootTrue() {
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             TestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         assertTrue(t.isRoot());
     }
 
     public void testIsRootFalse() {
-        TicketGrantingTicketImpl t1 = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicketImpl t1 = new TicketGrantingTicketImpl("test", null, null,
             TestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", t1,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", "grantor", t1,
             TestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         assertFalse(t.isRoot());
@@ -89,7 +89,7 @@ public class TicketGrantingTicketImplTests extends TestCase {
         List<Authentication> principals = new ArrayList<Authentication>();
         principals.add(authentication);
 
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             authentication, new NeverExpiresExpirationPolicy());
 
         assertEquals(principals, t.getChainedAuthentications());
@@ -101,7 +101,7 @@ public class TicketGrantingTicketImplTests extends TestCase {
         principals.add(authentication);
         
         final long startTime = System.currentTimeMillis();
-        final TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        final TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             authentication, new NeverExpiresExpirationPolicy());
         final long finishTime = System.currentTimeMillis();
         
@@ -115,16 +115,16 @@ public class TicketGrantingTicketImplTests extends TestCase {
         principals.add(authentication);
         principals.add(authentication1);
 
-        TicketGrantingTicketImpl t1 = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicketImpl t1 = new TicketGrantingTicketImpl("test", null, null,
             authentication1, new NeverExpiresExpirationPolicy());
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", t1,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", "grantor", t1,
             authentication, new NeverExpiresExpirationPolicy());
 
         assertEquals(principals, t.getChainedAuthentications());
     }
 
     public void testServiceTicketAsFromInitialCredentials() {
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             TestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
         ServiceTicket s = t.grantServiceTicket(this.uniqueTicketIdGenerator
             .getNewTicketId(ServiceTicket.PREFIX), TestUtils.getService(),
@@ -134,21 +134,25 @@ public class TicketGrantingTicketImplTests extends TestCase {
     }
 
     public void testServiceTicketAsFromNotInitialCredentials() {
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             TestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        ServiceTicket s = t.grantServiceTicket(this.uniqueTicketIdGenerator
-            .getNewTicketId(ServiceTicket.PREFIX), TestUtils.getService(),
-            new NeverExpiresExpirationPolicy(), false);
-        s = t.grantServiceTicket(this.uniqueTicketIdGenerator
-            .getNewTicketId(ServiceTicket.PREFIX), TestUtils.getService(),
-            new NeverExpiresExpirationPolicy(), false);
+        t.grantServiceTicket(
+                this.uniqueTicketIdGenerator.getNewTicketId(ServiceTicket.PREFIX),
+                TestUtils.getService(),
+                new NeverExpiresExpirationPolicy(),
+                false);
+        ServiceTicket s = t.grantServiceTicket(
+                this.uniqueTicketIdGenerator.getNewTicketId(ServiceTicket.PREFIX),
+                TestUtils.getService(),
+                new NeverExpiresExpirationPolicy(),
+                false);
 
         assertFalse(s.isFromNewLogin());
     }
     
     public void testWebApplicationSignOut() {
         final MockService testService = new MockService("test");
-        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null,
+        TicketGrantingTicket t = new TicketGrantingTicketImpl("test", null, null,
             TestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
         t.grantServiceTicket(this.uniqueTicketIdGenerator
             .getNewTicketId(ServiceTicket.PREFIX), testService,

--- a/cas-server-documentation/pom.xml
+++ b/cas-server-documentation/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>cas-server</artifactId>
     <groupId>org.jasig.cas</groupId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jasig.cas</groupId>
   <artifactId>cas-server-documentation</artifactId>

--- a/cas-server-extension-clearpass/pom.xml
+++ b/cas-server-extension-clearpass/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<artifactId>cas-server</artifactId>
 		<groupId>org.jasig.cas</groupId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jasig.cas</groupId>
 	<artifactId>cas-server-extension-clearpass</artifactId>

--- a/cas-server-integration-ehcache/pom.xml
+++ b/cas-server-integration-ehcache/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jasig.cas</groupId>
     <artifactId>cas-server</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>   
   <modelVersion>4.0.0</modelVersion>      
   <artifactId>cas-server-integration-ehcache</artifactId>   

--- a/cas-server-integration-jboss/pom.xml
+++ b/cas-server-integration-jboss/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-integration-memcached/pom.xml
+++ b/cas-server-integration-memcached/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-integration-restlet/pom.xml
+++ b/cas-server-integration-restlet/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-generic/pom.xml
+++ b/cas-server-support-generic/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-jdbc/pom.xml
+++ b/cas-server-support-jdbc/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-ldap/pom.xml
+++ b/cas-server-support-ldap/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-legacy/pom.xml
+++ b/cas-server-support-legacy/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-oauth/pom.xml
+++ b/cas-server-support-oauth/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>cas-server-support-oauth</artifactId>

--- a/cas-server-support-openid/pom.xml
+++ b/cas-server-support-openid/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-radius/pom.xml
+++ b/cas-server-support-radius/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-spnego/pom.xml
+++ b/cas-server-support-spnego/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jasig.cas</groupId>

--- a/cas-server-support-trusted/pom.xml
+++ b/cas-server-support-trusted/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.jasig.cas</groupId>
 		<artifactId>cas-server</artifactId>
-		<version>3.5.4-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jasig.cas</groupId>

--- a/cas-server-support-x509/pom.xml
+++ b/cas-server-support-x509/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jasig.cas</groupId>
     <artifactId>cas-server</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jasig.cas</groupId>

--- a/cas-server-uber-webapp/pom.xml
+++ b/cas-server-uber-webapp/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>cas-server</artifactId>
         <groupId>org.jasig.cas</groupId>
-        <version>3.5.4-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jasig.cas</groupId>
     <artifactId>cas-server</artifactId>
-    <version>3.5.4-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jasig.cas</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <packaging>pom</packaging>
   <name>Jasig Central Authentication Service</name>
   <description>Jasig CAS SSO server libraries and Web application.</description>
-  <version>3.5.4-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <url>http://www.jasig.org/cas/</url>
   <inceptionYear>2004</inceptionYear>
 


### PR DESCRIPTION
A new field, proxiedBy, is introduced on TicketGrantingTicket to track the service that generates a proxy-granting ticket to facilitate looking up the corresponding RegisteredService at the time proxy tickets are issued. The allowedToProxy flag on the proxiedBy service determines whether or not the proxy ticket request can proceed.