### PR TITLE
Update OAuthConstants.java

### DIFF
--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
@@ -54,7 +54,7 @@ public interface OAuthConstants {
     String ACCESS_TOKEN = "access_token";
 
     /** The bearer token. */
-    String BEARER_TOKEN = "bearer";
+    String BEARER_TOKEN = "Bearer";
     
     /** The OAUT h20_ callbackurl. */
     String OAUTH20_CALLBACKURL = "oauth20_callbackUrl";

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
@@ -155,7 +155,7 @@ public final class OAuth20ProfileControllerTests {
     public void verifyOKWithAuthorizationHeader() throws Exception {
         final MockHttpServletRequest mockRequest = new MockHttpServletRequest("GET", CONTEXT
                 + OAuthConstants.PROFILE_URL);
-        mockRequest.addHeader("Authorization", "bearer " + TGT_ID);
+        mockRequest.addHeader("Authorization", "Bearer " + TGT_ID);
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
         final OAuth20WrapperController oauth20WrapperController = new OAuth20WrapperController();
         final TicketRegistry ticketRegistry = mock(TicketRegistry.class);

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
@@ -155,7 +155,7 @@ public final class OAuth20ProfileControllerTests {
     public void verifyOKWithAuthorizationHeader() throws Exception {
         final MockHttpServletRequest mockRequest = new MockHttpServletRequest("GET", CONTEXT
                 + OAuthConstants.PROFILE_URL);
-        mockRequest.addHeader("Authorization", "Bearer " + TGT_ID);
+        mockRequest.addHeader("Authorization", OAuthConstants.BEARER_TOKEN + " " + TGT_ID);
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
         final OAuth20WrapperController oauth20WrapperController = new OAuth20WrapperController();
         final TicketRegistry ticketRegistry = mock(TicketRegistry.class);


### PR DESCRIPTION
As far as I can tell bearer token should be written with uppercase B, ie:
 - https://tools.ietf.org/html/rfc6750#section-2.1
 - http://stackoverflow.com/questions/22229996/basic-http-and-bearer-token-authentication

I'm not very fluent with RFC docs so I'm not sure how "bearer" should be treated. Currently the problem occurs in OAuth20ProfileController.handleRequestInternal() (line 71), this can be fixed by making authHeader lowercase before comparision, but that would allow usage of constructs like "bEarer" etc. which doesn't seem right.

According to https://tools.ietf.org/html/rfc6750#section-1.1 case sensitive comparision should be used, so it might be better to change OAuthConstants.BEARER_TOKEN to "Bearer".