### PR TITLE
"private" methods that don't access instance data should be "static"

### DIFF
--- a/cas-server-core-logging/src/main/java/org/slf4j/impl/CasLoggerFactory.java
+++ b/cas-server-core-logging/src/main/java/org/slf4j/impl/CasLoggerFactory.java
@@ -118,7 +118,7 @@ public final class CasLoggerFactory implements ILoggerFactory {
         }
     }
 
-    private ILoggerFactory getLoggerFactoryBeInstantiated(final Class<? extends ILoggerFactory> loggerFactory) {
+    private static ILoggerFactory getLoggerFactoryBeInstantiated(final Class<? extends ILoggerFactory> loggerFactory) {
         try {
             return loggerFactory.newInstance();
         } catch (final Exception e) {

--- a/cas-server-core-logging/src/test/java/org/slf4j/impl/CasLoggerFactoryTests.java
+++ b/cas-server-core-logging/src/test/java/org/slf4j/impl/CasLoggerFactoryTests.java
@@ -322,11 +322,11 @@ public class CasLoggerFactoryTests {
         validateLogData();
     }
 
-    private String getMessageToLog() {
+    private static String getMessageToLog() {
         return String.format("Here is one %s and here is another %s", ID1, ID2);
     }
 
-    private String getMessageToLogWithParams() {
+    private static String getMessageToLogWithParams() {
         return "Here is one {} and here is another {}";
     }
 

--- a/cas-server-core-services/src/main/java/org/jasig/cas/services/RegexRegisteredService.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/services/RegexRegisteredService.java
@@ -49,7 +49,7 @@ public class RegexRegisteredService extends AbstractRegisteredService {
      * @param pattern the pattern, may not be null.
      * @return the pattern
      */
-    private Pattern createPattern(final String pattern) {
+    private static Pattern createPattern(final String pattern) {
         if (pattern == null) {
             throw new IllegalArgumentException("Pattern cannot be null.");
         }

--- a/cas-server-core-services/src/test/java/org/jasig/cas/authentication/support/DefaultCasAttributeEncoderTests.java
+++ b/cas-server-core-services/src/test/java/org/jasig/cas/authentication/support/DefaultCasAttributeEncoderTests.java
@@ -43,7 +43,7 @@ public class DefaultCasAttributeEncoderTests {
         this.attributes.put(CasViewConstants.MODEL_ATTRIBUTE_NAME_PRINCIPAL_CREDENTIAL, newSingleAttribute("PrincipalPassword"));
     }
 
-    private Collection<String> newSingleAttribute(final String attr) {
+    private static Collection<String> newSingleAttribute(final String attr) {
         return Collections.singleton(attr);
     }
 

--- a/cas-server-core-util/src/main/java/org/jasig/cas/util/DefaultRandomStringGenerator.java
+++ b/cas-server-core-util/src/main/java/org/jasig/cas/util/DefaultRandomStringGenerator.java
@@ -74,7 +74,7 @@ public final class DefaultRandomStringGenerator implements RandomStringGenerator
      * @param random the random
      * @return the string
      */
-    private String convertBytesToString(final byte[] random) {
+    private static String convertBytesToString(final byte[] random) {
         final char[] output = new char[random.length];
         for (int i = 0; i < random.length; i++) {
             final int index = Math.abs(random[i] % PRINTABLE_CHARACTERS.length);

--- a/cas-server-core-web/src/main/java/org/jasig/cas/services/web/view/AbstractCasView.java
+++ b/cas-server-core-web/src/main/java/org/jasig/cas/services/web/view/AbstractCasView.java
@@ -167,7 +167,7 @@ public abstract class AbstractCasView extends AbstractView {
      * @param attributes the attributes
      * @return the map of attributes to return
      */
-    private Map<String, Object> convertAttributeValuesToMultiValuedObjects(final Map<String, Object> attributes) {
+    private static Map<String, Object> convertAttributeValuesToMultiValuedObjects(final Map<String, Object> attributes) {
         final Map<String, Object> attributesToReturn = new HashMap<>();
         final Set<Map.Entry<String, Object>> entries = attributes.entrySet();
         for (final Map.Entry<String, Object> entry : entries) {

--- a/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/EncryptedMapDecorator.java
+++ b/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/EncryptedMapDecorator.java
@@ -475,7 +475,7 @@ public final class EncryptedMapDecorator implements Map<String, String> {
      * @throws NoSuchPaddingException - if transformation contains a padding scheme that is not available.
      * @see Cipher#getInstance(String)
      */
-    private Cipher getCipherObject() throws NoSuchAlgorithmException, NoSuchPaddingException {
+    private static Cipher getCipherObject() throws NoSuchAlgorithmException, NoSuchPaddingException {
         return Cipher.getInstance(CIPHER_ALGORITHM);
     }
 

--- a/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/support/kryo/serial/RegisteredServiceSerializer.java
+++ b/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/support/kryo/serial/RegisteredServiceSerializer.java
@@ -36,7 +36,7 @@ public class RegisteredServiceSerializer  extends Serializer<RegisteredService> 
      * we need to be able to return a default/mock url.
      * @return mock url
      */
-    private URL getEmptyUrl() {
+    private static URL getEmptyUrl() {
         try {
             return new URL("https://");
         } catch (final Exception e) {

--- a/cas-server-support-jdbc/src/test/java/org/jasig/cas/adaptors/jdbc/QueryAndEncodeDatabaseAuthenticationHandlerTests.java
+++ b/cas-server-support-jdbc/src/test/java/org/jasig/cas/adaptors/jdbc/QueryAndEncodeDatabaseAuthenticationHandlerTests.java
@@ -145,11 +145,11 @@ public class QueryAndEncodeDatabaseAuthenticationHandlerTests {
         assertEquals(r.getPrincipal().getId(), "user1");
     }
 
-    private String buildSql(final String where) {
+    private static String buildSql(final String where) {
         return String.format(SQL, where);
     }
 
-    private String buildSql() {
+    private static String buildSql() {
         return String.format(SQL, "username=?;");
     }
 

--- a/cas-server-support-jdbc/src/test/java/org/jasig/cas/adaptors/jdbc/QueryDatabaseAuthenticationHandlerTests.java
+++ b/cas-server-support-jdbc/src/test/java/org/jasig/cas/adaptors/jdbc/QueryDatabaseAuthenticationHandlerTests.java
@@ -65,7 +65,7 @@ public class QueryDatabaseAuthenticationHandlerTests {
         c.close();
     }
 
-    private String getSqlInsertStatementToCreateUserAccount(final int i) {
+    private static String getSqlInsertStatementToCreateUserAccount(final int i) {
         return String.format("insert into casusers (username, password) values('%s', '%s');", "user" + i, "psw" + i);
     }
 

--- a/cas-server-support-jdbc/src/test/java/org/jasig/cas/adaptors/jdbc/SearchModeSearchDatabaseAuthenticationHandlerTests.java
+++ b/cas-server-support-jdbc/src/test/java/org/jasig/cas/adaptors/jdbc/SearchModeSearchDatabaseAuthenticationHandlerTests.java
@@ -72,7 +72,7 @@ public class SearchModeSearchDatabaseAuthenticationHandlerTests {
         c.close();
     }
 
-    private String getSqlInsertStatementToCreateUserAccount(final int i) {
+    private static String getSqlInsertStatementToCreateUserAccount(final int i) {
         return String.format("insert into cassearchusers (username, password) values('%s', '%s');", "user" + i, "psw" + i);
     }
 

--- a/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
@@ -217,7 +217,7 @@ public final class JpaTicketRegistry extends AbstractDistributedTicketRegistry i
      * @param result the result
      * @return the int
      */
-    private int countToInt(final Object result) {
+    private static int countToInt(final Object result) {
         final int intval;
         if (result instanceof Long) {
             intval = ((Long) result).intValue();

--- a/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
+++ b/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
@@ -144,7 +144,7 @@ public final class ClientAction extends AbstractAction {
             }
             restoreRequestAttribute(request, session, ThemeChangeInterceptor.DEFAULT_PARAM_NAME);
             restoreRequestAttribute(request, session, LocaleChangeInterceptor.DEFAULT_PARAM_NAME);
-            restoreRequestAttribute(request, session, CasProtocolConstants.PARAMETER_SERVICE);
+            restoreRequestAttribute(request, session, CasProtocolConstants.PARAMETER_METHOD);
 
             // credentials not null -> try to authenticate
             if (credentials != null) {

--- a/cas-server-support-x509/src/test/java/org/jasig/cas/adaptors/x509/util/MockWebServer.java
+++ b/cas-server-support-x509/src/test/java/org/jasig/cas/adaptors/x509/util/MockWebServer.java
@@ -164,7 +164,7 @@ public class MockWebServer {
             socket.shutdownOutput();
         }
 
-        private byte[] header(final String name, final Object value) {
+        private static byte[] header(final String name, final Object value) {
             return String.format("%s: %s\r\n", name, value).getBytes();
         }
     }

--- a/cas-server-webapp-reports/src/main/java/org/jasig/cas/web/report/StatisticsController.java
+++ b/cas-server-webapp-reports/src/main/java/org/jasig/cas/web/report/StatisticsController.java
@@ -135,7 +135,7 @@ public final class StatisticsController implements ServletContextAware {
      * @param bytes the total number of bytes
      * @return value converted to MB
      */
-    private double convertToMegaBytes(final double bytes) {
+    private static double convertToMegaBytes(final double bytes) {
         return bytes / NUMBER_OF_BYTES_IN_A_KILOBYTE / NUMBER_OF_BYTES_IN_A_KILOBYTE;
     }
     /**

--- a/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapter.java
@@ -105,7 +105,7 @@ public abstract class AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapt
      *
      * @return  Instantaneous submission rate in submissions/sec, e.g. {@code a - b}.
      */
-    private double submissionRate(final Date a, final Date b) {
+    private static double submissionRate(final Date a, final Date b) {
         return SUBMISSION_RATE_DIVIDEND / (a.getTime() - b.getTime());
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
Please let me know if you have any questions.
Kirill Vlasov