### PR TITLE
SAML: add securitymanager property

### DIFF
--- a/cas-server-documentation/protocol/SAML-Protocol.md
+++ b/cas-server-documentation/protocol/SAML-Protocol.md
@@ -190,6 +190,10 @@ In `cas-servlet.xml`, uncomment the following:
           p:location="${cas.viewResolver.xmlFile:classpath:/META-INF/spring/saml-protocol-views.xml}" />
 {% endhighlight %}
 
+
+###Xerces or JDK8
+The security manager for XML parsing defaults to Oracle's `cas.saml.securityManager=com.sun.org.apache.xerces.internal.util.SecurityManager`. If Xerces' security manager is preferred set `cas.saml.securityManager` to `org.apache.xerces.util.SecurityManager`. For JDK8 support, this value should instead be `com.sun.org.apache.xerces.internal.util.XMLSecurityManager` for Oracle's security manager.
+
 #SAML 2
 
 CAS support for SAML 2 at this point is mostly limited to [Google Apps Integration](../integration/Google-Apps-Integration.html). Full SAML 2 support can also be achieved via Shibboleth with CAS handling the authentication and SSO. [See this guide](../integration/Shibboleth.html) for more info.

--- a/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
@@ -47,9 +47,6 @@
           init-method="initialize">
         <property name="builderAttributes">
             <map>
-                <!-- Sun/Oracle is the default, for Xerces, set property to org.apache.xerces.util.SecurityManager
-                     For Java 1.8, set this property to com.sun.org.apache.xerces.internal.util.XMLSecurityManager-->
-                
                 <entry key="http://apache.org/xml/properties/security-manager">
                     <bean class="${cas.saml.securityManager:com.sun.org.apache.xerces.internal.util.SecurityManager}"/>
                 </entry>

--- a/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
@@ -47,9 +47,11 @@
           init-method="initialize">
         <property name="builderAttributes">
             <map>
-                <!-- Sun/Oracle is the default, for Xerces, set property to org.apache.xerces.util.SecurityManager -->
+                <!-- Sun/Oracle is the default, for Xerces, set property to org.apache.xerces.util.SecurityManager
+                     For Java 1.8, set this property to com.sun.org.apache.xerces.internal.util.XMLSecurityManager-->
+                
                 <entry key="http://apache.org/xml/properties/security-manager">
-                    <bean class="com.sun.org.apache.xerces.internal.util.SecurityManager"/>
+                    <bean class="${cas.saml.securityManager:com.sun.org.apache.xerces.internal.util.SecurityManager}"/>
                 </entry>
             </map>
         </property>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -213,3 +213,10 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 
 # URL to which the user will be redirected to change the password.
 # password.policy.url=https://password.example.edu/change
+
+##
+# Saml Support
+#
+# Sun/Oracle is the default, for Xerces, set property to org.apache.xerces.util.SecurityManager
+# For Java 1.8, set this property to com.sun.org.apache.xerces.internal.util.XMLSecurityManager
+# cas.saml.securityManager=com.sun.org.apache.xerces.internal.util.SecurityManager


### PR DESCRIPTION
Adds a property to control the security manager class for opensaml in the cas-server-support-saml package. This is used to support jdk8 by setting it to `com.sun.org.apache.xerces.internal.util.XMLSecurityManager` or to use Xerces with `org.apache.xerces.util.SecurityManager`
