### PR TITLE
create a new Array for modified args

### DIFF
--- a/cas-server-core/src/main/java/org/slf4j/impl/CasDelegatingLogger.java
+++ b/cas-server-core/src/main/java/org/slf4j/impl/CasDelegatingLogger.java
@@ -87,12 +87,15 @@ public final class CasDelegatingLogger extends MarkerIgnoringBase implements Ser
      * @return sanitized arguments
      */
     private Object[] manipulateLogArguments(final Object... args) {
+        final Object[] out = new Object[args.length];
         for (int i = 0; i < args.length; i++) {
             if (args[i] != null) {
-                args[i] = removeTicketId(args[i].toString());
+                out[i] = removeTicketId(args[i].toString());
+            } else {
+                out[i] = null;
             }
         }
-        return args;
+        return out;
     }
 
     /**


### PR DESCRIPTION
the source args Array may not be a superclass of the String class.

Closes #1300 
Backport of #1301 to 4.1.x