### PR TITLE
Unused private fields should be removed

### DIFF
--- a/cas-management-webapp-support/src/main/java/org/jasig/cas/services/web/beans/RegisteredServiceEditBean.java
+++ b/cas-management-webapp-support/src/main/java/org/jasig/cas/services/web/beans/RegisteredServiceEditBean.java
@@ -1,7 +1,5 @@
 package org.jasig.cas.services.web.beans;
 
-import org.slf4j.Logger;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -10,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Defines the service bean that is produced by the webapp
@@ -21,9 +18,6 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public final class RegisteredServiceEditBean implements Serializable {
     private static final long serialVersionUID = 4882440567964605644L;
-
-    private static final Logger LOGGER = getLogger(RegisteredServiceEditBean.class);
-
 
     private FormData formData = new FormData();
     private ServiceData serviceData = new ServiceData();

--- a/cas-server-core-logout/src/main/java/org/jasig/cas/logout/LogoutManagerImpl.java
+++ b/cas-server-core-logout/src/main/java/org/jasig/cas/logout/LogoutManagerImpl.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Component;
 
 import javax.validation.constraints.NotNull;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -37,9 +36,6 @@ public final class LogoutManagerImpl implements LogoutManager {
 
     /** The parameter name that contains the logout request. */
     private static final String LOGOUT_PARAMETER_NAME = "logoutRequest";
-
-    /** ASCII character set. */
-    private static final Charset ASCII = Charset.forName("ASCII");
 
     /** The services manager. */
     @NotNull

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
@@ -6,8 +6,6 @@ import org.jasig.cas.ticket.ExpirationPolicy;
 import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
-import org.jasig.cas.ticket.UniqueTicketIdGenerator;
-import org.jasig.cas.util.DefaultUniqueTicketIdGenerator;
 
 import java.util.Date;
 
@@ -20,8 +18,6 @@ import java.util.Date;
 public class MockServiceTicket implements ServiceTicket {
 
     private static final long serialVersionUID = 8203377063087967768L;
-
-    private static final UniqueTicketIdGenerator ID_GENERATOR = new DefaultUniqueTicketIdGenerator();
 
     private final String id;
 

--- a/cas-server-core-util/src/main/java/org/jasig/cas/util/AbstractJacksonBackedJsonSerializer.java
+++ b/cas-server-core-util/src/main/java/org/jasig/cas/util/AbstractJacksonBackedJsonSerializer.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
@@ -24,8 +22,6 @@ import java.io.Writer;
  */
 public abstract class AbstractJacksonBackedJsonSerializer<T> implements JsonSerializer<T> {
     private static final long serialVersionUID = -8415599777321259365L;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJacksonBackedJsonSerializer.class);
 
     /**
      * The Pretty printer.

--- a/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoder.java
+++ b/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoder.java
@@ -45,8 +45,6 @@ import org.jasig.cas.ticket.support.ThrottledUseAndTimeoutExpirationPolicy;
 import org.jasig.cas.ticket.support.TicketGrantingTicketExpirationPolicy;
 import org.jasig.cas.ticket.support.TimeoutExpirationPolicy;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
@@ -70,9 +68,6 @@ public class KryoTranscoder implements Transcoder<Object> {
 
     /** Kryo serializer. */
     private final Kryo kryo = new KryoReflectionFactorySupport();
-
-    /** Logging instance. */
-    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /** Map of class to serializer that handles it. */
     private Map<Class<?>, Serializer> serializerMap;

--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
@@ -4,8 +4,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
 
@@ -20,8 +18,6 @@ public final class LdapUtils {
 
     /** The Constant OBJECTCLASS_ATTRIBUTE. */
     public static final String OBJECTCLASS_ATTRIBUTE = "objectClass";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(LdapUtils.class);
 
     /**
      * Instantiates a new ldap utils.

--- a/cas-server-support-ldap/src/test/java/org/jasig/cas/util/LdapTestUtils.java
+++ b/cas-server-support-ldap/src/test/java/org/jasig/cas/util/LdapTestUtils.java
@@ -6,8 +6,6 @@ import com.unboundid.ldap.sdk.LDAPConnection;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.io.LdifReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,8 +27,6 @@ public final class LdapTestUtils {
 
     /** System-wide newline character string. */
     private static final String NEWLINE = System.getProperty("line.separator");
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(LdapTestUtils.class);
 
     /** Private constructor of utility class. */
     private LdapTestUtils() {

--- a/cas-server-support-saml-googleapps/src/main/java/org/jasig/cas/support/saml/SamlGoogleAppsServletContextListener.java
+++ b/cas-server-support-saml-googleapps/src/main/java/org/jasig/cas/support/saml/SamlGoogleAppsServletContextListener.java
@@ -3,8 +3,6 @@ package org.jasig.cas.support.saml;
 import org.jasig.cas.authentication.principal.ServiceFactory;
 import org.jasig.cas.support.saml.authentication.principal.GoogleAccountsService;
 import org.jasig.cas.web.AbstractServletContextInitializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -20,8 +18,6 @@ import javax.servlet.annotation.WebListener;
 @WebListener
 @Component
 public class SamlGoogleAppsServletContextListener extends AbstractServletContextInitializer {
-
-    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired
     @Qualifier("googleAccountsServiceFactory")

--- a/cas-server-support-saml-googleapps/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
+++ b/cas-server-support-saml-googleapps/src/test/java/org/jasig/cas/support/saml/authentication/principal/GoogleAccountsServiceTests.java
@@ -13,8 +13,6 @@ import org.jasig.cas.util.ISOStandardDateFormat;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -32,8 +30,6 @@ import static org.mockito.Mockito.*;
  * @since 3.1
  */
 public class GoogleAccountsServiceTests extends AbstractOpenSamlTests {
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     private GoogleAccountsServiceFactory factory;

--- a/cas-server-webapp-reports/src/main/java/org/jasig/cas/web/report/InternalConfigStateController.java
+++ b/cas-server-webapp-reports/src/main/java/org/jasig/cas/web/report/InternalConfigStateController.java
@@ -1,7 +1,5 @@
 package org.jasig.cas.web.report;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
@@ -25,8 +23,6 @@ import java.util.Set;
  */
 @Controller("internalConfigController")
 public final class InternalConfigStateController {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(InternalConfigStateController.class);
 
     private static final String VIEW_CONFIG = "monitoring/viewConfig";
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1068 - Unused private fields should be removed
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1068
Please let me know if you have any questions.
Kirill Vlasov