### PR TITLE
Move creation of HandlerResult up the chain

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractPreAndPostProcessingAuthenticationHandler.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractPreAndPostProcessingAuthenticationHandler.java
@@ -18,15 +18,20 @@
  */
 package org.jasig.cas.authentication.handler.support;
 
+import org.jasig.cas.MessageDescriptor;
 import org.jasig.cas.authentication.AbstractAuthenticationHandler;
+import org.jasig.cas.authentication.BasicCredentialMetaData;
 import org.jasig.cas.authentication.Credential;
+import org.jasig.cas.authentication.DefaultHandlerResult;
 import org.jasig.cas.authentication.HandlerResult;
 import org.jasig.cas.authentication.PreventedException;
+import org.jasig.cas.authentication.principal.Principal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.security.auth.login.FailedLoginException;
 import java.security.GeneralSecurityException;
+import java.util.List;
 
 /**
  * Abstract authentication handler that allows deployers to utilize the bundled
@@ -93,4 +98,20 @@ public abstract class AbstractPreAndPostProcessingAuthenticationHandler extends 
      */
     protected abstract HandlerResult doAuthentication(final Credential credential)
             throws GeneralSecurityException, PreventedException;
+
+    /**
+     * Helper method to construct a handler result
+     * on successful authentication events.
+     *
+     * @param credential the credential on which the authentication was successfully performed.
+     * Note that this credential instance may be different from what was originally provided
+     * as transformation of the username may have occurred, if one is in fact defined.
+     * @param principal the resolved principal
+     * @param warnings the warnings
+     * @return the constructed handler result
+     */
+    protected final HandlerResult createHandlerResult(final Credential credential, final Principal principal,
+                                                      final List<MessageDescriptor> warnings) {
+        return new DefaultHandlerResult(this, new BasicCredentialMetaData(credential), principal, warnings);
+    }
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
@@ -114,21 +114,6 @@ public abstract class AbstractUsernamePasswordAuthenticationHandler extends
     }
 
     /**
-     * Helper method to construct a handler result
-     * on successful authentication events.
-     *
-     * @param credential the credential on which the authentication was successfully performed.
-     * Note that this credential instance may be different from what was originally provided
-     * as transformation of the username may have occurred, if one is in fact defined.
-     * @param principal the resolved principal
-     * @param warnings the warnings
-     * @return the constructed handler result
-     */
-    protected final HandlerResult createHandlerResult(final Credential credential, final Principal principal,
-            final List<MessageDescriptor> warnings) {
-        return new DefaultHandlerResult(this, new BasicCredentialMetaData(credential), principal, warnings);
-    }
-    /**
      * Sets the PasswordEncoder to be used with this class.
      *
      * @param passwordEncoder the PasswordEncoder to use when encoding

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
@@ -18,12 +18,7 @@
  */
 package org.jasig.cas.authentication.handler.support;
 
-import java.security.GeneralSecurityException;
-import java.util.List;
-
-import org.jasig.cas.MessageDescriptor;
-import org.jasig.cas.authentication.BasicCredentialMetaData;
-import org.jasig.cas.authentication.DefaultHandlerResult;
+import org.jasig.cas.authentication.Credential;
 import org.jasig.cas.authentication.HandlerResult;
 import org.jasig.cas.authentication.PreventedException;
 import org.jasig.cas.authentication.UsernamePasswordCredential;
@@ -31,12 +26,11 @@ import org.jasig.cas.authentication.handler.NoOpPrincipalNameTransformer;
 import org.jasig.cas.authentication.handler.PasswordEncoder;
 import org.jasig.cas.authentication.handler.PlainTextPasswordEncoder;
 import org.jasig.cas.authentication.handler.PrincipalNameTransformer;
-import org.jasig.cas.authentication.principal.Principal;
 import org.jasig.cas.authentication.support.PasswordPolicyConfiguration;
-import org.jasig.cas.authentication.Credential;
 
 import javax.security.auth.login.AccountNotFoundException;
 import javax.validation.constraints.NotNull;
+import java.security.GeneralSecurityException;
 
 /**
  * Abstract class to override supports so that we don't need to duplicate the


### PR DESCRIPTION
The method that allows a given handler to create a HandlerResult object is presently placed in the wrong spot. Its placement is incorrect because the method has nothing to do with username/password authentication. In this PR, it is moved up the chain so it's available in a more generic place applicable to all credential. 