### PR TITLE
Changes to InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter

### DIFF
--- a/cas-server-core-audit/src/main/resources/inspektr-jdbc-audit-config.xml
+++ b/cas-server-core-audit/src/main/resources/inspektr-jdbc-audit-config.xml
@@ -70,4 +70,26 @@
           p:isolationLevelName="ISOLATION_READ_COMMITTED"
           p:propagationBehaviorName="PROPAGATION_REQUIRED" />
 
+    <bean id="inspektrAuditEntityManagerFactory"
+          class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean"
+          p:dataSource-ref="inspektrAuditTrailDataSource">
+        <property name="jpaVendorAdapter">
+            <bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter"
+                  p:generateDdl="${cas.audit.database.gen.ddl:true}"
+                  p:showSql="${cas.audit.database.show.sql:true}" />
+        </property>
+        <property name="jpaProperties">
+            <props>
+                <prop key="hibernate.dialect">${cas.audit.database.dialect:org.hibernate.dialect.HSQLDialect}</prop>
+                <prop key="hibernate.hbm2ddl.auto">${cas.audit.database.ddl.auto:create-drop}</prop>
+                <prop key="hibernate.jdbc.batch_size">${cas.audit.database.batchSize:1}</prop>
+            </props>
+        </property>
+        <property name="packagesToScan">
+            <set>
+                <value>org.jasig.cas.web.support.entity</value>
+            </set>
+        </property>
+    </bean>
+
 </beans>

--- a/cas-server-core-audit/src/main/resources/inspektr-jdbc-audit-config.xml
+++ b/cas-server-core-audit/src/main/resources/inspektr-jdbc-audit-config.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Apereo under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work
+  ~ for additional information regarding copyright ownership.
+  ~ Apereo licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file
+  ~ except in compliance with the License.  You may obtain a
+  ~ copy of the License at the following location:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:sec="http://www.springframework.org/schema/security"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+       http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <bean id="auditCleanupCriteria"
+          class="org.jasig.inspektr.audit.support.MaxAgeWhereClauseMatchCriteria"
+          c:maxAgeDays="${cas.audit.max.agedays:180}" />
+
+    <bean id="auditTrailManager"
+          class="org.jasig.inspektr.audit.support.JdbcAuditTrailManager"
+          p:cleanupCriteria-ref="auditCleanupCriteria"
+          c:transactionTemplate-ref="inspektrAuditTransactionTemplate"
+          p:dataSource-ref="inspektrAuditTrailDataSource" />
+
+    <bean id="inspektrAuditTrailDataSource"
+          class="com.mchange.v2.c3p0.ComboPooledDataSource"
+          p:driverClass="${cas.audit.database.driverClass:org.hsqldb.jdbcDriver}"
+          p:jdbcUrl="${cas.audit.database.url:jdbc:hsqldb:hsql://localhost}"
+          p:user="${cas.audit.database.user:sa}"
+          p:password="${cas.audit.database.password:}"
+          p:initialPoolSize="${cas.audit.database.pool.minSize:6}"
+          p:minPoolSize="${cas.audit.database.pool.minSize:6}"
+          p:maxPoolSize="${cas.audit.database.pool.maxSize:18}"
+          p:maxIdleTimeExcessConnections="${cas.audit.database.pool.maxIdleTime:1000}"
+          p:checkoutTimeout="${cas.audit.database.pool.maxWait:2000}"
+          p:acquireIncrement="${cas.audit.database.pool.acquireIncrement:16}"
+          p:acquireRetryAttempts="${cas.audit.database.pool.acquireRetryAttempts:5}"
+          p:acquireRetryDelay="${cas.audit.database.pool.acquireRetryDelay:2000}"
+          p:idleConnectionTestPeriod="${cas.audit.database.pool.idleConnectionTestPeriod:30}"
+          p:preferredTestQuery="${cas.audit.database.pool.connectionHealthQuery:select 1}"/>
+
+    <bean id="inspektrAuditTransactionManager"
+          class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
+          p:dataSource-ref="inspektrAuditTrailDataSource" />
+
+    <bean id="inspektrAuditTransactionTemplate"
+          class="org.springframework.transaction.support.TransactionTemplate"
+          p:transactionManager-ref="inspektrAuditTransactionManager"
+          p:isolationLevelName="ISOLATION_READ_COMMITTED"
+          p:propagationBehaviorName="PROPAGATION_REQUIRED" />
+
+</beans>

