### PR TITLE
Radius context config automated

### DIFF
--- a/cas-server-documentation/installation/RADIUS-Authentication.md
+++ b/cas-server-documentation/installation/RADIUS-Authentication.md
@@ -7,52 +7,47 @@ title: CAS - RADIUS Authentication
 RADIUS support is enabled by including the following dependency in the Maven WAR overlay:
 
 {% highlight xml %}
-    <dependency>
-      <groupId>org.jasig.cas</groupId>
-      <artifactId>cas-server-support-radius</artifactId>
-      <version>${cas.version}</version>
-    </dependency>
+<dependency>
+  <groupId>org.jasig.cas</groupId>
+  <artifactId>cas-server-support-radius</artifactId>
+  <version>${cas.version}</version>
+</dependency>
 {% endhighlight %}
 
-## RADIUS Components
+## Configuration
 
-######`RadiusAuthenticationHandler`
-The RADIUS handler accepts username/password credentials and delegates authentication to one or more RADIUS
-servers. It supports two types of failovers: failover on an authentication failure, and failover on a server exception.
-
-* `failoverOnAuthenticationFailure` - True to continue to the next configured RADIUS server on authentication failure,
-false otherwise. This flag is typically set when user accounts are spread across one or more RADIUS servers.
-* `failoverOnException` - True to continue to next configured RADIUS server on an error other than authentication
-failure, false otherwise. This flag is typically set to support highly available deployments where authentication
-should proceed in the face of one or more RADIUS server failures.
-* `servers` - Array of RADIUS servers to delegate to for authentication.
-
-
-######`JRadiusServerImpl`
-Component representing a RADIUS server has the following configuration properties.
-
-* `protocol` - radius protocol to use.
-* `clientFactory` - factory establish and create radius client instances.
-
-
-## RADIUS Configuration Example
 {% highlight xml %}
-<bean id="radiusServer"
-      class="org.jasig.cas.adaptors.radius.JRadiusServerImpl"
-      c:protocol="EAP_MSCHAPv2"
-      c:clientFactory-ref="radiusClientFactory" />
-
-<bean id="radiusClientFactory"
-      class="org.jasig.cas.adaptors.radius.RadiusClientFactory"
-      p:inetAddress="localhost"
-      p:sharedSecret="fqhwhgads" />
-
 <bean id="radiusAuthenticationHandler"
-      class="org.jasig.cas.adaptors.radius.authentication.handler.support.RadiusAuthenticationHandler">
-  <property name="servers">
-      <list>
-          <ref local="radiusServer" />
-      </list>
-  </property>
-</bean>
+      class="org.jasig.cas.adaptors.radius.authentication.handler.support.RadiusAuthenticationHandler"
+      p:failoverOnAuthenticationFailure="${cas.radius.failover.authn:false}"
+      p:failoverOnException="${cas.radius.failover.exception:false}"
+      p:servers-ref="radiusServers" />
+
+<util:list id="radiusServers">
+     <ref bean="radiusServer" />
+</util:list>
+
 {% endhighlight %}
+
+The following settings may control the configuration RADIUS server and client:
+
+{% highlight properties %}
+# cas.radius.client.inetaddr=localhost
+# cas.radius.client.port.acct=
+# cas.radius.client.socket.timeout=60
+# cas.radius.client.port.authn=
+# cas.radius.client.sharedsecret=N0Sh@ar3d$ecReT
+# cas.radius.server.protocol=EAP_MSCHAPv2
+# cas.radius.server.retries=3
+# cas.radius.server.nasIdentifier=-1
+# cas.radius.server.nasPort=-1
+# cas.radius.server.nasPortId=-1
+# cas.radius.server.nasRealPort=-1
+# cas.radius.server.nasPortType=-1
+# cas.radius.server.nasIpAddress=
+# cas.radius.server.nasIpv6Address=
+# cas.radius.failover.authn=false
+# cas.radius.failover.exception=false
+{% endhighlight %}
+
+

--- a/cas-server-support-openid/pom.xml
+++ b/cas-server-support-openid/pom.xml
@@ -42,6 +42,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jasig.cas</groupId>
+            <artifactId>cas-server-webapp-support</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openid4java</groupId>
             <artifactId>openid4java</artifactId>
             <version>${openid4java.version}</version>

--- a/cas-server-support-radius/pom.xml
+++ b/cas-server-support-radius/pom.xml
@@ -56,6 +56,18 @@
                     <artifactId>commons-collections</artifactId>
                     <groupId>commons-collections</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-beanutils</artifactId>
