### PR TITLE
Check for gateway mode on invalid TGT

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -38,7 +38,7 @@
 
     <action-state id="terminateSession">
         <evaluate expression="terminateSessionAction.terminate(flowRequestContext)"/>
-        <transition to="generateLoginTicket"/>
+        <transition to="gatewayRequestCheck"/>
     </action-state>
 
     <decision-state id="gatewayRequestCheck">


### PR DESCRIPTION
When an invalid TGT is present on the client, gateway=true was being ignored.