### PR TITLE
exclude xerces dependency

### DIFF
--- a/cas-server-support-openid/pom.xml
+++ b/cas-server-support-openid/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>openid4java</artifactId>
             <version>${openid4java.version}</version>
             <scope>compile</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
excludes xerces dependency from openid4java in cas-cerver-support-openid