### PR TITLE
BugFix: registered services equality mismatch

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/CachingPrincipalAttributesRepository.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/CachingPrincipalAttributesRepository.java
@@ -64,7 +64,7 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
 
     private final String cacheName = this.getClass().getSimpleName().concat(UUID.randomUUID().toString());
 
-    private transient Duration duration;
+    private Duration duration;
 
     /**
      * The merging strategy that deals with existing principal attributes

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/CachingPrincipalAttributesRepository.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/CachingPrincipalAttributesRepository.java
@@ -19,12 +19,16 @@
 package org.jasig.cas.authentication.principal;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jasig.services.persondir.IPersonAttributeDao;
 import org.jasig.services.persondir.IPersonAttributes;
 import org.jasig.services.persondir.support.merger.IAttributeMerger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PreDestroy;
 import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
@@ -60,6 +64,8 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
 
     private final String cacheName = this.getClass().getSimpleName().concat(UUID.randomUUID().toString());
 
+    private transient Duration duration;
+
     /**
      * The merging strategy that deals with existing principal attributes
      * and those that are retrieved from the source. By default, existing attributes
@@ -74,6 +80,7 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
     private CachingPrincipalAttributesRepository() {
         this.attributeRepository = null;
         this.cache = null;
+        this.duration = null;
     }
 
     /**
@@ -83,9 +90,7 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      * @param attributeRepository the attribute repository
      */
     public CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository) {
-        this(attributeRepository, createCacheConfiguration(
-                new Duration(DEFAULT_CACHE_EXPIRATION_UNIT, DEFAULT_CACHE_EXPIRATION_DURATION)));
-
+        this(attributeRepository, DEFAULT_CACHE_EXPIRATION_DURATION);
     }
 
     /**
@@ -96,9 +101,7 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      * @param expiryDuration the expiry duration based on the unit of {@link #DEFAULT_CACHE_EXPIRATION_DURATION}
      */
     public CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository, final long expiryDuration) {
-        this(attributeRepository, createCacheConfiguration(
-                new Duration(DEFAULT_CACHE_EXPIRATION_UNIT, expiryDuration)));
-
+        this(attributeRepository, DEFAULT_CACHE_EXPIRATION_UNIT, expiryDuration);
     }
 
     /**
@@ -111,7 +114,19 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
     public CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
                                                 final TimeUnit timeUnit,
                                                 final long expiryDuration) {
-        this(attributeRepository, createCacheConfiguration(new Duration(timeUnit, expiryDuration)));
+        this(attributeRepository, new Duration(timeUnit, expiryDuration));
+    }
+
+    /**
+     * Instantiates a new caching attributes principal factory.
+     *
+     * @param attributeRepository the attribute repository
+     * @param duration the duration
+     */
+    private CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
+                                                 final Duration duration) {
+        this(attributeRepository, createCacheConfiguration(duration));
+        this.duration = duration;
     }
 
     /**
@@ -120,8 +135,8 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      * @param attributeRepository the attribute repository
      * @param config the config
      */
-    public CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
-                                                final MutableConfiguration<String, Map<String, Object>> config) {
+    private CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
+                                                 final MutableConfiguration<String, Map<String, Object>> config) {
         this(attributeRepository, config, Caching.getCachingProvider().getCacheManager());
     }
 
@@ -132,9 +147,9 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      * @param config the config
      * @param cacheProviderFullClassName the cache provider full class name
      */
-    public CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
-                                                final MutableConfiguration<String, Map<String, Object>> config,
-                                                final String cacheProviderFullClassName) {
+    private CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
+                                                 final MutableConfiguration<String, Map<String, Object>> config,
+                                                 final String cacheProviderFullClassName) {
         this(attributeRepository, config,
                 Caching.getCachingProvider(cacheProviderFullClassName).getCacheManager());
     }
@@ -146,9 +161,9 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      * @param config the config
      * @param manager the manager
      */
-    public CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
-                                                final MutableConfiguration<String, Map<String, Object>> config,
-                                                final CacheManager manager) {
+    private CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
+                                                 final MutableConfiguration<String, Map<String, Object>> config,
+                                                 final CacheManager manager) {
         this.attributeRepository = attributeRepository;
         this.cache = manager.createCache(this.cacheName, config);
     }
@@ -159,8 +174,8 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      * @param attributeRepository the attribute repository
      * @param cache the cache
      */
