### PR TITLE
Login flow Transcoding config

### DIFF
--- a/cas-server-documentation/installation/Webflow-Customization.md
+++ b/cas-server-documentation/installation/Webflow-Customization.md
@@ -154,16 +154,28 @@ By default, the conversational state of Spring Webflow is managed inside the app
 
 {% highlight xml %}
 <bean id="loginFlowExecutionRepository" 
-    class=" org.jasig.spring.webflow.plugin.ClientFlowExecutionRepository"
+    class="org.jasig.spring.webflow.plugin.ClientFlowExecutionRepository"
     c:flowExecutionFactory-ref="loginFlowExecutionFactory"
     c:flowDefinitionLocator-ref="loginFlowRegistry"
     c:transcoder-ref="loginFlowStateTranscoder" />
 
-<bean id="loginFlowStateTranscoder" class="org.jasig.spring.webflow.plugin.EncryptedTranscoder"/>
-
 {% endhighlight %}
 
-Default encryption strategy is using the 128-bit AES in CBC ciphering mode with compression turned on.
+Default encryption strategy controlled via the `loginFlowStateTranscoder` component is using the 128-bit AES in CBC ciphering mode with compression turned on. These settings can be controlled via the following settings defined in the `cas.properties` file:
+
+{% highlight properties %}
+# cas.webflow.cipher.alg=AES
+# cas.webflow.cipher.mode=CBC
+# cas.webflow.cipher.padding=PKCS7
+# cas.webflow.keystore=classpath:/etc/keystore.jceks
+# cas.webflow.keystore.type=JCEKS
+# cas.webflow.keystore.password=changeit
+# cas.webflow.keyalias=aes128
+# cas.webflow.keypassword=changeit
+{% endhighlight %
+
+<div class="alert alert-warning"><strong>Usage Warning!</strong><p>
+While the above settings are all optional, it is recommended that you provide your own configuration and settings for encrypting and transcoding of the web session state.</p></div>
 
 ##Required Service for Authentication Flow
 By default, CAS will present a generic success page if the initial authentication request does not identify

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -171,7 +171,35 @@
 
   This behaviour can be altered by defining an explicit CipherBean.
   -->
-  <bean id="loginFlowStateTranscoder" class="org.jasig.spring.webflow.plugin.EncryptedTranscoder"/>
+    <bean id="loginFlowStateTranscoder" class="org.jasig.spring.webflow.plugin.EncryptedTranscoder"
+          c:cipherBean-ref="loginFlowCipherBean" />
+
+    <bean id="loginFlowCipherBean" class="org.cryptacular.bean.BufferedBlockCipherBean"
+          p:keyAlias="${cas.webflow.keyalias:aes128}"
+          p:keyStore-ref="loginFlowCipherKeystore"
+          p:keyPassword="${cas.webflow.keypassword:changeit}">
+        <property name="nonce">
+            <bean class="org.cryptacular.generator.sp80038a.RBGNonce" />
+        </property>
+        <property name="blockCipherSpec">
+            <bean class="org.cryptacular.spec.BufferedBlockCipherSpec"
+                  c:algName="${cas.webflow.cipher.alg:AES}"
+                  c:cipherMode="${cas.webflow.cipher.mode:CBC}"
+                  c:cipherPadding="${cas.webflow.cipher.padding:PKCS7}" />
+        </property>
+    </bean>
+
+    <bean id="loginFlowCipherKeystore" class="java.security.KeyStore"
+          factory-bean="loginFlowCipherKeystoreFactory" factory-method="newInstance" />
+
+    <bean id="loginFlowCipherKeystoreFactory" class="org.cryptacular.bean.KeyStoreFactoryBean"
+          c:type="${cas.webflow.keystore.type:JCEKS}"
+          c:password="${cas.webflow.keystore.password:changeit}">
+        <constructor-arg name="resource">
+            <bean class="org.cryptacular.io.URLResource"
+                  c:url="${cas.webflow.keystore:classpath:/etc/keystore.jceks}" />
+        </constructor-arg>
+    </bean>
 
   <webflow:flow-registry id="loginFlowRegistry" flow-builder-services="builder" base-path="/WEB-INF/webflow">
     <webflow:flow-location-pattern value="/login/*-webflow.xml"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -86,6 +86,19 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 # create.sso.missing.service=true
 
 ##
+# Spring Webflow Web Application Session
+# Define the settings that are required to encrypt and persist the CAS web application session.
+# See the cas-servlet.xml file to understand how these properties are used.
+#
+# cas.webflow.cipher.alg=AES
+# cas.webflow.cipher.mode=CBC
+# cas.webflow.cipher.padding=PKCS7
+# cas.webflow.keystore=classpath:/etc/keystore.jceks
+# cas.webflow.keystore.type=JCEKS
+# cas.webflow.keystore.password=changeit
+# cas.webflow.keyalias=aes128
+# cas.webflow.keypassword=changeit
+##
 # Single Sign-On Session Timeouts
 # Defaults sourced from WEB-INF/spring-configuration/ticketExpirationPolices.xml
 #


### PR DESCRIPTION
Updates documentation and config to note the settings used to transcode the login flow state. This allows adopters to easily change them via properties if need be. Defaults are still in place for all. 