### PR TITLE
Updated error message for invalid validation requests

### DIFF
--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -85,7 +85,7 @@ authenticationFailure.AccountNotFoundException=Invalid credentials.
 authenticationFailure.FailedLoginException=Invalid credentials.
 authenticationFailure.UNKNOWN=Invalid credentials.
 
-INVALID_REQUEST_PROXY='pgt' and 'targetService' parameters are both required
+INVALID_REQUEST_PROXY=The request is incorrectly formatted. Ensure all required parameters are properly encoded and included.
 INVALID_TICKET_SPEC=Ticket failed validation specification. Possible errors could include attempting to validate a Proxy Ticket via a Service Ticket validator, or not complying with the renew true request.
 INVALID_REQUEST='service' and 'ticket' parameters are both required
 INVALID_TICKET=Ticket ''{0}'' not recognized


### PR DESCRIPTION
Handles https://github.com/Jasig/cas/issues/866 

To convey the actual message back would possibly require some major API work to note missing parameters into the messages. This pull should try to generalize the error message, while exact details are available in the cas log. 