### PR TITLE
Ldap services fix

### DIFF
--- a/cas-management-webapp/src/main/java/org/jasig/cas/services/web/RegisteredServiceSimpleFormController.java
+++ b/cas-management-webapp/src/main/java/org/jasig/cas/services/web/RegisteredServiceSimpleFormController.java
@@ -83,12 +83,6 @@ public final class RegisteredServiceSimpleFormController extends AbstractManagem
         try {
 
             final RegisteredService svcToUse = service.toRegisteredService(this.personAttributeDao);
-            if (svcToUse.getId() != RegisteredService.INITIAL_IDENTIFIER_VALUE) {
-                final RegisteredService curService = this.servicesManager.findServiceBy(svcToUse.getId());
-                if (curService != null && this.servicesManager.delete(curService.getId()) == null) {
-                    throw new IllegalArgumentException("Service " + curService.getId() + " cannot be updated");
-                }
-            }
 
             final RegisteredService newSvc = this.servicesManager.save(svcToUse);
             logger.info("Saved changes to service {}", svcToUse.getId());

--- a/cas-server-core/src/test/java/org/jasig/cas/services/InMemoryServiceRegistryDaoImplTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/InMemoryServiceRegistryDaoImplTests.java
@@ -22,6 +22,8 @@ package org.jasig.cas.services;
 import org.jasig.cas.TestUtils;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 /**
@@ -67,5 +69,32 @@ public class InMemoryServiceRegistryDaoImplTests {
         assertEquals(reg.save(svc), svc);
         assertTrue(reg.delete(svc));
         assertEquals(reg.load().size(), 0);
+    }
+
+    @Test
+    public void verifyEdit()  {
+        final InMemoryServiceRegistryDaoImpl reg = new InMemoryServiceRegistryDaoImpl();
+        final RegisteredServiceImpl r = new RegisteredServiceImpl();
+        r.setName("test");
+        r.setServiceId("testId");
+        r.setTheme("theme");
+        r.setDescription("description");
+
+        reg.save(r);
+
+        final List<RegisteredService> services = reg.load();
+
+        final RegisteredService r2 = services.get(0);
+
+        r.setId(r2.getId());
+        r.setTheme("mytheme");
+
+        reg.save(r);
+
+        final RegisteredService r3 = reg.findServiceById(r.getId());
+
+        assertEquals(r, r3);
+        assertEquals(r.getTheme(), r3.getTheme());
+        reg.delete(r);
     }
 }

--- a/cas-server-core/src/test/java/org/jasig/cas/services/JsonServiceRegistryDaoTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/JsonServiceRegistryDaoTests.java
@@ -340,4 +340,29 @@ public class JsonServiceRegistryDaoTests {
         assertNotNull(this.dao.findServiceById(r.getId()));
     }
 
+    @Test
+    public void verifyEdit()  {
+        final RegisteredServiceImpl r = new RegisteredServiceImpl();
+        r.setName("test");
+        r.setServiceId("testId");
+        r.setTheme("theme");
+        r.setDescription("description");
+
+        this.dao.save(r);
+
+        final List<RegisteredService> services = this.dao.load();
+
+        final RegisteredService r2 = services.get(0);
+
+        r.setId(r2.getId());
+        r.setTheme("mytheme");
+
+        this.dao.save(r);
+
+        final RegisteredService r3 = this.dao.findServiceById(r.getId());
+
+        assertEquals(r, r3);
+        assertEquals(r.getTheme(), r3.getTheme());
+        this.dao.delete(r);
+    }
 }

--- a/cas-server-integration-mongo/src/test/java/org/jasig/cas/services/MongoServiceRegistryDaoTests.java
+++ b/cas-server-integration-mongo/src/test/java/org/jasig/cas/services/MongoServiceRegistryDaoTests.java
@@ -61,6 +61,32 @@ public class MongoServiceRegistryDaoTests {
         assertTrue(this.serviceRegistryDao.load().isEmpty());
     }
 
+    @Test
+    public void verifyEdit()  {
+          final RegisteredServiceImpl r = new RegisteredServiceImpl();
+          r.setName("test");
+          r.setServiceId("testId");
+          r.setTheme("theme");
+          r.setDescription("description");
+
+          this.serviceRegistryDao.save(r);
+
+          final List<RegisteredService> services = this.serviceRegistryDao.load();
+
+          final RegisteredService r2 = services.get(0);
+
+          r.setId(r2.getId());
+          r.setTheme("mytheme");
+
+          this.serviceRegistryDao.save(r);
+
+          final RegisteredService r3 = this.serviceRegistryDao.findServiceById(r.getId());
+
+          assertEquals(r, r3);
+          assertEquals(r.getTheme(), r3.getTheme());
+          this.serviceRegistryDao.delete(r);
+    }
+
     private RegisteredService buildService(final int i) {
         return TestUtils.getRegisteredService("^http://www.serviceid" + i + ".org");
     }

--- a/cas-server-support-jdbc/src/test/java/org/jasig/cas/services/JpaServiceRegistryDaoImplTests.java
+++ b/cas-server-support-jdbc/src/test/java/org/jasig/cas/services/JpaServiceRegistryDaoImplTests.java
@@ -93,7 +93,7 @@ public class JpaServiceRegistryDaoImplTests extends AbstractTransactionalJUnit4S
 
         final RegisteredService r3 = this.dao.findServiceById(r.getId());
 
-        assertEquals(r, r2);
+        assertEquals(r, r3);
         assertEquals(r.getTheme(), r3.getTheme());
     }
 


### PR DESCRIPTION
Removes an extra delete from the edit workflow since the DAO uses a modify not an add for edits.

Without this, the service management web app will delete the service then the DAO will fail to find it for updating.