### PR TITLE
Fix bug in form validation for proxy service regex. CAS-1498

### DIFF
--- a/cas-management-webapp/src/main/webapp/js/app/app-angular.js
+++ b/cas-management-webapp/src/main/webapp/js/app/app-angular.js
@@ -420,6 +420,7 @@ if (array.length == 3) {
                     if (pattern == "")
                         return true;
                     var patt = new RegExp(pattern);
+		    return true;
                 } catch (e) {
                     return false;
                 }


### PR DESCRIPTION
Validation always fails if regexp is non-empty.

Closes https://github.com/Jasig/cas/issues/1247