--- a/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/UsernamePasswordCredential.java
+++ b/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/UsernamePasswordCredential.java
@@ -39,9 +39,6 @@ public class UsernamePasswordCredential implements Credential, Serializable {
     /** Unique ID for serialization. */
     private static final long serialVersionUID = -700605081472810939L;
 
-    /** Password suffix appended to username in string representation. */
-    private static final String PASSWORD_SUFFIX = "+password";
-
     /** The username. */
     @NotNull
     @Size(min=1, message = "required.username")
@@ -104,7 +101,7 @@ public class UsernamePasswordCredential implements Credential, Serializable {
 
     @Override
     public String toString() {
-        return this.username + PASSWORD_SUFFIX;
+        return this.username;
     }
 
     @Override

--- a/cas-server-documentation/installation/Audits.md
+++ b/cas-server-documentation/installation/Audits.md
@@ -1,0 +1,78 @@
+---
+layout: default
+title: CAS - Audit Configuration
+---
+
+#Audits
+CAS uses the [Inspektr framework](https://github.com/Jasig/inspektr) for auditing purposes
+and statistics. The Inspektr project allows for non-intrusive auditing and logging of the
+coarse-grained execution paths e.g. Spring-managed beans method executions by using annotations
+and Spring-managed `@Aspect`-style aspects.
+
+##Configuration
+Configuration of the audit trail manager is defined inside `deployerConfigContext.xml`.
+
+### File-based Audits
+By default, audit messages appear in log files via the `Slf4jLoggingAuditTrailManager` and are routed to
+a `cas_audit.log` file defined in the `log4j2.xml` configuration as well as the usual `cas.log` file.
+
+{% highlight properties %}
+# cas.audit.singleline=true
+# cas.audit.singleline.separator=|
+# cas.audit.appcode=CAS
+{% endhighlight %}
+
+###Database Audits
+If you intend to use a database
+for auditing functionality, adjust the audit manager to match the configuration below:
+
+{% highlight xml %}
+<import resource="classpath:inspektr-jdbc-audit-config.xml" />
+{% endhighlight %}
+
+
+#### Configuration
+Configuration consists of:
+
+{% highlight properties %}
+#cas.audit.max.agedays=
+#cas.audit.database.dialect=
+#cas.audit.database.batchSize=
+#cas.audit.database.ddl.auto=
+#cas.audit.database.gen.ddl=
+#cas.audit.database.show.sql=
+#cas.audit.database.driverClass=
+#cas.audit.database.url=
+#cas.audit.database.user=
+#cas.audit.database.password=
+#cas.audit.database.pool.minSize=
+#cas.audit.database.pool.minSize=
+#cas.audit.database.pool.maxSize=
+#cas.audit.database.pool.maxIdleTime=
+#cas.audit.database.pool.maxWait=
+#cas.audit.database.pool.acquireIncrement=
+#cas.audit.database.pool.acquireRetryAttempts=
+#cas.audit.database.pool.acquireRetryDelay=
+#cas.audit.database.pool.idleConnectionTestPeriod=
+#cas.audit.database.pool.connectionHealthQuery=
+{% endhighlight %}
+
+
+##Sample Log Output
+{% highlight bash %}
+WHO: org.jasig.cas.support.oauth.authentication.principal.OAuthCredentials@6cd7c975
+WHAT: supplied credentials: org.jasig.cas.support.oauth.authentication.principal.OAuthCredentials@6cd7c975
+ACTION: AUTHENTICATION_SUCCESS
+APPLICATION: CAS
+WHEN: Mon Aug 26 12:35:59 IST 2013
+CLIENT IP ADDRESS: 172.16.5.181
+SERVER IP ADDRESS: 192.168.200.22
+
+WHO: org.jasig.cas.support.oauth.authentication.principal.OAuthCredentials@6cd7c975
+WHAT: TGT-9-qj2jZKQUmu1gQvXNf7tXQOJPOtROvOuvYAxybhZiVrdZ6pCUwW-cas01.example.org
+ACTION: TICKET_GRANTING_TICKET_CREATED
+APPLICATION: CAS
+WHEN: Mon Aug 26 12:35:59 IST 2013
+CLIENT IP ADDRESS: 172.16.5.181
+SERVER IP ADDRESS: 192.168.200.22
+{% endhighlight %}

--- a/cas-server-documentation/installation/Configuring-Authentication-Throttling.md
+++ b/cas-server-documentation/installation/Configuring-Authentication-Throttling.md
@@ -43,21 +43,21 @@ The _inspektr_ components, on the other hand, fully support stateless clusters.
 
 ## Components
 
-###`InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapter`
+###IP Address
 Uses a memory map to prevent successive failed login attempts from the same IP address.
 {% highlight xml %}
 <alias name="inMemoryIpAddressThrottle" alias="authenticationThrottle" />
 {% endhighlight %}
 
 
-###`InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter`
+###IP Address + Username
 Uses a memory map to prevent successive failed login attempts for a particular username from the same IP address.
 
 {% highlight xml %}
 <alias name="inMemoryIpAddressUsernameThrottle" alias="authenticationThrottle" />
 {% endhighlight %}
 
-###`InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter`
+###Inspektr + JDBC
 Queries the data source used by the CAS audit facility to prevent successive failed login attempts for a particular
 username from the same IP address. This component requires that the
 [inspektr library](https://github.com/Jasig/inspektr) used for CAS auditing be configured with
@@ -65,14 +65,7 @@ username from the same IP address. This component requires that the
 {% highlight xml %}
 
 <alias name="inspektrIpAddressUsernameThrottle" alias="authenticationThrottle" />
-
-<bean id="auditTrailDataSource" ... />
-
-<bean id="auditTrailManager"
-      class="org.jasig.inspektr.audit.support.JdbcAuditTrailManager"
-      c:transactionTemplate-ref="inspektrTransactionTemplate"
-      p:dataSource-ref="auditTrailDataSource" />
-{% endhighlight %}
+<import resource="classpath:inspektr-throttle-jdbc-config.xml" />
 
 For additional instructions on how to configure auditing via Inspektr,
 please [review the following guide](Logging.html).
@@ -81,10 +74,10 @@ please [review the following guide](Logging.html).
 Login throttling configuration consists of:
 
 {% highlight properties %}
-# cas.throttle.failure.threshold=
-# cas.throttle.failure.range.seconds=
-# cas.throttle.username.parameter=
-# cas.throttle.appcode=
-# cas.throttle.authn.failurecode=
-# cas.throttle.audit.query=
+#cas.throttle.failure.threshold=
+#cas.throttle.failure.range.seconds=
+#cas.throttle.username.parameter=
+#cas.throttle.appcode=
+#cas.throttle.authn.failurecode=
+#cas.throttle.audit.query=
 {% endhighlight %}

--- a/cas-server-documentation/sidebar.html
+++ b/cas-server-documentation/sidebar.html
@@ -67,7 +67,8 @@
           <li><a href="/$version/installation/JPA-Service-Management.html">JPA Service Management</a></li>
     </ul>
   </li>
-  <li><a href="/$version/installation/Logging.html">Logging & Audits</a></li>
+  <li><a href="/$version/installation/Logging.html">Logging</a></li>
+  <li><a href="/$version/installation/Audits.html">Audits</a></li>
   <li><a href="/$version/installation/Monitoring-Statistics.html">Monitoring & Statistics</a></li>
   <li><a href="/$version/installation/User-Interface-Customization.html">UI Customization</a></li>
   <li><a href="/$version/installation/Webflow-Customization.html">Webflow Customization</a></li>

--- a/cas-server-webapp-throttle/pom.xml
+++ b/cas-server-webapp-throttle/pom.xml
@@ -90,6 +90,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/cas-server-webapp-throttle/pom.xml
+++ b/cas-server-webapp-throttle/pom.xml
@@ -47,10 +47,15 @@
             <scope>compile</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.jasig.inspektr</groupId>
             <artifactId>inspektr-audit</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jasig.inspektr</groupId>
+            <artifactId>inspektr-support-spring</artifactId>
             <scope>compile</scope>
         </dependency>
 

--- a/cas-server-webapp-throttle/pom.xml
+++ b/cas-server-webapp-throttle/pom.xml
@@ -50,12 +50,24 @@
         <dependency>
             <groupId>org.jasig.inspektr</groupId>
             <artifactId>inspektr-audit</artifactId>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jasig.inspektr</groupId>
             <artifactId>inspektr-support-spring</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
             <scope>compile</scope>
         </dependency>
 

--- a/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -157,7 +157,7 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
      * @param request the request
      */
     protected void recordThrottle(final HttpServletRequest request) {
-        logger.warn("Throttling submission from {}.  More than {} failed login attempts within {} seconds. "
+        logger.warn("Throttling submission from {}. More than {} failed login attempts within {} seconds. "
                 + "Authentication attempt exceeds the failure threshold {}",
                 request.getRemoteAddr(), this.failureThreshold, this.failureRangeInSeconds,
                 this.failureThreshold);

--- a/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.sql.DataSource;
-import javax.validation.constraints.Null;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;

--- a/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/entity/AuditTrailEntity.java
+++ b/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/entity/AuditTrailEntity.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.cas.web.support.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
+
+/**
+ * This is {@link AuditTrailEntity} that represents the audit table.
+ * Schema is generated automatically.
+ *
+ * @author Misagh Moayyed
+ * @since 4.2.0
+ */
+@Entity(name="COM_AUDIT_TRAIL")
+public class AuditTrailEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="AUD_USER")
+    private String user;
+
+    @Column(name="AUD_CLIENT_IP")
+    private String clientIp;
+
+    @Column(name="AUD_SERVER_IP")
+    private String serverIp;
+
+    @Column(name="AUD_RESOURCE")
+    private String resource;
+
+    @Column(name="AUD_ACTION")
+    private String action;
+
+    @Column(name="APPLIC_CD")
+    private String applicationCode;
+
+    @Column(name="AUD_DATE", nullable=false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date date;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(final String user) {
+        this.user = user;
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public void setClientIp(final String clientIp) {
+        this.clientIp = clientIp;
+    }
+
+    public String getServerIp() {
+        return serverIp;
+    }
+
+    public void setServerIp(final String serverIp) {
+        this.serverIp = serverIp;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(final String resource) {
+        this.resource = resource;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(final String action) {
+        this.action = action;
+    }
+
+    public String getApplicationCode() {
+        return applicationCode;
+    }
+
+    public void setApplicationCode(final String applicationCode) {
+        this.applicationCode = applicationCode;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(final Date date) {
+        this.date = date;
+    }
+}

--- a/cas-server-webapp-throttle/src/main/resources/inspektr-throttle-jdbc-config.xml
+++ b/cas-server-webapp-throttle/src/main/resources/inspektr-throttle-jdbc-config.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Apereo under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work
+  ~ for additional information regarding copyright ownership.
+  ~ Apereo licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file
+  ~ except in compliance with the License.  You may obtain a
+  ~ copy of the License at the following location:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:sec="http://www.springframework.org/schema/security"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+       http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <import resource="classpath:inspektr-jdbc-audit-config.xml" />
+
+    <bean id="throttleInspektrEntityManagerFactory"
+              class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean"
+              p:dataSource-ref="inspektrAuditTrailDataSource">
+        <property name="jpaVendorAdapter">
+            <bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter"
+                  p:generateDdl="${cas.throttle.database.gen.ddl:true}"
+                  p:showSql="${cas.throttle.database.show.sql:true}" />
+        </property>
+        <property name="jpaProperties">
+            <props>
+                <prop key="hibernate.dialect">${cas.throttle.database.dialect:org.hibernate.dialect.HSQLDialect}</prop>
+                <prop key="hibernate.hbm2ddl.auto">${cas.throttle.database.ddl.auto:create-drop}</prop>
+                <prop key="hibernate.jdbc.batch_size">${cas.throttle.database.batchSize:1}</prop>
+            </props>
+        </property>
+        <property name="packagesToScan">
+            <set>
+                <value>org.jasig.cas.web.support.entity</value>
+            </set>
+        </property>
+    </bean>
+
+</beans>

--- a/cas-server-webapp-throttle/src/main/resources/inspektr-throttle-jdbc-config.xml
+++ b/cas-server-webapp-throttle/src/main/resources/inspektr-throttle-jdbc-config.xml
@@ -35,26 +35,4 @@
 
     <import resource="classpath:inspektr-jdbc-audit-config.xml" />
 
-    <bean id="throttleInspektrEntityManagerFactory"
-              class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean"
-              p:dataSource-ref="inspektrAuditTrailDataSource">
-        <property name="jpaVendorAdapter">
-            <bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter"
-                  p:generateDdl="${cas.throttle.database.gen.ddl:true}"
-                  p:showSql="${cas.throttle.database.show.sql:true}" />
-        </property>
-        <property name="jpaProperties">
-            <props>
-                <prop key="hibernate.dialect">${cas.throttle.database.dialect:org.hibernate.dialect.HSQLDialect}</prop>
-                <prop key="hibernate.hbm2ddl.auto">${cas.throttle.database.ddl.auto:create-drop}</prop>
-                <prop key="hibernate.jdbc.batch_size">${cas.throttle.database.batchSize:1}</prop>
-            </props>
-        </property>
-        <property name="packagesToScan">
-            <set>
-                <value>org.jasig.cas.web.support.entity</value>
-            </set>
-        </property>
-    </bean>
-
 </beans>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -171,6 +171,10 @@
             <groupId>org.jasig</groupId>
             <artifactId>spring-webflow-client-repo</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>c3p0</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cas-server-webapp/src/main/resources/log4j2.xml
+++ b/cas-server-webapp/src/main/resources/log4j2.xml
@@ -72,7 +72,7 @@
         <AsyncLogger name="org.jasig.cas.web.flow" level="info" additivity="true" includeLocation="true">
             <AppenderRef ref="file"/>
         </AsyncLogger>
-        <AsyncLogger name="org.jasig.inspektr.audit.support.Slf4jLoggingAuditTrailManager" level="info" includeLocation="true">
+        <AsyncLogger name="org.jasig.inspektr.audit.support" level="info" includeLocation="true">
             <AppenderRef ref="auditlogfile"/>
             <AppenderRef ref="file"/>
         </AsyncLogger>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -173,12 +173,12 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 ##
 # CAS Authentication Throttling
 #
-# cas.throttle.failure.threshold=
-# cas.throttle.failure.range.seconds=
-# cas.throttle.username.parameter=
-# cas.throttle.appcode=
-# cas.throttle.authn.failurecode=
-# cas.throttle.audit.query=
+#cas.throttle.failure.threshold=
+#cas.throttle.failure.range.seconds=
+#cas.throttle.username.parameter=
+#cas.throttle.appcode=
+#cas.throttle.authn.failurecode=
+#cas.throttle.audit.query=
 
 ##
 # CAS Health Monitoring
@@ -294,6 +294,29 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 # cas.audit.singleline.separator=|
 # Application code for audits
 # cas.audit.appcode=CAS
+#
+## JDBC Audits
+#
+#cas.audit.max.agedays=
+#cas.audit.database.dialect=
+#cas.audit.database.batchSize=
+#cas.audit.database.ddl.auto=
+#cas.audit.database.gen.ddl=
+#cas.audit.database.show.sql=
+#cas.audit.database.driverClass=
+#cas.audit.database.url=
+#cas.audit.database.user=
+#cas.audit.database.password=
+#cas.audit.database.pool.minSize=
+#cas.audit.database.pool.minSize=
+#cas.audit.database.pool.maxSize=
+#cas.audit.database.pool.maxIdleTime=
+#cas.audit.database.pool.maxWait=
+#cas.audit.database.pool.acquireIncrement=
+#cas.audit.database.pool.acquireRetryAttempts=
+#cas.audit.database.pool.acquireRetryDelay=
+#cas.audit.database.pool.idleConnectionTestPeriod=
+#cas.audit.database.pool.connectionHealthQuery=
 
 ##
 # Metrics

--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -87,12 +87,40 @@
     <alias name="anyAuthenticationPolicy" alias="authenticationPolicy" />
     <alias name="acceptAnyAuthenticationPolicyFactory" alias="authenticationPolicyFactory" />
 
-    <alias name="neverThrottle" alias="authenticationThrottle" />
+    <alias name="inspektrIpAddressUsernameThrottle" alias="authenticationThrottle" />
+
+    <bean
+        id="auditTrailDataSource"
+        class="com.mchange.v2.c3p0.ComboPooledDataSource"
+        p:driverClass="${svcreg.database.driverClass:org.hsqldb.jdbcDriver}"
+        p:jdbcUrl="${svcreg.database.url:jdbc:hsqldb:mem:cas-service-registry}"
+        p:user="${svcreg.database.user:sa}"
+        p:password="${svcreg.database.password:}"
+        p:initialPoolSize="${svcreg.database.pool.minSize:6}"
+        p:minPoolSize="${svcreg.database.pool.minSize:6}"
+        p:maxPoolSize="${svcreg.database.pool.maxSize:18}"
+        p:maxIdleTimeExcessConnections="${svcreg.database.pool.maxIdleTime:1000}"
+        p:checkoutTimeout="${svcreg.database.pool.maxWait:2000}"
+        p:acquireIncrement="${svcreg.database.pool.acquireIncrement:16}"
+        p:acquireRetryAttempts="${svcreg.database.pool.acquireRetryAttempts:5}"
+        p:acquireRetryDelay="${svcreg.database.pool.acquireRetryDelay:2000}"
+        p:idleConnectionTestPeriod="${svcreg.database.pool.idleConnectionTestPeriod:30}"
+        p:preferredTestQuery="${svcreg.database.pool.connectionHealthQuery:select 1}"/>
 
     <bean id="auditTrailManager"
-          class="org.jasig.inspektr.audit.support.Slf4jLoggingAuditTrailManager"
-          p:entrySeparator="${cas.audit.singleline.separator:|}"
-          p:useSingleLine="${cas.audit.singleline:false}"/>
+          class="org.jasig.inspektr.audit.support.JdbcAuditTrailManager"
+          c:transactionTemplate-ref="inspektrTransactionTemplate"
+          p:dataSource-ref="auditTrailDataSource" />
+
+    <bean id="inspektrTransactionManager"
+          class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
+          p:dataSource-ref="auditTrailDataSource" />
+
+    <bean id="inspektrTransactionTemplate"
+          class="org.springframework.transaction.support.TransactionTemplate"
+          p:transactionManager-ref="inspektrTransactionManager"
+          p:isolationLevelName="ISOLATION_READ_COMMITTED"
+          p:propagationBehaviorName="PROPAGATION_REQUIRED" />
 
     <util:list id="monitorsList">
         <ref bean="memoryMonitor" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -87,40 +87,12 @@
     <alias name="anyAuthenticationPolicy" alias="authenticationPolicy" />
     <alias name="acceptAnyAuthenticationPolicyFactory" alias="authenticationPolicyFactory" />
 
-    <alias name="inspektrIpAddressUsernameThrottle" alias="authenticationThrottle" />
-
-    <bean
-        id="auditTrailDataSource"
-        class="com.mchange.v2.c3p0.ComboPooledDataSource"
-        p:driverClass="${svcreg.database.driverClass:org.hsqldb.jdbcDriver}"
-        p:jdbcUrl="${svcreg.database.url:jdbc:hsqldb:mem:cas-service-registry}"
-        p:user="${svcreg.database.user:sa}"
-        p:password="${svcreg.database.password:}"
-        p:initialPoolSize="${svcreg.database.pool.minSize:6}"
-        p:minPoolSize="${svcreg.database.pool.minSize:6}"
-        p:maxPoolSize="${svcreg.database.pool.maxSize:18}"
-        p:maxIdleTimeExcessConnections="${svcreg.database.pool.maxIdleTime:1000}"
-        p:checkoutTimeout="${svcreg.database.pool.maxWait:2000}"
-        p:acquireIncrement="${svcreg.database.pool.acquireIncrement:16}"
-        p:acquireRetryAttempts="${svcreg.database.pool.acquireRetryAttempts:5}"
-        p:acquireRetryDelay="${svcreg.database.pool.acquireRetryDelay:2000}"
-        p:idleConnectionTestPeriod="${svcreg.database.pool.idleConnectionTestPeriod:30}"
-        p:preferredTestQuery="${svcreg.database.pool.connectionHealthQuery:select 1}"/>
-
     <bean id="auditTrailManager"
-          class="org.jasig.inspektr.audit.support.JdbcAuditTrailManager"
-          c:transactionTemplate-ref="inspektrTransactionTemplate"
-          p:dataSource-ref="auditTrailDataSource" />
+          class="org.jasig.inspektr.audit.support.Slf4jLoggingAuditTrailManager"
+          p:entrySeparator="${cas.audit.singleline.separator:|}"
+          p:useSingleLine="${cas.audit.singleline:false}"/>
 
-    <bean id="inspektrTransactionManager"
-          class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
-          p:dataSource-ref="auditTrailDataSource" />
-
-    <bean id="inspektrTransactionTemplate"
-          class="org.springframework.transaction.support.TransactionTemplate"
-          p:transactionManager-ref="inspektrTransactionManager"
-          p:isolationLevelName="ISOLATION_READ_COMMITTED"
-          p:propagationBehaviorName="PROPAGATION_REQUIRED" />
+    <alias name="neverThrottle" alias="authenticationThrottle" />
 
     <util:list id="monitorsList">
         <ref bean="memoryMonitor" />


### PR DESCRIPTION
Closes https://github.com/Jasig/cas/issues/1173

* Updated docs and added support for auto-config
* Made sure attempts are recorded by the audit manager
* Default config is switched to point to a local hsqldb database for simplicity
* Logging just the userid now, rather than a formatted version
