### PR TITLE
Resolve rendering issue with IE compatibility #976

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
@@ -29,6 +29,7 @@
 
 <html lang="en">
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"></meta>
   <meta charset="UTF-8" />
   
   <title>CAS &#8211; Central Authentication Service</title>


### PR DESCRIPTION
Now renders correctly in Windows Google Drive Application by forcing Internet Explorer to compatibility to use the most recent IE version.