### PR TITLE
Google Apps SAML authN request is not parsed correctly

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/util/ApplicationContextProvider.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/util/ApplicationContextProvider.java
@@ -20,6 +20,7 @@ package org.jasig.cas.util;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Misagh Moayyed
@@ -27,6 +28,7 @@ import org.springframework.context.ApplicationContextAware;
  * holds the application context
  * @since 3.0.0.
  */
+@Component
 public final class ApplicationContextProvider implements ApplicationContextAware {
     private static ApplicationContext CONTEXT;
 

--- a/cas-server-core/src/main/java/org/jasig/cas/util/CompressionUtils.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/util/CompressionUtils.java
@@ -19,7 +19,6 @@
 package org.jasig.cas.util;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +30,6 @@ import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-import java.util.zip.InflaterOutputStream;
 
 /**
  * This is {@link CompressionUtils}
@@ -63,7 +61,7 @@ public final class CompressionUtils {
      */
     public static String inflate(final byte[] bytes) {
         final Inflater inflater = new Inflater(true);
-        final byte[] xmlMessageBytes = new byte[10000];
+        final byte[] xmlMessageBytes = new byte[INFLATED_ARRAY_LENGTH];
 
         final byte[] extendedBytes = new byte[bytes.length + 1];
         System.arraycopy(bytes, 0, extendedBytes, 0, bytes.length);

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
@@ -25,8 +25,10 @@ import org.jasig.cas.authentication.principal.Response;
 import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.support.saml.util.AbstractSaml20ObjectBuilder;
+import org.jasig.cas.util.ApplicationContextProvider;
 import org.jasig.cas.util.ISOStandardDateFormat;
 import org.jdom.Document;
+import org.springframework.context.ApplicationContext;
 import org.springframework.util.StringUtils;
 import org.jasig.cas.support.saml.SamlProtocolConstants;
 import org.jasig.cas.support.saml.util.GoogleSaml20ObjectBuilder;
@@ -67,8 +69,6 @@ public class GoogleAccountsService extends AbstractWebApplicationService {
 
     private final String requestId;
 
-    private final ServicesManager servicesManager;
-    
     /**
      * Instantiates a new google accounts service.
      *
@@ -77,11 +77,10 @@ public class GoogleAccountsService extends AbstractWebApplicationService {
      * @param requestId the request id
      * @param privateKey the private key
      * @param publicKey the public key
-     * @param servicesManager the services manager
      */
     protected GoogleAccountsService(final String id, final String relayState, final String requestId,
-            final PrivateKey privateKey, final PublicKey publicKey, final ServicesManager servicesManager) {
-        this(id, id, null, relayState, requestId, privateKey, publicKey, servicesManager);
+            final PrivateKey privateKey, final PublicKey publicKey) {
+        this(id, id, null, relayState, requestId, privateKey, publicKey);
     }
 
     /**
@@ -94,20 +93,15 @@ public class GoogleAccountsService extends AbstractWebApplicationService {
      * @param requestId the request id
      * @param privateKey the private key
      * @param publicKey the public key
-     * @param servicesManager the services manager
      */
     protected GoogleAccountsService(final String id, final String originalUrl,
             final String artifactId, final String relayState, final String requestId,
-            final PrivateKey privateKey, final PublicKey publicKey,
-            final ServicesManager servicesManager) {
+            final PrivateKey privateKey, final PublicKey publicKey) {
         super(id, originalUrl, artifactId);
         this.relayState = relayState;
         this.privateKey = privateKey;
         this.publicKey = publicKey;
         this.requestId = requestId;
-        this.servicesManager = servicesManager;
-
-
     }
 
     /**
@@ -116,12 +110,11 @@ public class GoogleAccountsService extends AbstractWebApplicationService {
      * @param request the request
      * @param privateKey the private key
      * @param publicKey the public key
-     * @param servicesManager the services manager
      * @return the google accounts service
      */
     public static GoogleAccountsService createServiceFrom(
             final HttpServletRequest request, final PrivateKey privateKey,
-            final PublicKey publicKey, final ServicesManager servicesManager) {
+            final PublicKey publicKey) {
         final String relayState = request.getParameter(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE);
 
         final String xmlRequest = BUILDER.decodeSamlAuthnRequest(
@@ -142,7 +135,7 @@ public class GoogleAccountsService extends AbstractWebApplicationService {
         final String requestId = root.getAttributeValue("ID");
 
         return new GoogleAccountsService(assertionConsumerServiceUrl,
-                relayState, requestId, privateKey, publicKey, servicesManager);
+                relayState, requestId, privateKey, publicKey);
     }
 
     @Override
@@ -176,7 +169,9 @@ public class GoogleAccountsService extends AbstractWebApplicationService {
         final DateTime currentDateTime = DateTime.parse(new ISOStandardDateFormat().getCurrentDateAndTime());
         final DateTime notBeforeIssueInstant = DateTime.parse("2003-04-17T00:46:02Z");
 
-        final RegisteredService svc = this.servicesManager.findServiceBy(this);
+        final ApplicationContext context = ApplicationContextProvider.getApplicationContext();
+        final ServicesManager servicesManager = context.getBean("servicesManager", ServicesManager.class);
+        final RegisteredService svc = servicesManager.findServiceBy(this);
         final String userId = svc.getUsernameAttributeProvider().resolveUsername(getPrincipal(), this);
 
         final org.opensaml.saml.saml2.core.Response response = BUILDER.newResponse(

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
@@ -56,12 +56,6 @@ import org.jdom.Element;
 public class GoogleAccountsService extends AbstractWebApplicationService {
 
     private static final long serialVersionUID = 6678711809842282833L;
-    private static final int INFLATED_BYTE_ARRAY_LENGTH = 10000;
-    private static final int DEFLATED_BYTE_ARRAY_BUFFER_LENGTH = 1024;
-    private static final int SAML_RESPONSE_RANDOM_ID_LENGTH = 20;
-    private static final int SAML_RESPONSE_ID_LENGTH = 40;
-    private static final int HEX_HIGH_BITS_BITWISE_FLAG = 0x0f;
-    private static final int HEX_RIGHT_SHIFT_COEFFICIENT = 4;
 
     private static final GoogleSaml20ObjectBuilder BUILDER = new GoogleSaml20ObjectBuilder();
 

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
@@ -254,12 +254,16 @@ public abstract class AbstractSaml20ObjectBuilder extends AbstractSamlObjectBuil
             return null;
         }
 
+        logger.debug("Decoding SAML authN request: {}", encodedRequestXmlString);
+
         final byte[] decodedBytes = CompressionUtils.decodeBase64ToByteArray(encodedRequestXmlString);
         if (decodedBytes == null) {
             return null;
         }
 
         final String inflated = CompressionUtils.inflate(decodedBytes);
+        logger.debug("Inflated SAML authN request: {}", inflated);
+
         if (!StringUtils.isEmpty(inflated)) {
             return inflated;
         }

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/support/GoogleAccountsArgumentExtractor.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/support/GoogleAccountsArgumentExtractor.java
@@ -19,7 +19,6 @@
 package org.jasig.cas.support.saml.web.support;
 
 import org.jasig.cas.authentication.principal.WebApplicationService;
-import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.support.saml.authentication.principal.GoogleAccountsService;
 import org.jasig.cas.web.support.AbstractArgumentExtractor;
 import org.slf4j.Logger;
@@ -47,27 +46,23 @@ public final class GoogleAccountsArgumentExtractor extends AbstractArgumentExtra
     @NotNull
     private final PrivateKey privateKey;
 
-    @NotNull
-    private final ServicesManager servicesManager;
 
     /**
      * Instantiates a new google accounts argument extractor.
      *
      * @param publicKey the public key
      * @param privateKey the private key
-     * @param servicesManager the services manager
      */
     public GoogleAccountsArgumentExtractor(final PublicKey publicKey,
-                                           final PrivateKey privateKey, final ServicesManager servicesManager) {
+                                           final PrivateKey privateKey) {
         this.publicKey = publicKey;
         this.privateKey = privateKey;
-        this.servicesManager = servicesManager;
     }
 
     @Override
     public WebApplicationService extractServiceInternal(final HttpServletRequest request) {
         return GoogleAccountsService.createServiceFrom(request,
-                this.privateKey, this.publicKey, this.servicesManager);
+                this.privateKey, this.publicKey);
     }
 
     /**

--- a/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
+++ b/cas-server-support-saml/src/main/resources/META-INF/spring/opensaml-config.xml
@@ -32,7 +32,7 @@
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
                            http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-    <context:component-scan base-package="org.jasig.cas.support.saml"/>
+    <context:component-scan base-package="org.jasig.cas"/>
     <context:annotation-config/>
 
     <bean id="shibboleth.OpenSAMLConfig" class="org.jasig.cas.support.saml.OpenSamlConfigBean"

--- a/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
+++ b/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
@@ -27,6 +27,7 @@ import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.support.saml.AbstractOpenSamlTests;
 import org.jasig.cas.support.saml.SamlProtocolConstants;
+import org.jasig.cas.util.ApplicationContextProvider;
 import org.jasig.cas.util.CompressionUtils;
 import org.jasig.cas.util.PrivateKeyFactoryBean;
 import org.jasig.cas.util.PublicKeyFactoryBean;
@@ -87,7 +88,7 @@ public class GoogleAccountsServiceTests extends AbstractOpenSamlTests {
         final ServicesManager servicesManager = mock(ServicesManager.class);
         when(servicesManager.findServiceBy(any(Service.class))).thenReturn(regSvc);
         
-        return GoogleAccountsService.createServiceFrom(request, privateKey, publicKey, servicesManager);
+        return GoogleAccountsService.createServiceFrom(request, privateKey, publicKey);
     }
 
     @Before

--- a/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
+++ b/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
@@ -27,7 +27,6 @@ import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.support.saml.AbstractOpenSamlTests;
 import org.jasig.cas.support.saml.SamlProtocolConstants;
-import org.jasig.cas.util.ApplicationContextProvider;
 import org.jasig.cas.util.CompressionUtils;
 import org.jasig.cas.util.PrivateKeyFactoryBean;
 import org.jasig.cas.util.PublicKeyFactoryBean;
@@ -42,8 +41,8 @@ import java.io.IOException;
 import java.security.interfaces.DSAPrivateKey;
 import java.security.interfaces.DSAPublicKey;
 
-import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Scott Battaglia

--- a/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
+++ b/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
@@ -104,6 +104,20 @@ public class GoogleAccountsServiceTests extends AbstractOpenSamlTests {
         assertTrue(resp.getAttributes().containsKey(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE));
     }
 
+
+    @Test
+    public void verifyAuthnRequestEncoded() {
+
+        final byte[] decodedBytes = CompressionUtils.decodeBase64ToByteArray("fVJNT+MwEL0j8R8s35M0BbTIaoK6IEQldolo2MPej"
+                + "DOtpzh28Njt8u9xUxBwWK7PM+/LM7v41xu2BU/obMXLfMIZWOU6tOuKP7TX2Tm/qI+PZiR7M4h5DNrew3MECixtWhLjQ8Wjt8JJQ"
+                + "hJW9kAiKLGc/7oV03wiBu+CU85wtriquDHuSTulTfe4edLQOTQGN0avtV6h3AwaEaUcJGd/3m1N97YWRBEWloK0IUGT8iwrJ1l50p"
+                + "ZnYvpDnJ785ax5U/qJ9pDgO1uPhyESN23bZM3dsh0JttiB/52mK752bm0gV67fyzeSCLcJXklDwNmcCHxIBi+dpdiDX4LfooKH+9uK"
+                + "6xAGEkWx2+3yD5pCFtGYHLqYAxVSEa/HZsUYzn+q9Hvr8l2a1x/ks+ITVf32Y/sgi6vGGVQvbJ663116kCGlCD6mENfO9zL8X63My"
+                + "xHBLluNoyJaGkDhCqHjrKgPql9PIx3MKw==");
+        final String inflated = CompressionUtils.inflate(decodedBytes);
+        assertNotNull(inflated);
+
+    }
     private static String encodeMessage(final String xmlString) throws IOException {
         return CompressionUtils.deflate(xmlString);
     }

--- a/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/web/support/GoogleAccountsArgumentExtractorTests.java
+++ b/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/web/support/GoogleAccountsArgumentExtractorTests.java
@@ -63,7 +63,7 @@ public class GoogleAccountsArgumentExtractorTests extends AbstractOpenSamlTests 
         final ServicesManager servicesManager = mock(ServicesManager.class);
         
         this.extractor = new GoogleAccountsArgumentExtractor((PublicKey) pubKeyFactoryBean.getObject(), 
-                (PrivateKey) privKeyFactoryBean.getObject(), servicesManager);
+                (PrivateKey) privKeyFactoryBean.getObject());
     }
 
     @Test

--- a/cas-server-support-saml/src/test/resources/META-INF/spring/opensaml-config.xml
+++ b/cas-server-support-saml/src/test/resources/META-INF/spring/opensaml-config.xml
@@ -32,7 +32,7 @@
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
                            http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-    <context:component-scan base-package="org.jasig.cas.support.saml" annotation-config="true" />
+    <context:component-scan base-package="org.jasig.cas" annotation-config="true" />
     <context:annotation-config />
 
     <bean id="shibboleth.OpenSAMLConfig" class="org.jasig.cas.support.saml.OpenSamlConfigBean"


### PR DESCRIPTION
Closes #1205 

This is a problem with inflation of saml request that is now fixed. I also had to make the change to move the services manager out of the google service, and have it be dynamically looked up because I ran into serialization issues. 

This should be backported to 4.0.x and master.