### PR TITLE
Use TryResource syntax for LDAP connections

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/adaptors/ldap/services/LdapServiceRegistryDao.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/adaptors/ldap/services/LdapServiceRegistryDao.java
@@ -20,7 +20,6 @@ package org.jasig.cas.adaptors.ldap.services;
 
 import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServiceRegistryDao;
-import org.jasig.cas.util.LdapUtils;
 import org.ldaptive.AddOperation;
 import org.ldaptive.AddRequest;
 import org.ldaptive.AttributeModification;
@@ -100,23 +99,23 @@ public final class LdapServiceRegistryDao implements ServiceRegistryDao {
 
     @Override
     public RegisteredService save(final RegisteredService rs) {
-        if (rs.getId() != RegisteredService.INITIAL_IDENTIFIER_VALUE) {
-            return update(rs);
-        }
 
-        Connection connection = null;
-        try {
-            connection = getConnection();
-            final AddOperation operation = new AddOperation(connection);
+        if (this.ldapServiceMapper != null && this.searchRequest != null) {
+            if (rs.getId() != RegisteredService.INITIAL_IDENTIFIER_VALUE) {
+                return update(rs);
+            }
 
-            final LdapEntry entry = this.ldapServiceMapper.mapFromRegisteredService(this.searchRequest.getBaseDn(), rs);
-            operation.execute(new AddRequest(entry.getDn(), entry.getAttributes()));
-        } catch (final LdapException e) {
-            logger.error(e.getMessage(), e);
-        } finally {
-            LdapUtils.closeConnection(connection);
+            try (final Connection connection = getConnection()) {
+                final AddOperation operation = new AddOperation(connection);
+
+                final LdapEntry entry = this.ldapServiceMapper.mapFromRegisteredService(this.searchRequest.getBaseDn(), rs);
+                operation.execute(new AddRequest(entry.getDn(), entry.getAttributes()));
+            } catch (final LdapException e) {
+                logger.error(e.getMessage(), e);
+            }
+            return rs;
         }
-        return rs;
+        return null;
     }
 
     /**
@@ -126,17 +125,20 @@ public final class LdapServiceRegistryDao implements ServiceRegistryDao {
      * @return the registered service
      */
     private RegisteredService update(final RegisteredService rs) {
-        Connection searchConnection = null;
-        try {
-            searchConnection = getConnection();
+
+        if (ldapServiceMapper == null || searchRequest == null) {
+            return null;
+        }
+
+        try (final Connection searchConnection = getConnection()) {
+
             final Response<SearchResult> response = searchForServiceById(searchConnection, rs.getId());
             if (hasResults(response)) {
                 final String currentDn = response.getResult().getEntry().getDn();
 
-                Connection modifyConnection = null;
-                try {
-                    modifyConnection = getConnection();
-                    final ModifyOperation operation = new ModifyOperation(searchConnection);
+
+                try (final Connection modifyConnection = getConnection()) {
+                    final ModifyOperation operation = new ModifyOperation(modifyConnection);
 
                     final List<AttributeModification> mods = new ArrayList<>();
 
@@ -148,26 +150,20 @@ public final class LdapServiceRegistryDao implements ServiceRegistryDao {
                     }
                     final ModifyRequest request = new ModifyRequest(currentDn, mods.toArray(new AttributeModification[]{}));
                     operation.execute(request);
-                }catch (final LdapException e) {
+                } catch (final LdapException e) {
                     logger.error(e.getMessage(), e);
-                } finally {
-                    LdapUtils.closeConnection(modifyConnection);
                 }
             }
         } catch (final LdapException e) {
             logger.error(e.getMessage(), e);
-        } finally {
-            LdapUtils.closeConnection(searchConnection);
         }
         return rs;
     }
 
     @Override
     public boolean delete(final RegisteredService registeredService) {
-        Connection connection = null;
-        try {
-            connection = getConnection();
 
+        try (final Connection connection = getConnection()) {
             final Response<SearchResult> response = searchForServiceById(connection, registeredService.getId());
             if (hasResults(response)) {
                 final LdapEntry entry = response.getResult().getEntry();
@@ -178,19 +174,18 @@ public final class LdapServiceRegistryDao implements ServiceRegistryDao {
             }
         } catch (final LdapException e) {
             logger.error(e.getMessage(), e);
-        } finally {
-            LdapUtils.closeConnection(connection);
         }
-
         return false;
     }
 
     @Override
     public List<RegisteredService> load() {
-        Connection connection = null;
         final List<RegisteredService> list = new LinkedList<>();
-        try {
-            connection = getConnection();
+        if (ldapServiceMapper == null) {
+            return list;
+        }
+
+        try (final Connection connection = getConnection()) {
             final Response<SearchResult> response =
                     executeSearchOperation(connection, new SearchFilter(this.loadFilter));
             if (hasResults(response)) {
@@ -201,28 +196,24 @@ public final class LdapServiceRegistryDao implements ServiceRegistryDao {
             }
         } catch (final LdapException e) {
             logger.error(e.getMessage(), e);
-        } finally {
-            LdapUtils.closeConnection(connection);
         }
         return list;
     }
 
     @Override
     public RegisteredService findServiceById(final long id) {
-        Connection connection = null;
-        try {
-            connection = getConnection();
+        if (ldapServiceMapper == null) {
+            return null;
+        }
 
+        try (final Connection connection = getConnection()) {
             final Response<SearchResult> response = searchForServiceById(connection, id);
             if (hasResults(response)) {
                 return this.ldapServiceMapper.mapToRegisteredService(response.getResult().getEntry());
             }
         } catch (final LdapException e) {
             logger.error(e.getMessage(), e);
-        } finally {
-            LdapUtils.closeConnection(connection);
         }
-
         return null;
     }
 

--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/monitor/PooledConnectionFactoryMonitor.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/monitor/PooledConnectionFactoryMonitor.java
@@ -18,7 +18,6 @@
  */
 package org.jasig.cas.monitor;
 
-import org.jasig.cas.util.LdapUtils;
 import org.ldaptive.Connection;
 import org.ldaptive.pool.PooledConnectionFactory;
 import org.ldaptive.pool.Validator;
@@ -70,12 +69,12 @@ public class PooledConnectionFactoryMonitor extends AbstractPoolMonitor {
 
     @Override
     protected StatusCode checkPool() throws Exception {
-        final Connection conn = this.connectionFactory.getConnection();
-        try {
-            return this.validator.validate(conn) ? StatusCode.OK : StatusCode.ERROR;
-        } finally {
-            LdapUtils.closeConnection(conn);
+        if (this.connectionFactory != null && this.validator != null) {
+            try (final Connection conn = this.connectionFactory.getConnection()) {
+                return this.validator.validate(conn) ? StatusCode.OK : StatusCode.ERROR;
+            }
         }
+        return StatusCode.UNKNOWN;
     }
 
     @Override

--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
@@ -20,7 +20,6 @@ package org.jasig.cas.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.ldaptive.Connection;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.slf4j.Logger;
@@ -47,22 +46,6 @@ public final class LdapUtils {
      */
     private LdapUtils() {
         // private constructor so that no one can instantiate.
-    }
-
-    /**
-     * Close the given context and ignore any thrown exception. This is useful
-     * for typical finally blocks in manual Ldap statements.
-     *
-     * @param context the Ldap connection to close
-     */
-    public static void closeConnection(final Connection context) {
-        if (context != null && context.isOpen()) {
-            try {
-                context.close();
-            } catch (final Exception ex) {
-                LOGGER.warn("Could not close ldap connection", ex);
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Given the upgrade to ldaptive 1.1, we can now use the TryResource on LDAP connections, which removes the need to maintain LdapUtils.closeConnection. 