### PR TITLE
Explicit rest-context file param value

### DIFF
--- a/cas-server-documentation/protocol/REST-Protocol.md
+++ b/cas-server-documentation/protocol/REST-Protocol.md
@@ -41,7 +41,8 @@ To turn on the protocol, add the following to the `web.xml`:
 
 ...or delete the `web.xml` in the overlay altogether if there are no other customizations there as this mapping is provided by CAS' webapp module's `web.xml` out of the box.
 
-Please note that if there are local customizations in overlay's `web.xml`, the following `contextConfigLocation` `<context-param>` must also be added in order to enable the new REST module: `classpath*:/META-INF/spring/*.xml`. So the entire context-param block would look like this:
+Please note that if there are local customizations in overlay's `web.xml`, the following `contextConfigLocation` `<context-param>` must also be 
+added in order to enable the new REST module: `classpath*:/META-INF/spring/rest-context.xml`. So the entire context-param block would look like this:
 
 {% highlight xml %}
 <context-param>
@@ -49,7 +50,7 @@ Please note that if there are local customizations in overlay's `web.xml`, the f
     <param-value>
       /WEB-INF/spring-configuration/*.xml
       /WEB-INF/deployerConfigContext.xml
-      classpath*:/META-INF/spring/*.xml
+      classpath*:/META-INF/spring/rest-context.xml
     </param-value>
 </context-param>
 {% endhighlight %}

--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -35,9 +35,9 @@
         <param-value>
             /WEB-INF/spring-configuration/*.xml
             /WEB-INF/deployerConfigContext.xml
-            <!-- this enables extensions and addons to contribute to overall CAS' application context
-                 by loading spring context files from classpath i.e. found in classpath jars, etc. -->
-            classpath*:/META-INF/spring/*.xml
+            <!-- this enables REST module extension to contribute to overall CAS' application context
+                 by loading its spring context file from classpath i.e. found in classpath jar if that module is included -->
+            classpath*:/META-INF/spring/rest-context.xml
         </param-value>
     </context-param>
 


### PR DESCRIPTION
This allows a more fine-grained control of turning on/off classpath-based extension contexts and avoids potential conflicts with other contributed extensions via the same classpath mechanism. For example it will allow one to list explicitly (or turn off on demand) others like:

```...
classpath*:/META-INF/spring/rest-context.xml
classpath*:/META-INF/spring/hazelcast-ticket-registry-context.xml
...
```
