### PR TITLE
Reset regex servicePattern when the serviceId is changed

### DIFF
--- a/cas-server-core-services/src/main/java/org/jasig/cas/services/RegexRegisteredService.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/services/RegexRegisteredService.java
@@ -27,6 +27,9 @@ public class RegexRegisteredService extends AbstractRegisteredService {
     @Override
     public void setServiceId(final String id) {
         serviceId = id;
+
+        // reset the servicePattern because we just changed the serviceId
+        servicePattern = null;
     }
     
     @Override


### PR DESCRIPTION
I don't think there are currently any code paths that would trigger this corner case, but it's a simple corner case to protect against.