### PR TITLE
Doc : Throttling - SimpleTriggerFactoryBean

### DIFF
--- a/cas-server-documentation/installation/Configuring-Authentication-Throttling.md
+++ b/cas-server-documentation/installation/Configuring-Authentication-Throttling.md
@@ -112,7 +112,7 @@ It is convenient to place Spring configuration for login throttling components i
 
 <!-- A scheduler that drives all configured triggers is provided by default in applicationContext.xml. -->
 <bean id="loginThrottleTrigger"
-      class="org.springframework.scheduling.quartz.SimpleTriggerBean"
+      class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean"
       p:jobDetail-ref="loginThrottleJobDetail"
       p:startDelay="1000"
       p:repeatInterval="1000"/>


### PR DESCRIPTION
In spring 4.1, org.springframework.scheduling.quartz.SimpleTriggerBean doesn't exist anymore (ClassNotFoundEx) - we have to use org.springframework.scheduling.quartz.SimpleTriggerFactoryBean instead.

SimpleTriggerBean was dreprecated since some time : 
https://jira.spring.io/browse/SPR-10209