### PR TITLE
fix redirect loop on password expiration warning

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginMessageView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginMessageView.jsp
@@ -30,8 +30,13 @@
 
 </div>
 
+<c:url value="login" var="url">
+  <c:param name="execution" value="${flowExecutionKey}" />
+  <c:param name="_eventId" value="proceed" />
+</c:url>
+
 <div id="big-buttons">
- <a class="button" href="login?execution=${flowExecutionKey}&_eventId=proceed">Continue</a>
+ <a class="button" href="${url}">Continue</a>
 </div>
 
 <jsp:directive.include file="includes/bottom.jsp" />


### PR DESCRIPTION
Enabling LPPE causes a redirect loop. This is due to the `execution` parameter not being URL encoded causing it to decode improperly when it includes `+` characters. These get decoded to spaces by the web server before it gets passed to the application.