-    public CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
-                                                final Cache<String, Map<String, Object>> cache) {
+    private CachingPrincipalAttributesRepository(final IPersonAttributeDao attributeRepository,
+                                                 final Cache<String, Map<String, Object>> cache) {
         this.attributeRepository = attributeRepository;
         this.cache = cache;
     }
@@ -172,6 +187,10 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      */
     public IPersonAttributeDao getAttributeRepository() {
         return this.attributeRepository;
+    }
+
+    public Duration getDuration() {
+        return this.duration;
     }
 
     /**
@@ -218,7 +237,7 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
      * @param id the principal id that controls the grouping of the attributes in the cache.
      * @param attributes principal attributes to add to the cache
      */
-   private void addPrincipalAttributesIntoCache(final String id, final Map<String, Object> attributes) {
+    private void addPrincipalAttributesIntoCache(final String id, final Map<String, Object> attributes) {
         synchronized (this.cache) {
             if (attributes.isEmpty()) {
 
@@ -322,6 +341,7 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
     }
 
     @Override
+    @PreDestroy
     public void close() throws IOException {
         this.cache.close();
         this.cache.getCacheManager().close();
@@ -332,4 +352,44 @@ public final class CachingPrincipalAttributesRepository implements PrincipalAttr
         close();
         super.finalize();
     }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("attributeRepository", attributeRepository)
+                .append("cache", cache)
+                .append("cacheName", cacheName)
+                .append("durationTimeUnit", duration.getTimeUnit())
+                .append("durationAmount", duration.getDurationAmount())
+                .append("mergingStrategy", mergingStrategy)
+                .toString();
+    }
+
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        final CachingPrincipalAttributesRepository rhs = (CachingPrincipalAttributesRepository) obj;
+        final EqualsBuilder builder = new EqualsBuilder();
+        return builder
+                .append(this.duration, rhs.duration)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 133)
+                .append(duration)
+                .toHashCode();
+    }
+
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/DefaultPrincipalAttributesRepository.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/DefaultPrincipalAttributesRepository.java
@@ -18,6 +18,10 @@
  */
 package org.jasig.cas.authentication.principal;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.Map;
 
 /**
@@ -32,5 +36,33 @@ public final class DefaultPrincipalAttributesRepository implements PrincipalAttr
     @Override
     public Map<String, Object> getAttributes(final Principal p) {
         return p.getAttributes();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        final DefaultPrincipalAttributesRepository rhs = (DefaultPrincipalAttributesRepository) obj;
+        return new EqualsBuilder()
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 133)
+                .toHashCode();
     }
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/services/AbstractAttributeReleasePolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/AbstractAttributeReleasePolicy.java
@@ -20,6 +20,7 @@ package org.jasig.cas.services;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jasig.cas.authentication.principal.DefaultPrincipalAttributesRepository;
 import org.jasig.cas.authentication.principal.Principal;
 import org.jasig.cas.authentication.principal.PrincipalAttributesRepository;
@@ -114,7 +115,12 @@ public abstract class AbstractAttributeReleasePolicy implements AttributeRelease
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(13, 133).append(this.attributeFilter).toHashCode();
+        return new HashCodeBuilder(13, 133)
+                .append(this.attributeFilter)
+                .append(this.authorizedToReleaseCredentialPassword)
+                .append(this.authorizedToReleaseProxyGrantingTicket)
+                .append(this.principalAttributesRepository)
+                .toHashCode();
     }
 
     @Override
@@ -132,6 +138,25 @@ public abstract class AbstractAttributeReleasePolicy implements AttributeRelease
         }
 
         final AbstractAttributeReleasePolicy that = (AbstractAttributeReleasePolicy) o;
-        return new EqualsBuilder().append(this.attributeFilter, that.attributeFilter).isEquals();
+        final EqualsBuilder builder = new EqualsBuilder();
+        return builder
+                .append(this.attributeFilter, that.attributeFilter)
+                .append(this.authorizedToReleaseCredentialPassword, that.authorizedToReleaseCredentialPassword)
+                .append(this.authorizedToReleaseProxyGrantingTicket, that.authorizedToReleaseProxyGrantingTicket)
+                .append(this.principalAttributesRepository, that.principalAttributesRepository)
+                .isEquals();
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("attributeFilter", attributeFilter)
+                .append("principalAttributesRepository", principalAttributesRepository)
+                .append("authorizedToReleaseCredentialPassword", authorizedToReleaseCredentialPassword)
+                .append("authorizedToReleaseProxyGrantingTicket", authorizedToReleaseProxyGrantingTicket)
+                .toString();
     }
 }
+
+

--- a/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
@@ -215,7 +215,8 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
 
         final AbstractRegisteredService that = (AbstractRegisteredService) o;
 
-        return new EqualsBuilder()
+        final EqualsBuilder builder = new EqualsBuilder();
+        return builder
                 .append(this.proxyPolicy, that.proxyPolicy)
                 .append(this.evaluationOrder, that.evaluationOrder)
                 .append(this.description, that.description)
@@ -228,6 +229,8 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
                 .append(this.accessStrategy, that.accessStrategy)
                 .append(this.logo, that.logo)
                 .append(this.publicKey, that.publicKey)
+                .append(this.logoutUrl, that.logoutUrl)
+                .append(this.requiredHandlers, that.requiredHandlers)
                 .isEquals();
     }
 
@@ -246,6 +249,8 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
                 .append(this.accessStrategy)
                 .append(this.logo)
                 .append(this.publicKey)
+                .append(this.logoutUrl)
+                .append(this.requiredHandlers)
                 .toHashCode();
     }
 
@@ -349,6 +354,10 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
         this.setAccessStrategy(source.getAccessStrategy());
         this.setLogo(source.getLogo());
         this.setPublicKey(source.getPublicKey());
+        this.setLogoutUrl(source.getLogoutUrl());
+        this.setPublicKey(source.getPublicKey());
+        this.setRequiredHandlers(source.getRequiredHandlers());
+
     }
 
     /**
@@ -383,6 +392,8 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
         toStringBuilder.append("publicKey", this.publicKey);
         toStringBuilder.append("proxyPolicy", this.proxyPolicy);
         toStringBuilder.append("logo", this.logo);
+        toStringBuilder.append("logoutUrl", this.logoutUrl);
+        toStringBuilder.append("requiredHandlers", this.requiredHandlers);
 
         return toStringBuilder.toString();
     }

--- a/cas-server-core/src/main/java/org/jasig/cas/services/DefaultRegisteredServiceAccessStrategy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/DefaultRegisteredServiceAccessStrategy.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -253,5 +254,16 @@ public class DefaultRegisteredServiceAccessStrategy implements RegisteredService
                 .append(this.requireAllAttributes)
                 .append(this.requiredAttributes)
                 .toHashCode();
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("enabled", enabled)
+                .append("ssoEnabled", ssoEnabled)
+                .append("requireAllAttributes", requireAllAttributes)
+                .append("requiredAttributes", requiredAttributes)
+                .toString();
     }
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/services/RefuseRegisteredServiceProxyPolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/RefuseRegisteredServiceProxyPolicy.java
@@ -51,10 +51,6 @@ public final class RefuseRegisteredServiceProxyPolicy implements RegisteredServi
             return true;
         }
 
-        if (!(o instanceof RegisteredServiceProxyPolicy)) {
-            return false;
-        }
-
         return o instanceof RefuseRegisteredServiceProxyPolicy;
     }
 

--- a/cas-server-core/src/main/java/org/jasig/cas/services/RefuseRegisteredServiceProxyPolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/RefuseRegisteredServiceProxyPolicy.java
@@ -55,7 +55,7 @@ public final class RefuseRegisteredServiceProxyPolicy implements RegisteredServi
             return false;
         }
 
-        return true;
+        return o instanceof RefuseRegisteredServiceProxyPolicy;
     }
 
     @Override

--- a/cas-server-core/src/main/java/org/jasig/cas/services/ReturnAllAttributeReleasePolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/ReturnAllAttributeReleasePolicy.java
@@ -18,6 +18,10 @@
  */
 package org.jasig.cas.services;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.Map;
 
 /**
@@ -32,5 +36,38 @@ public final class ReturnAllAttributeReleasePolicy extends AbstractAttributeRele
     @Override
     protected Map<String, Object> getAttributesInternal(final Map<String, Object> resolvedAttributes) {
         return resolvedAttributes;
+    }
+
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+
+        return new EqualsBuilder()
+                .appendSuper(super.equals(obj))
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 133)
+                .appendSuper(super.hashCode())
+                .toHashCode();
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .appendSuper(super.toString())
+                .toString();
     }
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/services/ReturnAllowedAttributeReleasePolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/ReturnAllowedAttributeReleasePolicy.java
@@ -18,6 +18,10 @@
  */
 package org.jasig.cas.services;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,5 +70,41 @@ public final class ReturnAllowedAttributeReleasePolicy extends AbstractAttribute
             }
         }
         return attributesToRelease;
