### PR TITLE
Correction of LDAP AuthN documentation

### DIFF
--- a/cas-server-documentation/installation/LDAP-Authentication.md
+++ b/cas-server-documentation/installation/LDAP-Authentication.md
@@ -10,12 +10,12 @@ LDAP integration is enabled by including the following dependency in the Maven W
 <dependency>
      <groupId>org.jasig.cas</groupId>
      <artifactId>cas-server-support-ldap</artifactId>
-     <version>${cas.version}</version>
+     <version>${project.version}</version>
 </dependency>
 {% endhighlight %}
 
 `LdapAuthenticationHandler` authenticates a username/password against an LDAP directory such as Active Directory
-or OpenLDAP. There are numerous directory architectures and we provide configuration for four common cases:
+or OpenLDAP. There are numerous directory architectures and we provide configuration for these common cases:
 
 1. [Active Directory](#active-directory-authentication) - Users authenticate with _sAMAAccountName_.
 2. [Authenticated Search](#ldap-requiring-authenticated-search) - Manager bind/search followed by user simple bind.
@@ -227,10 +227,10 @@ followed by a bind. Copy the configuration to `deployerConfigContext.xml` and pr
 
 <bean id="bindConnectionInitializer"
       class="org.ldaptive.BindConnectionInitializer"
-      p:bindDn="${ldap.managerDn}">
+      p:bindDn="${ldap.authn.managerDN}">
     <property name="bindCredential">
         <bean class="org.ldaptive.Credential"
-              c:password="${ldap.managerPassword}" />
+              c:password="${ldap.authn.managerPassword}" />
     </property>
 </bean>
 
@@ -500,7 +500,7 @@ into the Spring application context by modifying the `propertyFileConfigurer.xml
     ldap.connectTimeout=3000
 
     # Whether to use StartTLS (probably needed if not SSL connection)
-    ldap.useStartTLS=true
+    ldap.useStartTLS=false
 
     #========================================
     # LDAP connection pool configuration
@@ -546,7 +546,10 @@ into the Spring application context by modifying the `propertyFileConfigurer.xml
     #ldap.authn.format=uid=%s,ou=Users,dc=example,dc=org
     ldap.authn.format=%s@example.com
 
+	# A path to trusted X.509 certificate for StartTLS 
+	ldap.trustedCert=/path/to/cert.cer
 
+	
 ## LDAP Password Policy Enforcement
 The purpose of the LPPE is twofold:
  

--- a/cas-server-documentation/installation/LDAP-Authentication.md
+++ b/cas-server-documentation/installation/LDAP-Authentication.md
@@ -10,7 +10,7 @@ LDAP integration is enabled by including the following dependency in the Maven W
 <dependency>
      <groupId>org.jasig.cas</groupId>
      <artifactId>cas-server-support-ldap</artifactId>
-     <version>${project.version}</version>
+     <version>${cas.version}</version>
 </dependency>
 {% endhighlight %}
 


### PR DESCRIPTION
- names of properties,
- $cas.version->$project.version,
- ldap.trustedCert should be in sample cas.properties file
- startTLS should be set to false, because sample config is for ldap://