### PR TITLE
Update pac4j to version 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1571,7 +1571,7 @@
         <jersey.version>1.19</jersey.version>
         <jose.version>0.4.1</jose.version>
         <woodstox.version>4.4.1</woodstox.version>
-        <pac4j.version>1.7.0</pac4j.version>
+        <pac4j.version>1.7.1</pac4j.version>
 
         <!-- Plugin Versions -->
         <coveralls-maven-plugin.version>3.1.0</coveralls-maven-plugin.version>


### PR DESCRIPTION
To avoid incompatibility issues between SAML supports (available via the `cas-server-support-saml` module and the `cas-server-support-pac4j` + `pac4j-saml` libraries)
