### PR TITLE
Reformat configuration of deployerConfigContext

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -45,63 +45,29 @@
        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
-    <!--
-       | The authentication manager defines security policy for authentication by specifying at a minimum
-       | the authentication handlers that will be used to authenticate credential. While the AuthenticationManager
-       | interface supports plugging in another implementation, the default PolicyBasedAuthenticationManager should
-       | be sufficient in most cases.
-       +-->
-    <bean id="authenticationManager" class="org.jasig.cas.authentication.PolicyBasedAuthenticationManager">
-        <constructor-arg>
-            <map>
-                <!--
-                   | IMPORTANT
-                   | Every handler requires a unique name.
-                   | If more than one instance of the same handler class is configured, you must explicitly
-                   | set its name to something other than its default name (typically the simple class name).
-                   -->
-                <entry key-ref="proxyAuthenticationHandler" value-ref="proxyPrincipalResolver" />
-                <entry key-ref="primaryAuthenticationHandler" value-ref="primaryPrincipalResolver" />
-            </map>
-        </constructor-arg>
+    <bean id="authenticationManager" class="org.jasig.cas.authentication.PolicyBasedAuthenticationManager"
+            c:map-ref="authenticationHandlersResolvers"
+            p:authenticationMetaDataPopulators-ref="authenticationMetadataPopulators"
+            p:authenticationPolicy-ref="authenticationPolicy" />
 
-        <!-- Uncomment the metadata populator to capture the password.
-        <property name="authenticationMetaDataPopulators">
-           <util:list>
-               <bean class="org.jasig.cas.authentication.CacheCredentialsMetaDataPopulator"/>
-           </util:list>
-        </property>
-        -->
+    <util:map id="authenticationHandlersResolvers">
+        <entry key-ref="proxyAuthenticationHandler" value-ref="proxyPrincipalResolver" />
+        <entry key-ref="primaryAuthenticationHandler" value-ref="primaryPrincipalResolver" />
+    </util:map>
 
+    <util:list id="authenticationMetadataPopulators">
         <!--
-           | Defines the security policy around authentication. Some alternative policies that ship with CAS:
-           |
-           | * NotPreventedAuthenticationPolicy - all credential must either pass or fail authentication
-           | * AllAuthenticationPolicy - all presented credential must be authenticated successfully
-           | * RequiredHandlerAuthenticationPolicy - specifies a handler that must authenticate its credential to pass
-           -->
-        <property name="authenticationPolicy">
-            <bean class="org.jasig.cas.authentication.AnyAuthenticationPolicy" />
-        </property>
-    </bean>
+        <bean class="org.jasig.cas.authentication.CacheCredentialsMetaDataPopulator"/>
+        -->
+    </util:list>
+
+    <bean id="authenticationPolicy" class="org.jasig.cas.authentication.AnyAuthenticationPolicy" />
 
     <!-- Required for proxy ticket mechanism. -->
     <bean id="proxyAuthenticationHandler"
           class="org.jasig.cas.authentication.handler.support.HttpBasedServiceCredentialsAuthenticationHandler"
           p:httpClient-ref="supportsTrustStoreSslSocketFactoryHttpClient" />
 
-    <!--
-       | TODO: Replace this component with one suitable for your enviroment.
-       |
-       | This component provides authentication for the kind of credential used in your environment. In most cases
-       | credential is a username/password pair that lives in a system of record like an LDAP directory.
-       | The most common authentication handler beans:
-       |
-       | * org.jasig.cas.authentication.LdapAuthenticationHandler
-       | * org.jasig.cas.adaptors.jdbc.QueryDatabaseAuthenticationHandler
-       | * org.jasig.cas.adaptors.x509.authentication.handler.support.X509CredentialsAuthenticationHandler
-       | * org.jasig.cas.support.spnego.authentication.handler.support.JCIFSSpnegoAuthenticationHandler
-       -->
     <bean id="primaryAuthenticationHandler"
           class="org.jasig.cas.authentication.AcceptUsersAuthenticationHandler">
         <property name="users">
@@ -115,19 +81,11 @@
     <bean id="proxyPrincipalResolver"
           class="org.jasig.cas.authentication.principal.BasicPrincipalResolver" />
 
-    <!--
-       | Resolves a principal from a credential using an attribute repository that is configured to resolve
-       | against a deployer-specific store (e.g. LDAP).
-       -->
     <bean id="primaryPrincipalResolver"
           class="org.jasig.cas.authentication.principal.PersonDirectoryPrincipalResolver"
           p:principalFactory-ref="principalFactory"
           p:attributeRepository-ref="attributeRepository" />
 
-    <!--
-    Bean that defines the attributes that a service may return.  This example uses the Stub/Mock version.  A real implementation
-    may go against a database or LDAP server.  The id should remain "attributeRepository" though.
-    +-->
     <bean id="attributeRepository" class="org.jasig.services.persondir.support.NamedStubPersonAttributeDao"
           p:backingMap-ref="attrRepoBackingMap" />
 
@@ -154,13 +112,6 @@
 
     <util:list id="monitorsList">
         <bean class="org.jasig.cas.monitor.MemoryMonitor" p:freeMemoryWarnThreshold="10" />
-        <!--
-          NOTE
-          The following ticket registries support SessionMonitor:
-            * DefaultTicketRegistry
-            * JpaTicketRegistry
-          Remove this monitor if you use an unsupported registry.
-        -->
         <bean class="org.jasig.cas.monitor.SessionMonitor"
               p:ticketRegistry-ref="ticketRegistry"
               p:serviceTicketCountWarnThreshold="5000"


### PR DESCRIPTION
Re-arranges the deployerConfigContext, fixes formatting issues and gives a number of beans explicit ids, so that sub modules can manipulate them automatically when needed.