+                    <groupId>commons-beanutils</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>bcprov-jdk15</artifactId>
+                    <groupId>org.bouncycastle</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
             </exclusions>
         </dependency>        
     </dependencies>

--- a/cas-server-support-radius/src/main/java/org/jasig/cas/adaptors/radius/authentication/handler/support/RadiusAuthenticationHandler.java
+++ b/cas-server-support-radius/src/main/java/org/jasig/cas/adaptors/radius/authentication/handler/support/RadiusAuthenticationHandler.java
@@ -56,6 +56,15 @@ public class RadiusAuthenticationHandler extends AbstractUsernamePasswordAuthent
      */
     private boolean failoverOnAuthenticationFailure;
 
+
+    /**
+     * Instantiates a new Radius authentication handler.
+     */
+    public RadiusAuthenticationHandler() {
+        super();
+        logger.debug("Using {}", getClass().getSimpleName());
+    }
+
     @Override
     protected final HandlerResult authenticateUsernamePasswordInternal(final UsernamePasswordCredential credential)
             throws GeneralSecurityException, PreventedException {

--- a/cas-server-support-radius/src/main/resources/META-INF/spring/radius-server-config.xml
+++ b/cas-server-support-radius/src/main/resources/META-INF/spring/radius-server-config.xml
@@ -1,0 +1,66 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+        This file is loaded by the Spring configuration automatically, and serves as a placeholder
+        for various view definitions and beans. This helps with construction of views that require
+        references to other beans and whose changes can be configured externally.
+    </description>
+
+
+    <util:constant static-field="org.jasig.cas.adaptors.radius.RadiusServer.DEFAULT_PORT_ACCOUNTING"
+                   id="accountingPort" />
+    <util:constant static-field="org.jasig.cas.adaptors.radius.RadiusServer.DEFAULT_PORT_AUTHENTICATION"
+                   id="authenticationPort" />
+
+    <bean id="radiusServer"
+          class="org.jasig.cas.adaptors.radius.JRadiusServerImpl"
+          c:protocol="${cas.radius.server.protocol:EAP_MSCHAPv2}"
+          p:retries="${cas.radius.server.retries:3}"
+          p:nasIdentifier="${cas.radius.server.nasIdentifier:-1}"
+          p:nasPort="${cas.radius.server.nasPort:-1}"
+          p:nasPortId="${cas.radius.server.nasPortId:-1}"
+          p:nasRealPort="${cas.radius.server.nasRealPort:-1}"
+          p:nasPortType="${cas.radius.server.nasPortType:-1}"
+          p:nasIpAddress="${cas.radius.server.nasIpAddress:}"
+          p:nasIpv6Address="${cas.radius.server.nasIpv6Address:}"
+          c:clientFactory-ref="radiusClientFactory" />
+
+    <bean id="radiusClientFactory"
+          class="org.jasig.cas.adaptors.radius.RadiusClientFactory"
+          p:inetAddress="${cas.radius.client.inetaddr:localhost}"
+          p:accountingPort="${cas.radius.client.port.acct:#{accountingPort}}"
+          p:socketTimeout="${cas.radius.client.socket.timeout:60}"
+          p:authenticationPort="${cas.radius.client.port.authn:#{authenticationPort}}"
+          p:sharedSecret="${cas.radius.client.sharedsecret:N0Sh@ar3d$ecReT}" />
+
+
+
+</beans>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -356,9 +356,28 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 # memcached.failureMode=Redistribute
 # memcached.buffersize=8192
 
-
 ##
 # OpenID Support
 #
 # Enforce relying party id
 # cas.openid.enforce.rpid=false
+
+##
+# RADIUS Authentication Server
+#
+# cas.radius.client.inetaddr=localhost
+# cas.radius.client.port.acct=
+# cas.radius.client.socket.timeout=60
+# cas.radius.client.port.authn=
+# cas.radius.client.sharedsecret=N0Sh@ar3d$ecReT
+# cas.radius.server.protocol=EAP_MSCHAPv2
+# cas.radius.server.retries=3
+# cas.radius.server.nasIdentifier=-1
+# cas.radius.server.nasPort=-1
+# cas.radius.server.nasPortId=-1
+# cas.radius.server.nasRealPort=-1
+# cas.radius.server.nasPortType=-1
+# cas.radius.server.nasIpAddress=
+# cas.radius.server.nasIpv6Address=
+# cas.radius.failover.authn=false
+# cas.radius.failover.exception=false


### PR DESCRIPTION
Automates the configuration radius servers and clients, so that only declaring the authN handler is needed, and configuration is moved to the cas.properties. Adopters can still define additional servers and clients if they need to, just like before.