### PR TITLE
update SecurityManager reference for JDK8

### DIFF
--- a/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
@@ -49,7 +49,7 @@
             <map>
                 <!-- Sun/Oracle is the default, for Xerces, set property to org.apache.xerces.util.SecurityManager -->
                 <entry key="http://apache.org/xml/properties/security-manager">
-                    <bean class="com.sun.org.apache.xerces.internal.util.SecurityManager"/>
+                    <bean class="com.sun.org.apache.xerces.internal.util.XMLSecurityManager"/>
                 </entry>
             </map>
         </property>


### PR DESCRIPTION
com.sun.org.apache.xerces.internal.util.SecurityManager was changed to com.sun.org.apache.xerces.internal.util.XMLSecurityManager in jdk8.
This may be better as a configurable property.

http://mail.openjdk.java.net/pipermail/jdk8-dev/2013-October/003455.html