### PR TITLE
CAS-986 Schema validation error on web.xml

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -100,6 +100,8 @@
         <listener-class>
             org.springframework.web.context.ContextLoaderListener
         </listener-class>
+    </listener>
+    <listener>
         <listener-class>
             org.jasig.cas.CasEnvironmentContextListener
         </listener-class>


### PR DESCRIPTION
The validation error #986 resolved by including the new listener-class in its own listener tag in web.xml