### PR TITLE
if NTLM is not allowed, refuse NTLM ASAP instead of going to JCIFS code

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JCIFSSpnegoAuthenticationHandler.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JCIFSSpnegoAuthenticationHandler.java
@@ -65,6 +65,9 @@ public final class JCIFSSpnegoAuthenticationHandler extends AbstractPreAndPostPr
         final SpnegoCredential spnegoCredential = (SpnegoCredential) credential;
         java.security.Principal principal;
         byte[] nextToken;
+        if (!this.isNTLMallowed && spnegoCredential.isNtlm()) {
+            throw new FailedLoginException("NTLM not allowed");
+        }
         try {
             // proceed authentication using jcifs
             synchronized (this) {
@@ -90,7 +93,7 @@ public final class JCIFSSpnegoAuthenticationHandler extends AbstractPreAndPostPr
             if (spnegoCredential.isNtlm()) {
                 logger.debug("NTLM Credential is valid for user [{}]", principal.getName());
                 spnegoCredential.setPrincipal(getPrincipal(principal.getName(), true));
-                success = this.isNTLMallowed;
+                success = true;
             }
             // else => kerberos
             logger.debug("Kerberos Credential is valid for user [{}]", principal.getName());


### PR DESCRIPTION
If your localhost is ipv6, with default configuration JCIFS NTLM process will try to connect to a pseudo-random server:
http://article.gmane.org/gmane.network.samba.java/9539