### PR TITLE
Reduce SAML configuration noise

### DIFF
--- a/cas-server-documentation/protocol/SAML-Protocol.md
+++ b/cas-server-documentation/protocol/SAML-Protocol.md
@@ -116,13 +116,9 @@ Content-Type: text/xml
 ##Configuration
 SAML configuration in CAS is contained within the `cas.properties` file.
 
-
 {% highlight properties %}
 # Indicates the SAML response issuer
 # cas.saml.response.issuer=localhost
-
-### SAML IssueInstant Skew
-The SAML response can be allowed a skew value to control the issue instant. The behavior is controlled via:
 
 # Indicates the skew allowance which controls the issue instant of the SAML response
 # cas.saml.response.skewAllowance=0

--- a/cas-server-documentation/protocol/SAML-Protocol.md
+++ b/cas-server-documentation/protocol/SAML-Protocol.md
@@ -114,44 +114,6 @@ Content-Type: text/xml
 
 
 ##Configuration
-
-In addition to the `cas-server-support-saml` module dependency, the following steps are required to enabled the SAML 1.1 support.
-
-
-###SAML Argument Extractor 
-
-In the `argumentExtractorsConfiguration.xml` file:
-
-{% highlight xml %}
-<bean id="samlArgumentExtractor" class="org.jasig.cas.support.saml.web.support.SamlArgumentExtractor" />
-
-<util:list id="argumentExtractors">
-  <ref bean="casArgumentExtractor" />
-  <ref bean="samlArgumentExtractor" />
-</util:list>
-{% endhighlight %}
-
-###SAML ID Generator
-
-In the uniqueIdGenerators.xml file:
-
-{% highlight xml %}
-<bean id="samlServiceTicketUniqueIdGenerator" class="org.jasig.cas.support.saml.util.SamlCompliantUniqueTicketIdGenerator">
-  <constructor-arg index="0" value="[CAS-FQ-HOST-NAME]" />
-</bean>
-
-<util:map id="uniqueIdGeneratorsMap">
-  <entry
-    key="org.jasig.cas.authentication.principal.SimpleWebApplicationServiceImpl"
-    value-ref="serviceTicketUniqueIdGenerator" />
-  <entry
-    key="org.jasig.cas.support.saml.authentication.principal.SamlService"
-    value-ref="samlServiceTicketUniqueIdGenerator" />
-</util:map>
-{% endhighlight %}
-
-
-##SAML Configuration
 SAML configuration in CAS is contained within the `cas.properties` file.
 
 ### SAML Response Issuer

--- a/cas-server-documentation/protocol/SAML-Protocol.md
+++ b/cas-server-documentation/protocol/SAML-Protocol.md
@@ -181,16 +181,30 @@ In the uniqueIdGenerators.xml file:
 </util:map>
 {% endhighlight %}
 
-###SAML Views 
-In `cas-servlet.xml`, uncomment the following:
 
-{% highlight xml %}
-<bean id="xmlViewResolver" class="org.springframework.web.servlet.view.XmlViewResolver"
-          p:order="3"
-          p:location="${cas.viewResolver.xmlFile:classpath:/META-INF/spring/saml-protocol-views.xml}" />
+##SAML Configuration
+SAML configuration in CAS is contained within the `cas.properties` file.
+
+### SAML Response Issuer
+The SAML response issuer can be controlled via:
+
+{% highlight properties %}
+# Indicates the SAML response issuer
+# cas.saml.response.issuer=localhost
+{% endhighlight %}
+
+### SAML IssueInstant Skew
+The SAML response can be allowed a skew value to control the issue instant. The behavior is controlled via:
+
+{% highlight properties %}
+# Indicates the skew allowance which controls the issue instant of the SAML response
+# cas.saml.response.skewAllowance=0
 {% endhighlight %}
 
 #SAML 2
 
-CAS support for SAML 2 at this point is mostly limited to [Google Apps Integration](../integration/Google-Apps-Integration.html). Full SAML 2 support can also be achieved via Shibboleth with CAS handling the authentication and SSO. [See this guide](../integration/Shibboleth.html) for more info.
+CAS support for SAML 2 at this point is mostly limited to 
+[Google Apps Integration](../integration/Google-Apps-Integration.html). 
+Full SAML 2 support can also be achieved via Shibboleth with CAS 
+handling the authentication and SSO. [See this guide](../integration/Shibboleth.html) for more info.
 

