### PR TITLE
CAS 948 -- NPE during SPNEGO Authentication

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -152,7 +152,9 @@ public final class SpnegoCredential implements Credential, Serializable {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(this.getInitToken()) ^ Arrays.hashCode(this.getNextToken()) ^ this.principal.hashCode();
+    	int hash = 3;
+    	if (this.principal != null) hash = this.principal.hashCode();
+        return Arrays.hashCode(this.getInitToken()) ^ Arrays.hashCode(this.getNextToken()) ^ hash;
     }
 
     /**

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -19,6 +19,7 @@
 package org.jasig.cas.support.spnego.authentication.principal;
 
 import com.google.common.io.ByteSource;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jasig.cas.authentication.Credential;
 import org.jasig.cas.authentication.principal.Principal;
 import org.jasig.cas.support.spnego.util.SpnegoConstants;
@@ -152,11 +153,13 @@ public final class SpnegoCredential implements Credential, Serializable {
 
     @Override
     public int hashCode() {
-        int hash = 3;
+        int hash = super.hashCode();
         if (this.principal != null) {
             hash = this.principal.hashCode();
         }
-        return Arrays.hashCode(this.getInitToken()) ^ Arrays.hashCode(this.getNextToken()) ^ hash;
+        return new HashCodeBuilder().append(this.getInitToken())
+            .append(this.getNextToken())
+            .append(hash).toHashCode();
     }
 
     /**

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -152,8 +152,10 @@ public final class SpnegoCredential implements Credential, Serializable {
 
     @Override
     public int hashCode() {
-    	int hash = 3;
-    	if (this.principal != null) hash = this.principal.hashCode();
+        int hash = 3;
+        if (this.principal != null) {
+            hash = this.principal.hashCode();
+        }
         return Arrays.hashCode(this.getInitToken()) ^ Arrays.hashCode(this.getNextToken()) ^ hash;
     }
 

--- a/cas-server-support-spnego/src/test/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredentialsTests.java
+++ b/cas-server-support-spnego/src/test/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredentialsTests.java
@@ -22,6 +22,9 @@ import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
 import org.jasig.cas.authentication.principal.Principal;
 import org.junit.Test;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 
@@ -52,11 +55,10 @@ public class SpnegoCredentialsTests {
     @Test
     public void verifyCredentialsHashSafelyWithoutPrincipal() {
         final SpnegoCredential credential = new SpnegoCredential(new byte[] {});
+        final Set<SpnegoCredential> set = new HashSet<>();
         try {
-            final int hash = credential.hashCode();
-            assertNotNull(hash);
-        }
-        catch(final Exception e) {
+            set.add(credential);
+        } catch(final Exception e) {
             fail(e.getMessage());
         }
     }

--- a/cas-server-support-spnego/src/test/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredentialsTests.java
+++ b/cas-server-support-spnego/src/test/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredentialsTests.java
@@ -45,4 +45,32 @@ public class SpnegoCredentialsTests {
         credentials.setPrincipal(principal);
         assertEquals("test", credentials.toString());
     }
+
+    /**
+     * Important for SPNEGO in particular as the credential will be hashed prior to Principal resolution
+     */
+    @Test
+    public void verifyCredentialsHashSafelyWithoutPrincipal() {
+        final SpnegoCredential credential = new SpnegoCredential(new byte[] {});
+        try {
+            final int hash = credential.hashCode();
+            assertNotNull(hash);
+        }
+        catch(final Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Make sure that when the Principal becomes populated / changes we return a new hash
+     */
+    @Test
+    public void verifyPrincipalAffectsHash(){
+        final SpnegoCredential credential = new SpnegoCredential(new byte[] {});
+        final int hash1 = credential.hashCode();
+        final Principal principal = new DefaultPrincipalFactory().createPrincipal("test");
+        credential.setPrincipal(principal);
+        final int hash2 = credential.hashCode();
+        assertNotEquals(hash1, hash2);
+    }
 }


### PR DESCRIPTION
Fixes #948.  Modify hashCode function of SpnegoCredential in order to avoid NPE when principal has not yet been resolved.