### PR TITLE
Add missing SAML property: servicesManager

### DIFF
--- a/cas-server-documentation/protocol/SAML-Protocol.md
+++ b/cas-server-documentation/protocol/SAML-Protocol.md
@@ -126,6 +126,7 @@ In `cas-servlet.xml`:
   p:validationSpecificationClass="org.jasig.cas.validation.Cas20WithoutProxyingValidationSpecification"
   p:centralAuthenticationService-ref="centralAuthenticationService"
   p:proxyHandler-ref="proxy20Handler"
+  p:servicesManager-ref="servicesManager"
   p:argumentExtractor-ref="samlArgumentExtractor"
   p:successView="casSamlServiceSuccessView"
   p:failureView="casSamlServiceFailureView"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -345,6 +345,7 @@
   <bean id="samlValidateController" class="org.jasig.cas.web.ServiceValidateController"
           p:validationSpecificationClass="org.jasig.cas.validation.Cas20WithoutProxyingValidationSpecification"
           p:centralAuthenticationService-ref="centralAuthenticationService"
+          p:servicesManager-ref="servicesManager"
           p:proxyHandler-ref="proxy20Handler"
           p:argumentExtractor-ref="samlArgumentExtractor"
           p:successView="casSamlServiceSuccessView"


### PR DESCRIPTION
Add missing `servicesManager` property to the SAML validator.