### PR TITLE
#1274 fix typo in cas protocol 3 spec and add example response

### DIFF
--- a/cas-server-documentation/protocol/CAS-Protocol-Specification.md
+++ b/cas-server-documentation/protocol/CAS-Protocol-Specification.md
@@ -1603,7 +1603,19 @@ to the CAS client.
 
 {% highlight xml %}
 <cas:attributes>
-    <cas:[attribute-name]>VALUE</cas:attribute>
+    ...
+    <cas:[attribute-name]>VALUE</cas:[attribute-name]>
+</cas:attributes>
+{% endhighlight %}
+
+> Example response with custom attribute:
+
+{% highlight xml %}
+<cas:attributes>
+    <cas:authenticationDate>2015-11-12T09:30:10Z</cas:authenticationDate>
+    <cas:longTermAuthenticationRequestTokenUsed>true</cas:longTermAuthenticationRequestTokenUsed>
+    <cas:isFromNewLogin>true</cas:isFromNewLogin>
+    <cas:myAttribute>myValue</cas:myAttribute>
 </cas:attributes>
 {% endhighlight %}
 


### PR DESCRIPTION
Fixed semantic typo and added an example custom attribute snippet to the spec doc.

(my previous local branch GH_1274 was published to the jasig repo by my beloved Tower git client - grr). Deleted the branch in the cas repo and published into my gh clone repo.)