+    }
+
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        final ReturnAllowedAttributeReleasePolicy rhs = (ReturnAllowedAttributeReleasePolicy) obj;
+        return new EqualsBuilder()
+                .appendSuper(super.equals(obj))
+                .append(this.allowedAttributes, rhs.allowedAttributes)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 133)
+                .appendSuper(super.hashCode())
+                .append(allowedAttributes)
+                .toHashCode();
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .appendSuper(super.toString())
+                .append("allowedAttributes", allowedAttributes)
+                .toString();
     }
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/services/ReturnMappedAttributeReleasePolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/ReturnMappedAttributeReleasePolicy.java
@@ -18,6 +18,10 @@
  */
 package org.jasig.cas.services;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -68,5 +72,40 @@ public class ReturnMappedAttributeReleasePolicy extends AbstractAttributeRelease
             }
         }
         return attributesToRelease;
+    }
+
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        final ReturnMappedAttributeReleasePolicy rhs = (ReturnMappedAttributeReleasePolicy) obj;
+        return new EqualsBuilder()
+                .appendSuper(super.equals(obj))
+                .append(this.allowedAttributes, rhs.allowedAttributes)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(allowedAttributes)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .appendSuper(super.toString())
+                .append("allowedAttributes", allowedAttributes)
+                .toString();
     }
 }

