### PR TITLE
Fix OpenSAML initialization error

### DIFF
--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/AbstractSamlObjectBuilder.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/AbstractSamlObjectBuilder.java
@@ -100,22 +100,6 @@ public abstract class AbstractSamlObjectBuilder {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
-     * Initialize and bootstrap opensaml.
-     * Check for prior OpenSAML initialization to prevent double init
-     * that would overwrite existing OpenSAML configuration.
-     */
-    static {
-        try {
-
-            if (XMLObjectProviderRegistrySupport.getParserPool() == null) {
-                InitializationService.initialize();
-            }
-        } catch (final InitializationException e) {
-            throw new IllegalStateException("Error initializing OpenSAML library.", e);
-        }
-    }
-
-    /**
      * Create a new SAML object.
      *
      * @param <T> the generic type
@@ -212,6 +196,9 @@ public abstract class AbstractSamlObjectBuilder {
         try {
             final MarshallerFactory marshallerFactory = XMLObjectProviderRegistrySupport.getMarshallerFactory();
             final Marshaller marshaller = marshallerFactory.getMarshaller(object);
+            if (marshaller == null) {
+                throw new IllegalArgumentException("Could not obtain marshaller for object " + object);
+            }
             final Element element = marshaller.marshall(object);
             element.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns", SAMLConstants.SAML20_NS);
             element.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xenc", "http://www.w3.org/2001/04/xmlenc#");

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -24,9 +24,6 @@ import org.jasig.cas.support.saml.web.support.SamlArgumentExtractor;
 import org.jasig.cas.web.view.AbstractCasView;
 import org.joda.time.DateTime;
 
-import org.opensaml.core.config.InitializationException;
-import org.opensaml.core.config.InitializationService;
-import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.saml.saml1.core.Response;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,17 +52,6 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
 
     /** Defaults to 0. */
     private int skewAllowance;
-
-    static {
-        try {
-
-            if (XMLObjectProviderRegistrySupport.getParserPool() == null) {
-                InitializationService.initialize();
-            }
-        } catch (final InitializationException e) {
-            throw new IllegalStateException("Error initializing OpenSAML library.", e);
-        }
-    }
 
     /**
      * Sets the character encoding in the HTTP response.


### PR DESCRIPTION
A number of classes attempt to manually init opensaml.
All init functionality is handled via the opensaml config bean.