--- a/cas-server-documentation/protocol/SAML-Protocol.md
+++ b/cas-server-documentation/protocol/SAML-Protocol.md
@@ -117,37 +117,6 @@ Content-Type: text/xml
 
 In addition to the `cas-server-support-saml` module dependency, the following steps are required to enabled the SAML 1.1 support.
 
-###Definition/Mapping of `samlValidateController` 
-
-In `cas-servlet.xml`:
-
-{% highlight xml %}
-<bean id="samlValidateController" class="org.jasig.cas.web.ServiceValidateController"
-  p:validationSpecificationClass="org.jasig.cas.validation.Cas20WithoutProxyingValidationSpecification"
-  p:centralAuthenticationService-ref="centralAuthenticationService"
-  p:proxyHandler-ref="proxy20Handler"
-  p:argumentExtractor-ref="samlArgumentExtractor"
-  p:successView="casSamlServiceSuccessView"
-  p:failureView="casSamlServiceFailureView"/>
-
-<bean id="handlerMappingC" class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">
-  <property name="mappings">
-    <props>
-      ...
-      <prop key="/samlValidate">samlValidateController</prop>
-      ...
-{% endhighlight %}
-
-###Servlet mapping for `/samlValidate` 
-
-In the `web.xml` file:
-
-{% highlight xml %}
-<servlet-mapping>
-  <servlet-name>cas</servlet-name>
-  <url-pattern>/samlValidate</url-pattern>
-</servlet-mapping>
-{% endhighlight %}
 
 ###SAML Argument Extractor 
 

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/SamlApplicationContextInitializer.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/SamlApplicationContextInitializer.java
@@ -20,6 +20,7 @@
 package org.jasig.cas;
 
 import org.jasig.cas.support.saml.SamlProtocolConstants;