--- a/cas-server-core/src/test/java/org/jasig/cas/TestUtils.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/TestUtils.java
@@ -37,7 +37,6 @@ import org.jasig.cas.services.AbstractRegisteredService;
 import org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy;
 import org.jasig.cas.services.LogoutType;
 import org.jasig.cas.services.PrincipalAttributeRegisteredServiceUsernameProvider;
-import org.jasig.cas.services.RefuseRegisteredServiceProxyPolicy;
 import org.jasig.cas.services.RegexMatchingRegisteredServiceProxyPolicy;
 import org.jasig.cas.services.RegexRegisteredService;
 import org.jasig.cas.services.RegisteredServicePublicKeyImpl;

--- a/cas-server-core/src/test/java/org/jasig/cas/TestUtils.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/TestUtils.java
@@ -162,7 +162,7 @@ public final class TestUtils {
             s.setLogo(new URL("https://logo.example.org/logo.png"));
             s.setLogoutType(LogoutType.BACK_CHANNEL);
             s.setLogoutUrl(new URL("https://sys.example.org/logout.png"));
-            s.setProxyPolicy(new RefuseRegisteredServiceProxyPolicy());
+            s.setProxyPolicy(new RegexMatchingRegisteredServiceProxyPolicy("^http.+"));
 
             s.setPublicKey(new RegisteredServicePublicKeyImpl("classpath:pub.key", "RSA"));
 

--- a/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
@@ -182,4 +182,11 @@ public class AbstractRegisteredServiceTests {
         final RegisteredService svc2 = TestUtils.getRegisteredService(SERVICEID);
         assertEquals(svc1, svc2);
     }
+
+    @Test
+    public void verifyServiceCopy() throws Exception {
+        final RegisteredService svc1 = TestUtils.getRegisteredService(SERVICEID);
+        final RegisteredService svc2 = svc1.clone();
+        assertEquals(svc1, svc2);
+    }
 }

--- a/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.cas.services;
 
+import org.jasig.cas.TestUtils;
 import org.jasig.cas.authentication.principal.Principal;
 import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.authentication.principal.ShibbolethCompatiblePersistentIdGenerator;
@@ -173,5 +174,12 @@ public class AbstractRegisteredServiceTests {
         final Map<String, Object> attr = this.r.getAttributeReleasePolicy().getAttributes(p);
         assertEquals(attr.size(), 1);
         assertTrue(attr.containsKey("newAttr1"));
+    }
+
+    @Test
+    public void verifyServiceEquality() {
+        final RegisteredService svc1 = TestUtils.getRegisteredService(SERVICEID);
+        final RegisteredService svc2 = TestUtils.getRegisteredService(SERVICEID);
+        assertEquals(svc1, svc2);
     }
 }


### PR DESCRIPTION
While working on a different issue, I realized that the equality/hashCode rules for two registered services do not fully take into account all correct fields. Fixed, and also added missing toString() methods.