### PR TITLE
Incorrect class in code samples for throttling doc

### DIFF
--- a/4.0.x/installation/Configuring-Authentication-Components.html
+++ b/4.0.x/installation/Configuring-Authentication-Components.html
@@ -636,7 +636,7 @@ preventing more than 1 failed login every 3 seconds.</p>
 <p>Uses a memory map to prevent successive failed login attempts for a particular username from the same IP address.</p>
 
 <div class="highlight"><pre><code class="xml"><span class="nt">&lt;bean</span> <span class="na">id=</span><span class="s">&quot;loginThrottle&quot;</span>
-      <span class="na">class=</span><span class="s">&quot;org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapter&quot;</span>
+      <span class="na">class=</span><span class="s">&quot;org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter&quot;</span>
       <span class="na">p:failureRangeInSeconds=</span><span class="s">&quot;3&quot;</span>
       <span class="na">p:failureThreshold=</span><span class="s">&quot;1&quot;</span> <span class="nt">/&gt;</span>
 </code></pre></div>

--- a/4.1.x/installation/Configuring-Authentication-Throttling.md
+++ b/4.1.x/installation/Configuring-Authentication-Throttling.md
@@ -43,7 +43,7 @@ Uses a memory map to prevent successive failed login attempts from the same IP a
 Uses a memory map to prevent successive failed login attempts for a particular username from the same IP address.
 {% highlight xml %}
 <bean id="loginThrottle"
-      class="org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapter"
+      class="org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter"
       p:failureRangeInSeconds="3"
       p:failureThreshold="1"
       p:usernameParameter="username" />

--- a/development/installation/Configuring-Authentication-Throttling.md
+++ b/development/installation/Configuring-Authentication-Throttling.md
@@ -43,7 +43,7 @@ Uses a memory map to prevent successive failed login attempts from the same IP a
 Uses a memory map to prevent successive failed login attempts for a particular username from the same IP address.
 {% highlight xml %}
 <bean id="loginThrottle"
-      class="org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapter"
+      class="org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter"
       p:failureRangeInSeconds="3"
       p:failureThreshold="1"
       p:usernameParameter="username" />


### PR DESCRIPTION
The code samples given in documentation of the
InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter
class are invalid, featuring the similar
InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapter
class instead