### PR TITLE
CAS #947 -- NTLMSSP_SIGNATURE Casting Exception

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -130,7 +130,7 @@ public final class SpnegoCredential implements Credential, Serializable {
             return false;
         }
         for (int i = 0; i < NTLM_TOKEN_MAX_LENGTH; i++) {
-            if (SpnegoConstants.NTLMSSP_SIGNATURE[i] != token[i]) {
+            if (SpnegoConstants.NTLMSSP_SIGNATURE[i].byteValue() != token[i]) {
                 return false;
             }
         }

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/util/SpnegoConstants.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/util/SpnegoConstants.java
@@ -18,9 +18,6 @@
  */
 package org.jasig.cas.support.spnego.util;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Bytes;
-
 /**
  * Spnego Constants.
  *
@@ -49,9 +46,8 @@ public interface SpnegoConstants {
     String SPNEGO_CREDENTIALS = "spnegoCredentials";
 
     /** The ntlmssp signature. */
-    Byte[] NTLMSSP_SIGNATURE = (Byte[]) ImmutableList.copyOf(
-            Bytes.asList(new byte[]{(byte) 'N', (byte) 'T', (byte) 'L',
-            (byte) 'M', (byte) 'S', (byte) 'S', (byte) 'P', (byte) 0})).toArray();
+    Byte[] NTLMSSP_SIGNATURE = {Byte.valueOf((byte) 'N'), Byte.valueOf((byte) 'T'), Byte.valueOf((byte) 'L'),
+        Byte.valueOf((byte) 'M'), Byte.valueOf((byte) 'S'), Byte.valueOf((byte) 'S'), Byte.valueOf((byte) 'P'), Byte.valueOf((byte) 0)};
 
     /** The ntlm. */
     String NTLM = "NTLM";


### PR DESCRIPTION
Fixes #947 by tweaking storage and checking of NTLMSSP_SIGNATURE.  Short version: different comparison method; different storage method.