### PR TITLE
Documentation: Update Package Name for SAML.

### DIFF
--- a/cas-server-documentation/integration/Google-Apps-Integration.md
+++ b/cas-server-documentation/integration/Google-Apps-Integration.md
@@ -56,7 +56,7 @@ As an optional step, you can configure an `alternateUsername` to be send to Goog
 
 {% highlight xml %}
 <bean name="googleAccountsArgumentExtractor"
-      class="org.jasig.cas.web.support.GoogleAccountsArgumentExtractor"
+      class="org.jasig.cas.support.saml.web.support.GoogleAccountsArgumentExtractor"
         p:privateKey-ref="privateKeyFactoryBean"
         p:publicKey-ref="publicKeyFactoryBean"
         p:alternateUsername="emailAddress" />


### PR DESCRIPTION
The package name for the GoogleAccountsArgumentExtractor changed at some point (probably when it was moved out of the primary repo) and the docs didn't follow the change.  Without this change, you get a class not found exception.