+import org.jasig.cas.web.support.ArgumentExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.Controller;
 
 import javax.annotation.PostConstruct;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -50,7 +52,6 @@ public class SamlApplicationContextInitializer {
     @Qualifier("handlerMappingC")
     private SimpleUrlHandlerMapping handlerMappingC;
 
-
     @Autowired
     @Qualifier("samlValidateController")
     private Controller samlValidateController;
@@ -63,8 +64,11 @@ public class SamlApplicationContextInitializer {
     @PostConstruct
     public void initialize() {
         logger.info("Initializing Saml application context");
-        final Map<String, Object> urlMap = (Map<String, Object>) handlerMappingC.getUrlMap();
+
+        final Map<String, Object> urlMap = (Map<String, Object>) this.handlerMappingC.getUrlMap();
         urlMap.put(SamlProtocolConstants.ENDPOINT_SAML_VALIDATE, this.samlValidateController);
-        handlerMappingC.initApplicationContext();
+        this.handlerMappingC.initApplicationContext();
+
+        logger.info("Initialized Saml application context successfully");
     }
 }

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/SamlApplicationContextInitializer.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/SamlApplicationContextInitializer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.cas;
+
+import org.jasig.cas.support.saml.SamlProtocolConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.servlet.mvc.Controller;
+
+import javax.annotation.PostConstruct;
+import java.util.Map;
+
+/**
+ * This component is loaded by the CAS servlet web application context
+ * automatically. It is responsible for registering beans
+ * into the web application context.
+ * @author Misagh Moayyed
+ * @since 4.2
+ */
+@Component
+public class SamlApplicationContextInitializer {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    @Qualifier("handlerMappingC")
+    private SimpleUrlHandlerMapping handlerMappingC;
+
+
+    @Autowired
+    @Qualifier("samlValidateController")
+    private Controller samlValidateController;
+
+    /**
+     * Initializes the CAS servlet application context
+     * to make sure the saml validation controller can respond
+     * to requests.
+     */
+    @PostConstruct
+    public void initialize() {
+        logger.info("Initializing Saml application context");
+        final Map<String, Object> urlMap = (Map<String, Object>) handlerMappingC.getUrlMap();
+        urlMap.put(SamlProtocolConstants.ENDPOINT_SAML_VALIDATE, this.samlValidateController);
+        handlerMappingC.initApplicationContext();
+    }
+}

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/SamlApplicationContextInitializer.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/SamlApplicationContextInitializer.java
@@ -20,7 +20,6 @@
 package org.jasig.cas;
 
 import org.jasig.cas.support.saml.SamlProtocolConstants;
-import org.jasig.cas.web.support.ArgumentExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +30,6 @@ import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.Controller;
 
 import javax.annotation.PostConstruct;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/OpenSamlConfigBean.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/OpenSamlConfigBean.java
@@ -64,7 +64,7 @@ public final class OpenSamlConfigBean {
      */
     @PostConstruct
     public void init() {
-        LOGGER.debug("Initializing OpenSaml configuration...");
+        LOGGER.info("Initializing OpenSaml configuration...");
         Assert.notNull(this.parserPool, "parserPool cannot be null");
 
         try {
@@ -84,5 +84,6 @@ public final class OpenSamlConfigBean {
         }
 
         registry.setParserPool(parserPool);
+        LOGGER.info("Initialized OpenSaml configuration successfully.");
     }
 }

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlProtocolConstants.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlProtocolConstants.java
@@ -44,4 +44,7 @@ public interface SamlProtocolConstants {
     /** Constant representing service. */
     String CONST_PARAM_TARGET = "TARGET";
 
+    /** Indicates the endpoint for saml validation. */
+    String ENDPOINT_SAML_VALIDATE = "/samlValidate";
+
 }

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlServletContextListener.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlServletContextListener.java
@@ -19,24 +19,23 @@
 
 package org.jasig.cas.support.saml;
 
+import org.jasig.cas.support.saml.authentication.principal.SamlService;
+import org.jasig.cas.util.UniqueTicketIdGenerator;
 import org.jasig.cas.web.support.ArgumentExtractor;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.ServletContextAware;
 
-import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletRegistration;
 import javax.servlet.annotation.WebListener;
-
 import java.util.List;
+import java.util.Map;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -57,6 +56,10 @@ public class SamlServletContextListener implements ServletContextListener, Appli
     @Qualifier("samlArgumentExtractor")
     private ArgumentExtractor samlArgumentExtractor;
 
+    @Autowired
+    @Qualifier("samlServiceTicketUniqueIdGenerator")
+    private UniqueTicketIdGenerator samlServiceTicketUniqueIdGenerator;
+
     @Override
     public void contextInitialized(final ServletContextEvent sce) {
         logger.info("Initializing SAML servlet context...");
@@ -73,8 +76,13 @@ public class SamlServletContextListener implements ServletContextListener, Appli
     @Override
     public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
         if (applicationContext.getParent() == null) {
+
             final List<ArgumentExtractor> list = applicationContext.getBean("argumentExtractors", List.class);
             list.add(this.samlArgumentExtractor);
+
+            final Map<String, UniqueTicketIdGenerator> map = applicationContext.getBean("uniqueIdGeneratorsMap", Map.class);
+            map.put(SamlService.class.getCanonicalName(), samlServiceTicketUniqueIdGenerator);
+
         }
     }
 

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlServletContextListener.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlServletContextListener.java
@@ -19,13 +19,26 @@
 
 package org.jasig.cas.support.saml;
 
+import org.jasig.cas.web.support.ArgumentExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.ServletContextAware;
 
+import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletRegistration;
 import javax.servlet.annotation.WebListener;
+
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Initializes the CAS root servlet context to make sure
@@ -34,10 +47,15 @@ import javax.servlet.annotation.WebListener;
  * @since 4.2
  */
 @WebListener
-public class SamlServletContextListener implements ServletContextListener {
+@Component
+public class SamlServletContextListener implements ServletContextListener, ApplicationContextAware {
     private static final String CAS_SERVLET_NAME = "cas";
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = getLogger(this.getClass());
+
+    @Autowired
+    @Qualifier("samlArgumentExtractor")
+    private ArgumentExtractor samlArgumentExtractor;
 
     @Override
     public void contextInitialized(final ServletContextEvent sce) {
@@ -51,4 +69,13 @@ public class SamlServletContextListener implements ServletContextListener {
 
     @Override
     public void contextDestroyed(final ServletContextEvent sce) {}
+
+    @Override
+    public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
+        if (applicationContext.getParent() == null) {
+            final List<ArgumentExtractor> list = applicationContext.getBean("argumentExtractors", List.class);
+            list.add(this.samlArgumentExtractor);
+        }
+    }
+
 }

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlServletContextListener.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/SamlServletContextListener.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.cas.support.saml;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletRegistration;
+import javax.servlet.annotation.WebListener;
+
+/**
+ * Initializes the CAS root servlet context to make sure
+ * SAML validation endpoint can be activated by the main CAS servlet.
+ * @author Misagh Moayyed
+ * @since 4.2
+ */
+@WebListener
+public class SamlServletContextListener implements ServletContextListener {
+    private static final String CAS_SERVLET_NAME = "cas";
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    public void contextInitialized(final ServletContextEvent sce) {
+        logger.info("Initializing SAML servlet context...");
+
+        final ServletRegistration registration = sce.getServletContext().getServletRegistration(CAS_SERVLET_NAME);
+        registration.addMapping(SamlProtocolConstants.ENDPOINT_SAML_VALIDATE);
+
+        logger.info("Added [{}] to {} servlet context", SamlProtocolConstants.ENDPOINT_SAML_VALIDATE, CAS_SERVLET_NAME);
+    }
+
+    @Override
+    public void contextDestroyed(final ServletContextEvent sce) {}
+}

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
@@ -25,6 +25,9 @@ import java.security.SecureRandom;
 import org.jasig.cas.util.UniqueTicketIdGenerator;
 import org.opensaml.saml.saml1.binding.artifact.SAML1ArtifactType0001;
 import org.opensaml.saml.saml2.binding.artifact.SAML2ArtifactType0004;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 /**
  * Unique Ticket Id Generator compliant with the SAML 1.1 specification for
@@ -35,6 +38,7 @@ import org.opensaml.saml.saml2.binding.artifact.SAML2ArtifactType0004;
  * @author Scott Battaglia
  * @since 3.0.0
  */
+@Component("samlServiceTicketUniqueIdGenerator")
 public final class SamlCompliantUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
 
     /** Assertion handles are randomly-generated 20-byte identifiers. */
@@ -47,6 +51,7 @@ public final class SamlCompliantUniqueTicketIdGenerator implements UniqueTicketI
     private final byte[] sourceIdDigest;
 
     /** Flag to indicate SAML2 compliance. Default is SAML1.1. */
+    @Value("${cas.saml.ticketid.saml2:false}")
     private boolean saml2compliant;
 
     /** Random generator to construct the AssertionHandle. */
@@ -57,7 +62,8 @@ public final class SamlCompliantUniqueTicketIdGenerator implements UniqueTicketI
      *
      * @param sourceId the source id
      */
-    public SamlCompliantUniqueTicketIdGenerator(final String sourceId) {
+    @Autowired
+    public SamlCompliantUniqueTicketIdGenerator(@Value("${server.name}") final String sourceId) {
         try {
             final MessageDigest messageDigest = MessageDigest.getInstance("SHA");
             messageDigest.update(sourceId.getBytes("8859_1"));

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/support/SamlArgumentExtractor.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/support/SamlArgumentExtractor.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.jasig.cas.authentication.principal.WebApplicationService;
 import org.jasig.cas.support.saml.authentication.principal.SamlService;
 import org.jasig.cas.web.support.AbstractArgumentExtractor;
+import org.springframework.stereotype.Component;
 
 /**
  * Retrieve the ticket and artifact based on the SAML 1.1 profile.
@@ -30,6 +31,7 @@ import org.jasig.cas.web.support.AbstractArgumentExtractor;
  * @author Scott Battaglia
  * @since 3.1
  */
+@Component("samlArgumentExtractor")
 public final class SamlArgumentExtractor extends AbstractArgumentExtractor {
 
     @Override

--- a/cas-server-support-saml/src/main/resources/META-INF/cas-servlet-saml.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/cas-servlet-saml.xml
@@ -40,5 +40,4 @@
           p:argumentExtractor-ref="samlArgumentExtractor"
           p:successView="casSamlServiceSuccessView"
           p:failureView="casSamlServiceFailureView"/>
-
 </beans>

--- a/cas-server-support-saml/src/main/resources/META-INF/cas-servlet-saml.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/cas-servlet-saml.xml
@@ -1,0 +1,44 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:webflow="http://www.springframework.org/schema/webflow-config"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+       http://www.springframework.org/schema/webflow-config http://www.springframework.org/schema/webflow-config/spring-webflow-config-2.3.xsd">
+
+    <bean id="samlValidateController" class="org.jasig.cas.web.ServiceValidateController"
+          p:validationSpecificationClass="org.jasig.cas.validation.Cas20WithoutProxyingValidationSpecification"
+          p:centralAuthenticationService-ref="centralAuthenticationService"
+          p:servicesManager-ref="servicesManager"
+          p:proxyHandler-ref="proxy20Handler"
+          p:argumentExtractor-ref="samlArgumentExtractor"
+          p:successView="casSamlServiceSuccessView"
+          p:failureView="casSamlServiceFailureView"/>
+
+</beans>

--- a/cas-server-support-saml/src/main/resources/META-INF/spring/saml-protocol-views.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/spring/saml-protocol-views.xml
@@ -32,15 +32,15 @@
     </description>
 
     <!-- Sample configuration to turn on SAML validation. Note that the SAML module dependency
-         is required to be included in the final weba application file.  -->
+         is required to be included in the final web application file.  -->
 
     <bean id="abstractsamlView" class="org.jasig.cas.support.saml.web.view.AbstractSaml10ResponseView"
           abstract="true"/>
 
     <bean id="casSamlServiceSuccessView" class="org.jasig.cas.support.saml.web.view.Saml10SuccessResponseView"
           parent="abstractsamlView"
-          p:issuer="localhost"
-          p:skewAllowance="0" />
+          p:issuer="${cas.saml.response.issuer:localhost}"
+          p:skewAllowance="${cas.saml.response.skewAllowance:0}" />
 
     <bean id="casSamlServiceFailureView" class="org.jasig.cas.support.saml.web.view.Saml10FailureResponseView"
           parent="abstractsamlView"  />

--- a/cas-server-support-saml/src/main/resources/META-INF/spring/saml-protocol-views.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/spring/saml-protocol-views.xml
@@ -34,6 +34,16 @@
     <!-- Sample configuration to turn on SAML validation. Note that the SAML module dependency
          is required to be included in the final web application file.  -->
 
+    <bean id="samlValidateController" class="org.jasig.cas.web.ServiceValidateController"
+          p:validationSpecificationClass="org.jasig.cas.validation.Cas20WithoutProxyingValidationSpecification"
+          p:centralAuthenticationService-ref="centralAuthenticationService"
+          p:servicesManager-ref="servicesManager"
+          p:proxyHandler-ref="proxy20Handler"
+          p:argumentExtractor-ref="samlArgumentExtractor"
+          p:successView="casSamlServiceSuccessView"
+          p:failureView="casSamlServiceFailureView"/>
+
+
     <bean id="abstractsamlView" class="org.jasig.cas.support.saml.web.view.AbstractSaml10ResponseView"
           abstract="true"/>
 

--- a/cas-server-support-saml/src/main/resources/META-INF/spring/saml-protocol-views.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/spring/saml-protocol-views.xml
@@ -34,16 +34,6 @@
     <!-- Sample configuration to turn on SAML validation. Note that the SAML module dependency
          is required to be included in the final web application file.  -->
 
-    <bean id="samlValidateController" class="org.jasig.cas.web.ServiceValidateController"
-          p:validationSpecificationClass="org.jasig.cas.validation.Cas20WithoutProxyingValidationSpecification"
-          p:centralAuthenticationService-ref="centralAuthenticationService"
-          p:servicesManager-ref="servicesManager"
-          p:proxyHandler-ref="proxy20Handler"
-          p:argumentExtractor-ref="samlArgumentExtractor"
-          p:successView="casSamlServiceSuccessView"
-          p:failureView="casSamlServiceFailureView"/>
-
-
     <bean id="abstractsamlView" class="org.jasig.cas.support.saml.web.view.AbstractSaml10ResponseView"
           abstract="true"/>
 

--- a/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/util/SamlCompliantUniqueTicketIdGeneratorTests.java
+++ b/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/util/SamlCompliantUniqueTicketIdGeneratorTests.java
@@ -20,6 +20,7 @@ package org.jasig.cas.support.saml.util;
 
 import static org.junit.Assert.*;
 
+import org.jasig.cas.support.saml.AbstractOpenSamlTests;
 import org.junit.Test;
 
 /**
@@ -27,7 +28,7 @@ import org.junit.Test;
  * @author Scott Battaglia
  * @since 3.4.3
  */
-public final class SamlCompliantUniqueTicketIdGeneratorTests {
+public final class SamlCompliantUniqueTicketIdGeneratorTests extends AbstractOpenSamlTests {
 
     @Test
     public void verifySaml1Compliant() {

--- a/cas-server-support-saml/src/test/resources/META-INF/spring/opensaml-config.xml
+++ b/cas-server-support-saml/src/test/resources/META-INF/spring/opensaml-config.xml
@@ -32,6 +32,10 @@
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
                            http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
+    <context:property-placeholder location="classpath:cas.properties"
+                                  ignore-resource-not-found="false"
+                                  ignore-unresolvable="false"/>
+
     <context:component-scan base-package="org.jasig.cas.support.saml" annotation-config="true" />
     <context:annotation-config />
 

--- a/cas-server-support-saml/src/test/resources/cas.properties
+++ b/cas-server-support-saml/src/test/resources/cas.properties
@@ -1,0 +1,33 @@
+#
+# Licensed to Apereo under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Apereo licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+server.name=http://localhost:8080
+server.prefix=${server.name}/cas
+
+##
+# SAML
+#
+# Indicates the SAML response issuer
+cas.saml.response.issuer=localhost
+#
+# Indicates the skew allowance which controls the issue instant of the SAML response
+cas.saml.response.skewAllowance=0
+#
+# Indicates whether SAML ticket id generation should be saml2-compliant.
+cas.saml.ticketid.saml2=false

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -77,11 +77,6 @@
   <bean id="xmlViewResolver" class="org.springframework.web.servlet.view.XmlViewResolver"
           p:order="1"
           p:location="${cas.viewResolver.xmlFile:classpath:/META-INF/spring/views.xml}" />
-
-
-    <bean id="xmlViewResolver" class="org.springframework.web.servlet.view.XmlViewResolver"
-          p:order="1"
-          p:location="${cas.viewResolver.xmlFile:classpath:/META-INF/spring/saml-protocol-views.xml}" />
   -->
 
   <bean id="urlBasedViewResolver" class="org.springframework.web.servlet.view.UrlBasedViewResolver"
@@ -341,13 +336,4 @@
 
   <bean id="acceptableUsagePolicyFormAction" class="org.jasig.cas.web.flow.AcceptableUsagePolicyFormAction"/>
 
-  <!--
-  <bean id="samlValidateController" class="org.jasig.cas.web.ServiceValidateController"
-          p:validationSpecificationClass="org.jasig.cas.validation.Cas20WithoutProxyingValidationSpecification"
-          p:centralAuthenticationService-ref="centralAuthenticationService"
-          p:proxyHandler-ref="proxy20Handler"
-          p:argumentExtractor-ref="samlArgumentExtractor"
-          p:successView="casSamlServiceSuccessView"
-          p:failureView="casSamlServiceFailureView"/>
-  -->
 </beans>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -108,11 +108,6 @@
       <util:properties>
         <prop key="/serviceValidate">serviceValidateController</prop>
         <prop key="/proxyValidate">proxyValidateController</prop>
-
-        <!--
-        <prop key="/samlValidate">samlValidateController</prop>
-        -->
-
         <prop key="/p3/serviceValidate">v3ServiceValidateController</prop>
         <prop key="/p3/proxyValidate">v3ProxyValidateController</prop>
         <prop key="/validate">legacyValidateController</prop>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -203,6 +203,15 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 # sso.sessions.include.tgt=false
 
 ##
+# SAML
+#
+# Indicates the SAML response issuer
+# cas.saml.response.issuer=localhost
+#
+# Indicates the skew allowance which controls the issue instant of the SAML response
+# cas.saml.response.skewAllowance=0
+
+##
 # Password Policy
 #
 # Warn all users of expiration date regardless of warningDays value.

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -210,6 +210,9 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 #
 # Indicates the skew allowance which controls the issue instant of the SAML response
 # cas.saml.response.skewAllowance=0
+#
+# Indicates whether SAML ticket id generation should be saml2-compliant.
+# cas.saml.ticketid.saml2=false
 
 ##
 # Password Policy

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/argumentExtractorsConfiguration.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/argumentExtractorsConfiguration.xml
@@ -30,16 +30,10 @@
         OpenId, etc.). By default, only CAS is enabled.
     </description>
 
-    <!--
-    <bean id="samlArgumentExtractor" class="org.jasig.cas.support.saml.web.support.SamlArgumentExtractor" />
-    -->
-
-    <bean
-            id="casArgumentExtractor"
+    <bean id="casArgumentExtractor"
             class="org.jasig.cas.web.support.CasArgumentExtractor"/>
 
     <util:list id="argumentExtractors">
-        <!-- <ref bean="samlArgumentExtractor" /> -->
         <ref bean="casArgumentExtractor"/>
     </util:list>
 </beans>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/uniqueIdGenerators.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/uniqueIdGenerators.xml
@@ -31,11 +31,6 @@
         the SAML ticket id generator.
     </description>
 
-    <!--
-    <bean id="samlServiceTicketUniqueIdGenerator" class="org.jasig.cas.support.saml.util.SamlCompliantUniqueTicketIdGenerator"
-        c:sourceId="unique-source-id" />
-    -->
-
     <!-- ID Generators -->
     <bean id="ticketGrantingTicketUniqueIdGenerator" class="org.jasig.cas.util.DefaultUniqueTicketIdGenerator"
           c:maxLength="50" c:suffix="${host.name}" />
@@ -53,12 +48,6 @@
         <entry
                 key="org.jasig.cas.authentication.principal.SimpleWebApplicationServiceImpl"
                 value-ref="serviceTicketUniqueIdGenerator" />
-
-        <!--
-        <entry
-                key="org.jasig.cas.support.saml.authentication.principal.SamlService"
-                value-ref="samlServiceTicketUniqueIdGenerator" />
-        -->
     </util:map>
 
 </beans>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -110,7 +110,8 @@
         </servlet-class>
         <init-param>
             <param-name>contextConfigLocation</param-name>
-            <param-value>/WEB-INF/cas-servlet.xml, /WEB-INF/cas-servlet-*.xml</param-value>
+            <!-- Load the child application context. Start with the default, then modules, then overlays. -->
+            <param-value>/WEB-INF/cas-servlet.xml,classpath*:/META-INF/cas-servlet-*.xml,/WEB-INF/cas-servlet-*.xml</param-value>
         </init-param>
         <init-param>
             <param-name>publishContext</param-name>
@@ -233,14 +234,7 @@
         <servlet-name>cas</servlet-name>
         <url-pattern>/v1/*</url-pattern>
     </servlet-mapping>
-
-    <!--
-    <servlet-mapping>
-        <servlet-name>cas</servlet-name>
-        <url-pattern>/samlValidate</url-pattern>
-    </servlet-mapping>
-    -->
-
+    
     <session-config>
         <!-- Default to 5 minute session timeouts -->
         <session-timeout>5</session-timeout>


### PR DESCRIPTION
This pull reduces the SAML configuration noise down to one step: including the dependency. That's it. No more manual steps are actually required. There are also a few settings that are now exposed via the cas.properties file. This should grealy simplify the configuration, and reduce maven overlay sizes. 

All functionality works just as it did before. 

This depends on #1118 