### PR TITLE
fix for #1173

### DIFF
--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
@@ -148,6 +148,6 @@ public class InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptor
      */
     protected String constructUsername(final HttpServletRequest request, final String usernameParameter) {
         final String username = request.getParameter(usernameParameter);
-        return "[username: " + (username != null ? username : "") + ']';
+        return (username != null ? username : "unknown") + "+password";
     }
 }


### PR DESCRIPTION
Fix for #1173. Modified the constructed string in InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.constructUsername() to match the value stored in database.