### PR TITLE
OAuth2 - Bearer token handling - Ignore case comparision of bearer token authorization header

### DIFF
--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
@@ -56,6 +56,9 @@ public interface OAuthConstants {
     /** The bearer token. */
     String BEARER_TOKEN = "Bearer";
     
+    /** The bearer token in lower case. */
+    String BEARER_TOKEN_IGNORE_CASE = BEARER_TOKEN.toLowerCase();
+
     /** The OAUT h20_ callbackurl. */
     String OAUTH20_CALLBACKURL = "oauth20_callbackUrl";
 

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
@@ -56,9 +56,6 @@ public interface OAuthConstants {
     /** The bearer token. */
     String BEARER_TOKEN = "Bearer";
     
-    /** The bearer token in lower case. */
-    String BEARER_TOKEN_IGNORE_CASE = BEARER_TOKEN.toLowerCase();
-
     /** The OAUT h20_ callbackurl. */
     String OAUTH20_CALLBACKURL = "oauth20_callbackUrl";
 

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20ProfileController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20ProfileController.java
@@ -68,7 +68,8 @@ public final class OAuth20ProfileController extends AbstractController {
         String accessToken = request.getParameter(OAuthConstants.ACCESS_TOKEN);
         if (StringUtils.isBlank(accessToken)) {
             final String authHeader = request.getHeader("Authorization");
-            if (StringUtils.isNotBlank(authHeader) && authHeader.startsWith(OAuthConstants.BEARER_TOKEN + " ")) {
+            if (StringUtils.isNotBlank(authHeader) 
+                    && authHeader.toLowerCase().startsWith(OAuthConstants.BEARER_TOKEN_IGNORE_CASE + " ")) {
                 accessToken = authHeader.substring(OAuthConstants.BEARER_TOKEN.length() + 1);
             }
         }

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20ProfileController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20ProfileController.java
@@ -69,7 +69,7 @@ public final class OAuth20ProfileController extends AbstractController {
         if (StringUtils.isBlank(accessToken)) {
             final String authHeader = request.getHeader("Authorization");
             if (StringUtils.isNotBlank(authHeader) 
-                    && authHeader.toLowerCase().startsWith(OAuthConstants.BEARER_TOKEN_IGNORE_CASE + " ")) {
+                    && authHeader.toLowerCase().startsWith(OAuthConstants.BEARER_TOKEN.toLowerCase() + " ")) {
                 accessToken = authHeader.substring(OAuthConstants.BEARER_TOKEN.length() + 1);
             }
         }


### PR DESCRIPTION
Hello,
I'm not sure if this is the right place, yet I'm still encountering problems with how "Bearer" keyword is used. Changing "bearer" to "Bearer" fixed some issues yet it introduced another. Please take a look at:
https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/DefaultOAuth2RequestAuthenticator.java#L39

when authorizing request tokenType from Oauth2AccessToken is used (if it exists), default implementation lowercases the "Bearer" keyword:

https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/DefaultOAuth2AccessToken.java#L27

Bottom line - being case sensitive in here will probably lead to such problems in the future and they are quite hard to debug. I think it would be best to do a ignorecase comparision. What do you think?