### PR TITLE
Corrected properties name to match setters

### DIFF
--- a/cas-server-documentation/installation/X509-Authentication.md
+++ b/cas-server-documentation/installation/X509-Authentication.md
@@ -34,8 +34,8 @@ by the Web server terminating the SSL connection. Since an SSL peer may be confi
 certificates, the CAS X.509 handler provides a number of properties that place additional restrictions on
 acceptable client certificates.
 
-* `regExTrustedIssuerDnPattern` - Regular expression defining allowed issuer DNs. (must be specified)
-* `regExSubjectDnPattern` - Regular expression defining allowed subject DNs. (default=`.*`)
+* `trustedIssuerDnPattern` - Regular expression defining allowed issuer DNs. (must be specified)
+* `subjectDnPattern` - Regular expression defining allowed subject DNs. (default=`.*`)
 * `maxPathLength` - Maximum number of certs allowed in certificate chain. (default=1)
 * `maxPathLengthAllowUnspecified` - True to allow unspecified path length, false otherwise. (default=false)
 * `checkKeyUsage` - True to enforce certificate `keyUsage` field (if present), false otherwise. (default=false)


### PR DESCRIPTION
```regExTrustedIssuerDnPattern``` and ```regExSubjectDnPattern``` are variable name and does not match setters. 
The properties to set on deployerConfigContext.xml must be ```trustedIssuerDnPattern``` and ```regExSubjectDnPattern```.

A real minor change but avoid to have to read the source :)