### PR TITLE
CAS-957 Switch the build to use Java 8 by default

### DIFF
--- a/cas-management-webapp/src/main/java/org/jasig/cas/services/web/RegisteredServiceSimpleFormController.java
+++ b/cas-management-webapp/src/main/java/org/jasig/cas/services/web/RegisteredServiceSimpleFormController.java
@@ -165,8 +165,8 @@ public final class RegisteredServiceSimpleFormController {
     }
 
     /**
-     * Render the page noted by {@link #VIEW_NAME}.
-     * The view is first updated by {@link #updateModelMap(ModelMap, HttpServletRequest)}.
+     * Handles displaying the add and edit view by first updating the view by calling
+     * {@link #updateModelMap(ModelMap, HttpServletRequest)}.
      * @param request the request
      * @param model the model
      * @return the model and view

--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -82,7 +82,7 @@ import java.util.Set;
  * central, organizing component of CAS's internal implementation.
  * <p>
  * This class is threadsafe.
- * <p>
+ * </p>
  * This class has the following properties that must be set:
  * <ul>
  * <li> <code>ticketRegistry</code> - The Ticket Registry to maintain the list

--- a/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
+++ b/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
@@ -53,12 +53,12 @@ import javax.servlet.http.HttpSession;
 import javax.validation.constraints.NotNull;
 
 /**
- * This class represents an action to put at the beginning of the webflow.<br>
+ * This class represents an action to put at the beginning of the webflow.
+ * <p>
  * Before any authentication, redirection urls are computed for the different clients defined as well as the theme,
- * locale, method and service are saved into the web session.<br>
+ * locale, method and service are saved into the web session.</p>
  * After authentication, appropriate information are expected on this callback url to finish the authentication
  * process with the provider.
- *
  * @author Jerome Leleu
  * @since 3.5.0
  */

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/SpnegoCredentialsAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/SpnegoCredentialsAction.java
@@ -33,10 +33,11 @@ import java.nio.charset.Charset;
 
 /**
  * Second action of a SPNEGO flow : decode the gssapi-data and build a new
- * {@link org.jasig.cas.support.spnego.authentication.principal.SpnegoCredential}.<br>
+ * {@link org.jasig.cas.support.spnego.authentication.principal.SpnegoCredential}.
+ * <p>
  * Once AbstractNonInteractiveCredentialsAction has executed the authentication
  * procedure, this action check whether a principal is present in Credential and
- * add corresponding response headers.
+ * add corresponding response headers.</p>
  *
  * @author Arnaud Lesueur
  * @author Marc-Antoine Garrigue
@@ -51,7 +52,7 @@ public final class SpnegoCredentialsAction extends AbstractNonInteractiveCredent
     private String messageBeginPrefix = constructMessagePrefix();
 
     /**
-     * Behavior in case of SPNEGO authentication failure :<br>
+     * Behavior in case of SPNEGO authentication failure :
      * <ul><li>True : if SPNEGO is the last authentication method with no fallback.</li>
      * <li>False : if an interactive view (eg: login page) should be send to user as SPNEGO failure fallback</li>
      * </ul>

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/SpnegoNegociateCredentialsAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/SpnegoNegociateCredentialsAction.java
@@ -35,7 +35,8 @@ import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
 /**
- * First action of a SPNEGO flow : negotiation.<br> The server checks if the
+ * First action of a SPNEGO flow : negotiation.
+ * <p>The server checks if the
  * negotiation string is in the request header and this is a supported browser:
  * <ul>
  * <li>If found do nothing and return <code>success()</code></li>

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
@@ -46,10 +46,13 @@ public class HostNameSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnow
     }
 
     /**
-     * {@inheritDoc}. <p/>
+     * {@inheritDoc}.
+     * <p>
      * Checks whether the IP should even be paid attention to,
      * then does a reverse DNS lookup, and if it matches the supplied pattern, performs SPNEGO
      * else skips the process.
+     *
+     * @param remoteIp The remote ip address to validate
      */
     @Override
     protected boolean shouldDoSpnego(final String remoteIp) {

--- a/cas-server-support-x509/src/main/java/org/jasig/cas/adaptors/x509/authentication/principal/X509SubjectPrincipalResolver.java
+++ b/cas-server-support-x509/src/main/java/org/jasig/cas/adaptors/x509/authentication/principal/X509SubjectPrincipalResolver.java
@@ -54,16 +54,19 @@ public class X509SubjectPrincipalResolver extends AbstractX509PrincipalResolver 
      * attribute values extracted from DN attribute values.
      * <p>
      * EXAMPLE:
-     * <p>
+     * </p>
+     * {@code
      * <code>
      * &lt;bean class="org.jasig.cas.adaptors.x509.authentication.principal.X509SubjectPrincipalResolver"
      *   p:descriptor="$UID@$DC.$DC" /&gt;
      * </code>
+     * }
+     *
+     * The above bean when applied to a certificate with the DN
      * <p>
-     * The above bean when applied to a certificate with the DN<br>
-     * <strong>DC=edu, DC=vt/UID=jacky, CN=Jascarnella Ellagwonto</strong><br>
-     * produces the principal <strong>jacky@vt.edu</strong>.
-     * </p>
+     * <b>DC=edu, DC=vt/UID=jacky, CN=Jascarnella Ellagwonto</b></p>
+     * <p>
+     * produces the principal <strong>jacky@vt.edu</strong>.</p>
      *
      * @param s Descriptor string where attribute names are prefixed with "$"
      * to identify replacement by real attribute values from the subject DN.


### PR DESCRIPTION
Regarding #957, I updated HTML tags in javadocs to make them compatible with JDK 8 javadoc doclient standards. Changes include:

- Removing self-close tags (like `<br/>`)
- Pairing each single `<p>` tag with corresponding closing tag (`</p>`)
- Removing or fixing any invalid references in `{@link}` doclets
- Adding missed `@params` doclets

It worth reading [Javadoc doclint](http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html) by Stephen Colebourne to have better understanding of Java 8 doclint