### PR TITLE
Introduce PrincipalIdProvider strategy

### DIFF
--- a/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/PrincipalIdProvider.java
+++ b/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/PrincipalIdProvider.java
@@ -1,0 +1,25 @@
+package org.jasig.cas.audit.spi;
+
+import org.jasig.cas.authentication.Authentication;
+
+/**
+ * Strategy interface to provide principal id tokens from any given authentication event.
+ *
+ * Useful for authentication scenarios where there is not only one primary principal id available, but additional authentication metadata
+ * in addition to custom requirement to compute and show more complex principal identifier for auditing purposes.
+ * An example would be compound ids resulted from multi-legged mfa authentications, 'surrogate' authentications, etc.
+ *
+ * @author Dmitriy Kopylenko
+ * @since 4.2.0
+ */
+public interface PrincipalIdProvider {
+
+    /**
+     * Return principal id from a given authentication event.
+     *
+     * @param authentication authentication event containing the data to computed the final principal id from
+     *
+     * @return computed principal id
+     */
+    String getPrincipalIdFrom(Authentication authentication);
+}

--- a/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/TicketOrCredentialPrincipalResolver.java
+++ b/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/TicketOrCredentialPrincipalResolver.java
@@ -13,6 +13,7 @@ import org.jasig.inspektr.common.spi.PrincipalResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
@@ -36,6 +37,7 @@ public final class TicketOrCredentialPrincipalResolver implements PrincipalResol
     private CentralAuthenticationService centralAuthenticationService;
 
     @Autowired(required = false)
+    @Qualifier("principalIdProvider")
     private PrincipalIdProvider principalIdProvider = new DefaultPrincipalIdProvider();
 
     private TicketOrCredentialPrincipalResolver() {}

--- a/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/TicketOrCredentialPrincipalResolver.java
+++ b/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/TicketOrCredentialPrincipalResolver.java
@@ -125,7 +125,7 @@ public final class TicketOrCredentialPrincipalResolver implements PrincipalResol
     /**
      * Default implementation that simply returns principal#id.
      */
-    public static class DefaultPrincipalIdProvider implements PrincipalIdProvider {
+    static class DefaultPrincipalIdProvider implements PrincipalIdProvider {
 
         @Override
         public String getPrincipalIdFrom(final org.jasig.cas.authentication.Authentication authentication) {

--- a/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/TicketOrCredentialPrincipalResolver.java
+++ b/cas-server-core-audit/src/main/java/org/jasig/cas/audit/spi/TicketOrCredentialPrincipalResolver.java
@@ -2,6 +2,7 @@ package org.jasig.cas.audit.spi;
 
 import org.aspectj.lang.JoinPoint;
 import org.jasig.cas.CentralAuthenticationService;
+import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.Credential;
 import org.jasig.cas.ticket.InvalidTicketException;
 import org.jasig.cas.ticket.ServiceTicket;
@@ -104,13 +105,13 @@ public final class TicketOrCredentialPrincipalResolver implements PrincipalResol
         } else if (arg1 instanceof String) {
             try {
                 final Ticket ticket = this.centralAuthenticationService.getTicket((String) arg1, Ticket.class);
-                org.jasig.cas.authentication.Authentication casAuthentication = null;
+                Authentication authentication = null;
                 if (ticket instanceof ServiceTicket) {
-                    casAuthentication = ServiceTicket.class.cast(ticket).getGrantingTicket().getAuthentication();
+                    authentication = ServiceTicket.class.cast(ticket).getGrantingTicket().getAuthentication();
                 } else if (ticket instanceof TicketGrantingTicket) {
-                    casAuthentication = TicketGrantingTicket.class.cast(ticket).getAuthentication();
+                    authentication = TicketGrantingTicket.class.cast(ticket).getAuthentication();
                 }
-                return this.principalIdProvider.getPrincipalIdFrom(casAuthentication);
+                return this.principalIdProvider.getPrincipalIdFrom(authentication);
             } catch (final InvalidTicketException e) {
                 LOGGER.trace(e.getMessage(), e);
             }
@@ -128,7 +129,7 @@ public final class TicketOrCredentialPrincipalResolver implements PrincipalResol
     static class DefaultPrincipalIdProvider implements PrincipalIdProvider {
 
         @Override
-        public String getPrincipalIdFrom(final org.jasig.cas.authentication.Authentication authentication) {
+        public String getPrincipalIdFrom(final Authentication authentication) {
             return authentication.getPrincipal().getId();
         }
     }


### PR DESCRIPTION
This is a pluggable strategy interface that would be useful for use cases that require more audit logging of more complex principal ids (authenticated entities) in case of more complex authentication scenarios - for example a "surrogate" authentication scenario where there is a "real" and "surrogate" principal ids involved. With the current implementation of just getting the `principal#id` that would not be possible. With this strategy API, a custom implementation would be provided that would compute the compound principal id to display in the `WHO` field based on the provided `Authentication` metadata available for that scenario, etc.

With a custom implementation, the "surrogate" case might look like this:

```bash
=============================================================
WHO: (Real user: [casuser], Surrogate user: [surrogateuser])
WHAT: TGT-**********************************************tmNDj1KIoP-cas.university.edu
ACTION: TICKET_GRANTING_TICKET_CREATED
APPLICATION: CAS
WHEN: Thu Dec 17 14:27:53 EST 2015
CLIENT IP ADDRESS: 127.0.0.1
SERVER IP ADDRESS: 127.0.0.1
=============================================================
```


