### PR TITLE
Fix a possible issue with Google Apps SAML2 timezones

### DIFF
--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
@@ -28,7 +28,6 @@ import org.jasig.cas.support.saml.SamlProtocolConstants;
 import org.jasig.cas.support.saml.util.AbstractSaml20ObjectBuilder;
 import org.jasig.cas.support.saml.util.GoogleSaml20ObjectBuilder;
 import org.jasig.cas.util.ApplicationContextProvider;
-import org.jasig.cas.util.ISOStandardDateFormat;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.joda.time.DateTime;

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsService.java
@@ -168,7 +168,7 @@ public class GoogleAccountsService extends AbstractWebApplicationService {
      * @return the SAML response
      */
     private String constructSamlResponse() {
-        final DateTime currentDateTime = DateTime.parse(new ISOStandardDateFormat().getCurrentDateAndTime());
+        final DateTime currentDateTime = new DateTime();
         final DateTime notBeforeIssueInstant = DateTime.parse("2003-04-17T00:46:02Z");
 
         final ApplicationContext context = ApplicationContextProvider.getApplicationContext();


### PR DESCRIPTION
Fix an issue with the time zone being ignored, which caused the googleapps auth to expire. Removing the ISOStandardDateFormat seems to fix it