### PR TITLE
fix regression introduced in commit "CAS-1238 ..."

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JCIFSSpnegoAuthenticationHandler.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JCIFSSpnegoAuthenticationHandler.java
@@ -94,11 +94,11 @@ public final class JCIFSSpnegoAuthenticationHandler extends AbstractPreAndPostPr
                 logger.debug("NTLM Credential is valid for user [{}]", principal.getName());
                 spnegoCredential.setPrincipal(getPrincipal(principal.getName(), true));
                 success = true;
+            } else {
+                logger.debug("Kerberos Credential is valid for user [{}]", principal.getName());
+                spnegoCredential.setPrincipal(getPrincipal(principal.getName(), false));
+                success = true;
             }
-            // else => kerberos
-            logger.debug("Kerberos Credential is valid for user [{}]", principal.getName());
-            spnegoCredential.setPrincipal(getPrincipal(principal.getName(), false));
-            success = true;
         }
 
         if (!success) {

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JCIFSSpnegoAuthenticationHandler.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JCIFSSpnegoAuthenticationHandler.java
@@ -92,13 +92,11 @@ public final class JCIFSSpnegoAuthenticationHandler extends AbstractPreAndPostPr
         if (principal != null) {
             if (spnegoCredential.isNtlm()) {
                 logger.debug("NTLM Credential is valid for user [{}]", principal.getName());
-                spnegoCredential.setPrincipal(getPrincipal(principal.getName(), true));
-                success = true;
             } else {
                 logger.debug("Kerberos Credential is valid for user [{}]", principal.getName());
-                spnegoCredential.setPrincipal(getPrincipal(principal.getName(), false));
-                success = true;
             }
+            spnegoCredential.setPrincipal(getPrincipal(principal.getName(), spnegoCredential.isNtlm()));
+            success = true;
         }
 
         if (!success) {


### PR DESCRIPTION
Commit "CAS-1238 Port handlers to new AuthenticationHandler interface" reworked the code, replacing "return" with "success" variable, but it surely broke NTLM (maybe the breakage is no real pb though)
