### PR TITLE
Proxy block missing from CAS response

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
@@ -40,6 +40,9 @@ public interface TicketGrantingTicket extends Ticket {
     /** The prefix to use when generating an id for a Proxy Granting Ticket. */
     String PROXY_GRANTING_TICKET_PREFIX = "PGT";
 
+    /** The prefix to use when generating an id for a Proxy Granting Ticket IOU. */
+    String PROXY_GRANTING_TICKET_IOU_PREFIX = "PGTIOU";
+
     /**
      * Method to retrieve the authentication.
      *

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/proxy/support/Cas20ProxyHandler.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/proxy/support/Cas20ProxyHandler.java
@@ -44,9 +44,6 @@ import java.net.URL;
 public final class Cas20ProxyHandler implements ProxyHandler {
     private static final int BUFFER_LENGTH_ADDITIONAL_CHARGE = 15;
 
-    /** The PGTIOU ticket prefix. */
-    private static final String PGTIOU_PREFIX = "PGTIOU";
-
     /** The proxy granting ticket identifier parameter. */
     private static final String PARAMETER_PROXY_GRANTING_TICKET_IOU = "pgtIou";
 
@@ -67,7 +64,7 @@ public final class Cas20ProxyHandler implements ProxyHandler {
     @Override
     public String handle(final Credential credential, final TicketGrantingTicket proxyGrantingTicketId) {
         final HttpBasedServiceCredential serviceCredentials = (HttpBasedServiceCredential) credential;
-        final String proxyIou = this.uniqueTicketIdGenerator.getNewTicketId(PGTIOU_PREFIX);
+        final String proxyIou = this.uniqueTicketIdGenerator.getNewTicketId(TicketGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX);
 
         final URL callbackUrl = serviceCredentials.getCallbackUrl();
         final String serviceCredentialsAsString = callbackUrl.toExternalForm();
@@ -92,11 +89,11 @@ public final class Cas20ProxyHandler implements ProxyHandler {
         stringBuffer.append(proxyGrantingTicketId);
 
         if (this.httpClient.isValidEndPoint(stringBuffer.toString())) {
-            logger.debug("Sent ProxyIou of {} for service: {}", proxyIou, serviceCredentials.toString());
+            logger.debug("Sent ProxyIou of {} for service: {}", proxyIou, serviceCredentials);
             return proxyIou;
         }
 
-        logger.debug("Failed to send ProxyIou of {} for service: {}", proxyIou, serviceCredentials.toString());
+        logger.debug("Failed to send ProxyIou of {} for service: {}", proxyIou, serviceCredentials);
         return null;
     }
 

--- a/cas-server-core/src/main/java/org/jasig/cas/web/view/AbstractCasView.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/view/AbstractCasView.java
@@ -211,7 +211,17 @@ public abstract class AbstractCasView extends AbstractView {
 
         final Assertion assertion = getAssertionFrom(model);
         final List<Authentication> chainedAuthentications = assertion.getChainedAuthentications();
-        for (int i = 0; i < chainedAuthentications.size() - 1; i++) {
+
+        /**
+         * Note that the last index in the list always describes the primary authentication
+         * event. All others in the chain should denote proxies. Per the CAS protocol,
+         * when authentication has proceeded through multiple proxies,
+         * the order in which the proxies were traversed MUST be reflected in the response.
+         * The most recently-visited proxy MUST be the first proxy listed, and all the
+         * other proxies MUST be shifted down as new proxies are added. I
+         */
+        final int numberAuthenticationsExceptPrimary = chainedAuthentications.size() - 1;
+        for (int i = 0; i < numberAuthenticationsExceptPrimary; i++) {
             chainedAuthenticationsToReturn.add(chainedAuthentications.get(i));
         }
         return chainedAuthenticationsToReturn;

--- a/cas-server-core/src/main/java/org/jasig/cas/web/view/AbstractCasView.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/view/AbstractCasView.java
@@ -211,7 +211,7 @@ public abstract class AbstractCasView extends AbstractView {
 
         final Assertion assertion = getAssertionFrom(model);
         final List<Authentication> chainedAuthentications = assertion.getChainedAuthentications();
-        for (int i = 0; i < chainedAuthentications.size() - 2; i++) {
+        for (int i = 0; i < chainedAuthentications.size() - 1; i++) {
             chainedAuthenticationsToReturn.add(chainedAuthentications.get(i));
         }
         return chainedAuthenticationsToReturn;

--- a/cas-server-core/src/main/java/org/slf4j/impl/CasDelegatingLogger.java
+++ b/cas-server-core/src/main/java/org/slf4j/impl/CasDelegatingLogger.java
@@ -44,7 +44,7 @@ public final class CasDelegatingLogger extends MarkerIgnoringBase implements Ser
     private static final long serialVersionUID = 6182834493563598289L;
 
     private static final Pattern TICKET_ID_PATTERN = Pattern.compile("(" + TicketGrantingTicket.PREFIX + "|"
-            + TicketGrantingTicket.PROXY_GRANTING_TICKET_PREFIX
+            + TicketGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX + "|" + TicketGrantingTicket.PROXY_GRANTING_TICKET_PREFIX
             + ")(-)*(\\w)*(-)*(\\w)*");
 
     /**

--- a/cas-server-core/src/test/java/org/slf4j/impl/CasLoggerFactoryTests.java
+++ b/cas-server-core/src/test/java/org/slf4j/impl/CasLoggerFactoryTests.java
@@ -45,9 +45,12 @@ public class CasLoggerFactoryTests {
 
     private static final File LOG_FILE = new File("target", "slf4j.log");
 
-    private static final String ID1 = TicketGrantingTicket.PREFIX + "-1-B0tjWgMIhUU4kgCZdXbxnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
-    private static final String ID2 = TicketGrantingTicket.PROXY_GRANTING_TICKET_PREFIX + "-1-B0tjWgMIhUU4kgCZd32xnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
-    private static final String ID3 = TicketGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX + "-1-B0tjWgMIhUU4kgCZd32xnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
+    private static final String ID1 = TicketGrantingTicket.PREFIX
+            + "-1-B0tjWgMIhUU4kgCZdXbxnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
+    private static final String ID2 = TicketGrantingTicket.PROXY_GRANTING_TICKET_PREFIX
+            + "-1-B0tjWgMIhUU4kgCZd32xnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
+    private static final String ID3 = TicketGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX
+            + "-1-B0tjWgMIhUU4kgCZd32xnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
     private Logger logger;
 
     @BeforeClass

--- a/cas-server-core/src/test/java/org/slf4j/impl/CasLoggerFactoryTests.java
+++ b/cas-server-core/src/test/java/org/slf4j/impl/CasLoggerFactoryTests.java
@@ -45,9 +45,9 @@ public class CasLoggerFactoryTests {
 
     private static final File LOG_FILE = new File("target", "slf4j.log");
 
-    private static final String ID1 = "TGT-1-B0tjWgMIhUU4kgCZdXbxnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
-    private static final String ID2 = "PGT-1-B0tjWgMIhUU4kgCZd32xnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
-
+    private static final String ID1 = TicketGrantingTicket.PREFIX + "-1-B0tjWgMIhUU4kgCZdXbxnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
+    private static final String ID2 = TicketGrantingTicket.PROXY_GRANTING_TICKET_PREFIX + "-1-B0tjWgMIhUU4kgCZd32xnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
+    private static final String ID3 = TicketGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX + "-1-B0tjWgMIhUU4kgCZd32xnWccTFYpTbRbArjaoutXnlNMbIShEu-cas";
     private Logger logger;
 
     @BeforeClass
@@ -124,6 +124,12 @@ public class CasLoggerFactoryTests {
     @Test
     public void verifyLogging9() {
         logger.trace(getMessageToLog(), new RuntimeException(ID1, new InvalidTicketException(ID2)));
+        validateLogData();
+    }
+
+    @Test
+    public void verifyLogging10() {
+        logger.debug(getMarker("debug"), getMessageToLogWithParams(), ID3, ID1);
         validateLogData();
     }
 
@@ -345,6 +351,7 @@ public class CasLoggerFactoryTests {
             assertTrue("Logged buffer data is blank in " + LOG_FILE.getCanonicalPath(), StringUtils.isNotBlank(data));
             assertFalse("Logged buffer data should not contain " + ID1, data.contains(ID1));
             assertFalse("Logged buffer data should not contain " + ID2, data.contains(ID2));
+            assertFalse("Logged buffer data should not contain " + ID3, data.contains(ID3));
         } catch (final IOException e) {
             fail(e.getMessage());
         }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/unused-spring-configuration/clearpass-configuration.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/unused-spring-configuration/clearpass-configuration.xml
@@ -83,14 +83,24 @@
    -->
     <!--
       NOTE:
-      A bean named clearPassProxyList must be defined in deployerConfigContext.xml that defines
+      A bean named clearPassProxyList must be defined that defines
       the list of proxying services authorized to obtain clearpass credential.
     -->
+    <bean id="clearPassProxyList" class="org.jasig.cas.client.validation.ProxyList">
+        <constructor-arg>
+            <list>
+                <value>...</value>
+            </list>
+        </constructor-arg>
+    </bean>
+
     <bean id="casValidationFilter" class="org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter"
           p:serverName="${server.name}" p:exceptionOnValidationFailure="false"
           p:useSession="true" p:ticketValidator-ref="clearPassTicketValidator"/>
 
     <bean id="clearPassTicketValidator" class="org.jasig.cas.client.validation.Cas20ProxyTicketValidator"
+          p:allowEmptyProxyChain="false"
+          p:acceptAnyProxy="false"
           c:casServerUrlPrefix="${server.prefix}" p:allowedProxyChains-ref="clearPassProxyList"/>
 
     <bean id="httpServletRequestWrappingFilter" class="org.jasig.cas.client.util.HttpServletRequestWrapperFilter"/>


### PR DESCRIPTION
Troubleshooting an issue with Clearpass that had to do with a missing proxy block in the CAS response. Turns out that there is a bug in the way chained authentications are handled and passed down to the view in that the index from which the chain starts is incorrectly calculated. This pull fixes that. 

In the course of applying the fix, I discovered and made the following fixes:

1. Made sure PGTIOUs are correctly formatted in logs.
2. Updated clearpass sample configuration to denote use of proxy lists and acceptance. 

This issue only affects master as far as I can tell. 
