### PR TITLE
Updated docs for mgmt webapp

### DIFF
--- a/cas-management-webapp-support/src/main/java/org/jasig/cas/services/web/ManageRegisteredServicesMultiActionController.java
+++ b/cas-management-webapp-support/src/main/java/org/jasig/cas/services/web/ManageRegisteredServicesMultiActionController.java
@@ -79,6 +79,7 @@ public final class ManageRegisteredServicesMultiActionController extends Abstrac
             svc.setName("Services Management Web Application");
             svc.setDescription(svc.getName());
             this.servicesManager.save(svc);
+            this.servicesManager.reload();
         }
     }
     /**

--- a/cas-management-webapp/src/main/resources/user-details.properties
+++ b/cas-management-webapp/src/main/resources/user-details.properties
@@ -26,4 +26,4 @@
 # username=password,grantedAuthority[,grantedAuthority][,enabled|disabled]
 
 # Example:
-# casuser=notused,ROLE_ADMIN
+casuser=notused,ROLE_ADMIN

--- a/cas-management-webapp/src/main/webapp/WEB-INF/cas-management.properties
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/cas-management.properties
@@ -1,34 +1,14 @@
-#
-# Licensed to Apereo under one or more contributor license
-# agreements. See the NOTICE file distributed with this work
-# for additional information regarding copyright ownership.
-# Apereo licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file
-# except in compliance with the License.  You may obtain a
-# copy of the License at the following location:
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
-# hosts and urls
-
 # CAS
-cas.host=http://localhost:8080
-cas.prefix=${cas.host}/cas
+cas.host=https://jasigcas.herokuapp.com
+cas.prefix=${cas.host}
 cas.securityContext.casProcessingFilterEntryPoint.loginUrl=${cas.prefix}/login
 
 # Management
-cas-management.host=${cas.host}
+cas-management.host=https://localhost:8443
 cas-management.prefix=${cas-management.host}/cas-management
 cas-management.securityContext.serviceProperties.service=${cas-management.prefix}/callback
-# security
+
+# Security
 cas-management.securityContext.serviceProperties.adminRoles=ROLE_ADMIN
 pac4j.callback.defaultUrl=/manage.html
 

--- a/cas-management-webapp/src/main/webapp/WEB-INF/managementConfigContext.xml
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/managementConfigContext.xml
@@ -1,39 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    | managementConfigContext.xml centralizes into one file some of the declarative configuration that
-    | all CAS deployers will need to modify for the (services) management webapp.
-    |
-    | The beans declared in this file are instantiated at context initialization time by the Spring
-    | ContextLoaderListener declared in web.xml.  It finds this file because this
-    | file is among those declared in the context parameter "contextConfigLocation".
-    +-->
-
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
-    <!--
-    This bean defines the security roles for the Services Management application.  Simple deployments can use the in-memory version.
-    More robust deployments will want to use another option, such as the Jdbc version.
 
-    The name of this should remain "authorizationGenerator" in order for the pac4j security context to find it.
-     -->
     <util:properties id="userProperties" location="${user.details.file.location:classpath:user-details.properties}" />
 
-    <bean id="authorizationGenerator" class="org.pac4j.core.authorization.generator.SpringSecurityPropertiesAuthorizationGenerator">
-        <constructor-arg name="properties" ref="userProperties" />
-    </bean>
+    <!--
+    This bean defines the security roles for the Services Management application.
+    Simple deployments can use the in-memory version.
+    More robust deployments will want to use another option, such as the Jdbc version.
+    The name of this should remain "authorizationGenerator" in order for the pac4j security context to find it.
+    -->
 
-    <!-- 
-    Bean that defines the attributes that a service may return.  This example uses the Stub/Mock version.  A real implementation
-    may go against a database or LDAP server.  The id should remain "attributeRepository" though.
-     -->
-    <bean id="attributeRepository"
-          class="org.jasig.services.persondir.support.StubPersonAttributeDao" p:backingMap-ref="backingMap">
-    </bean>
+    <bean id="authorizationGenerator" class="org.pac4j.core.authorization.generator.SpringSecurityPropertiesAuthorizationGenerator"
+          c:properties-ref="userProperties" />
+
+    <bean id="attributeRepository" class="org.jasig.services.persondir.support.StubPersonAttributeDao" p:backingMap-ref="backingMap" />
 
     <util:map id="backingMap">
         <entry key="uid" value="uid"/>

--- a/cas-management-webapp/src/main/webapp/WEB-INF/spring-configuration/securityContext.xml
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/spring-configuration/securityContext.xml
@@ -2,33 +2,26 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-    <description>
-      Security configuration for services management and other sensitive areas of CAS.
-      In most cases it should not be necessary to edit this file as common configuration
-      can be managed by setting properties in the cas-management.properties file.
-    </description>
-
     <context:component-scan base-package="org.pac4j.springframework.web" />
 
-    <bean id="config" class="org.pac4j.core.config.Config">
-        <constructor-arg name="callbackUrl" value="${cas-management.securityContext.serviceProperties.service}" />
-        <constructor-arg name="client">
-            <bean class="org.pac4j.cas.client.CasClient">
-                <property name="casLoginUrl" value="${cas.securityContext.casProcessingFilterEntryPoint.loginUrl}" />
-                <property name="authorizationGenerator" ref="authorizationGenerator" />
-            </bean>
-        </constructor-arg>
-        <property name="authorizer">
-            <bean class="org.pac4j.core.authorization.RequireAnyRoleAuthorizer">
-                <constructor-arg name="roles" value="${cas-management.securityContext.serviceProperties.adminRoles}" />
-            </bean>
-        </property>
-    </bean>
+    <bean id="config" class="org.pac4j.core.config.Config"
+          c:callbackUrl="${cas-management.securityContext.serviceProperties.service}"
+          c:client-ref="casClient"
+          p:authorizer-ref="requireAnyRoleAuthoizer" />
+
+    <bean id="casClient" class="org.pac4j.cas.client.CasClient"
+          p:casLoginUrl="${cas.securityContext.casProcessingFilterEntryPoint.loginUrl}"
+          p:authorizationGenerator-ref="authorizationGenerator" />
+
+    <bean id="requireAnyRoleAuthoizer" class="org.pac4j.core.authorization.RequireAnyRoleAuthorizer"
+          c:roles="${cas-management.securityContext.serviceProperties.adminRoles}" />
 
     <mvc:interceptors>
         <mvc:interceptor>
@@ -36,11 +29,10 @@
             <mvc:exclude-mapping path="/callback*" />
             <mvc:exclude-mapping path="/logout*" />
             <mvc:exclude-mapping path="/authorizationFailure.html" />
-            <bean class="org.pac4j.springframework.web.RequiresAuthenticationInterceptor">
-                <constructor-arg name="config" ref="config" />
-                <constructor-arg name="clientName" value="CasClient" />
-                <constructor-arg name="authorizerName" value="securityHeaders,csrfToken,RequireAnyRoleAuthorizer" />
-            </bean>
+            <bean class="org.pac4j.springframework.web.RequiresAuthenticationInterceptor"
+                  c:config-ref="config"
+                  c:clientName="CasClient"
+                  c:authorizerName="securityHeaders,csrfToken,RequireAnyRoleAuthorizer" />
         </mvc:interceptor>
     </mvc:interceptors>
 

--- a/cas-server-core-logging/src/main/java/org/slf4j/impl/CasLoggerFactory.java
+++ b/cas-server-core-logging/src/main/java/org/slf4j/impl/CasLoggerFactory.java
@@ -122,7 +122,8 @@ public final class CasLoggerFactory implements ILoggerFactory {
         try {
             return loggerFactory.newInstance();
         } catch (final Exception e) {
-            return null;
+            Util.report(e.getMessage(), e);
         }
+        return null;
     }
 }

--- a/cas-server-documentation/installation/Installing-ServicesMgmt-Webapp.md
+++ b/cas-server-documentation/installation/Installing-ServicesMgmt-Webapp.md
@@ -15,21 +15,8 @@ You MUST keep in mind that both applications (the CAS server and the services ma
 share the <strong>same</strong> configuration for the CAS services.
 </p></div>
 
-You can install the services management webapp in your favorite applications server, there is no restriction.
-Though, you need to configure it according to your environment. Towards that goal, the best way to
-proceed is to create your own services management webapp using
-a [Maven overlay](http://maven.apache.org/plugins/maven-war-plugin/overlays.html)
-based on the CAS services management webapp:
-
-{% highlight xml %}
-<dependency>
-  <groupId>org.jasig.cas</groupId>
-  <artifactId>cas-management-webapp</artifactId>
-  <version>${cas.version}</version>
-  <type>war</type>
-  <scope>runtime</scope>
-</dependency>
-{% endhighlight %}
+A sample Maven overlay for the services management webapp is provided here: [https://github.com/Jasig/cas-services-management-overlay]
+(https://github.com/Jasig/cas-services-management-overlay)
 
 ## Services Registry
 
@@ -37,17 +24,37 @@ You also need to define the *common* services registry by overriding the `WEB-IN
 file and set the appropriate `serviceRegistryDao`. The [persistence storage](Service-Management.html) MUST be the same.
 It should be the same configuration you already use in your CAS server in the `WEB-INF/deployerConfigContext.xml` file.
 
-## Authentication method
+## Authentication Method
 
-By default, the `cas-management-webapp` is configured to authenticate against a CAS server. We assume that it's the case in this documentation. However, you could change the authentication method by overriding the `WEB-INF/spring-configuration/securityContext.xml` file.
+By default, the `cas-management-webapp` is configured to authenticate against a CAS server. We assume that it's the case in this 
+documentation. However, you could change the authentication method by 
+overriding the `WEB-INF/spring-configuration/securityContext.xml` file.
 
+## Configuration
+The following properties are applicable and must be adjusted by overriding the default `WEB-INF/cas-management.properties` file:
+
+{% highlight properties %}
+# CAS
+cas.host=http://localhost:8080
+cas.prefix=${cas.host}/cas
+cas.securityContext.casProcessingFilterEntryPoint.loginUrl=${cas.prefix}/login
+
+# Management
+cas-management.host=${cas.host}
+cas-management.prefix=${cas-management.host}/cas-management
+cas-management.securityContext.serviceProperties.service=${cas-management.prefix}/callback
+
+cas-management.securityContext.serviceProperties.adminRoles=ROLE_ADMIN
+{% endhighlight %}
 
 ##Securing Access and Authorization
-Access to the management webapp is controlled via pac4j. Rules are defined in the `/cas-management-webapp/src/main/webapp/WEB-INF/managementConfigContext.xml` file.
+Access to the management webapp is controlled via pac4j. Rules are defined in 
+the `/WEB-INF/managementConfigContext.xml` file.
 
 
 ###Static List of Users
-By default, access is limited to a static list of users whose credentials may be specified in a `user-details.properties` file that should be available on the runtime classpath.
+By default, access is limited to a static list of users whose credentials may be specified in a `user-details.properties` 
+file that should be available on the runtime classpath.
 
 {% highlight xml %}
 <sec:user-service id="userDetailsService"
@@ -75,72 +82,83 @@ The format of the file should be as such:
 # casuser=notused,ROLE_ADMIN
 {% endhighlight %}
 
+###CAS ABAC
 
-###LDAP-managed List of Users
-If you wish allow access to the services management application via an LDAP group/server, open up the `deployerConfigContext` file of the management web application and adjust for the following:
-
+The following authorization generator examines the CAS response for attributes
+and will grant access if an attribute name matches the value of `adminRoles` defined in the configuration.
+ 
 {% highlight xml %}
-<sec:ldap-server id="ldapServer" url="ldap://myserver:13060/"
-                 manager-dn="cn=adminusername,cn=Users,dc=london-scottish,dc=com"
-                 manager-password="mypassword" />
-<sec:ldap-user-service id="userDetailsService" server-ref="ldapServer"
-            group-search-base="cn=Groups,dc=mycompany,dc=com" group-role-attribute="cn"
-            group-search-filter="(uniquemember={0})"
-            user-search-base="cn=Users,dc=mycompany,dc=com"
-            user-search-filter="(uid={0})"/>
+<bean id="authorizationGenerator" class="org.pac4j.core.authorization.FromAttributesAuthorizationGenerator"
+    c:roleAttributes="ROLE_ADMIN,ROLE_CUSTOM" c:permissionAttributes="CUSTOM_PERMISSION1,CUSTOM_PERMISSION2" />
 {% endhighlight %}
 
-You will also need to ensure that the `spring-security-ldap` dependency is available to your build at runtime:
+###Custom ABAC
+
+Define a custom set of roles and permissions that would be cross-checked later against the value of `adminRoles`
+defined in the configuration.
+ 
+{% highlight xml %}
+<bean id="authorizationGenerator" class="org.pac4j.core.authorization.DefaultRolesPermissionsAuthorizationGenerator">
+    c:defaultRoles="ROLE_ADMIN,ROLE_CUSTOM" c:defaultPermissions="CUSTOM_PERMISSION1,CUSTOM_PERMISSION2" />
+{% endhighlight %}
+
+###LDAP
+
+Support is enabled by including the following dependency in the Maven WAR overlay:
 
 {% highlight xml %}
 <dependency>
-   <groupId>org.springframework.security</groupId>
-   <artifactId>spring-security-ldap</artifactId>
-   <version>${spring.security.ldap.version}</version>
-   <exclusions>
-     <exclusion>
-             <groupId>org.springframework</groupId>
-             <artifactId>spring-aop</artifactId>
-     </exclusion>
-     <exclusion>
-             <groupId>org.springframework</groupId>
-             <artifactId>spring-tx</artifactId>
-     </exclusion>
-     <exclusion>
-             <groupId>org.springframework</groupId>
-             <artifactId>spring-beans</artifactId>
-     </exclusion>
-     <exclusion>
-             <groupId>org.springframework</groupId>
-             <artifactId>spring-context</artifactId>
-     </exclusion>
-     <exclusion>
-             <groupId>org.springframework</groupId>
-             <artifactId>spring-core</artifactId>
-     </exclusion>
-   </exclusions>
+  <groupId>org.jasig.cas</groupId>
+  <artifactId>cas-server-support-ldap</artifactId>
+  <version>${cas.version}</version>
 </dependency>
 {% endhighlight %}
 
+Define a custom set of roles and permissions that would be cross-checked later against the value of `adminRoles`.
+ 
+{% highlight xml %}
+<ldaptive:pooled-connection-factory
+    id="ldapAuthorizationGeneratorConnectionFactory"
+    ldapUrl="${ldap.url}"
+    blockWaitTime="${ldap.pool.blockWaitTime}"
+    failFastInitialize="true"
+    connectTimeout="${ldap.connectTimeout}"
+    useStartTLS="${ldap.useStartTLS}"
+    validateOnCheckOut="${ldap.pool.validateOnCheckout}"
+    validatePeriodically="${ldap.pool.validatePeriodically}"
+    validatePeriod="${ldap.pool.validatePeriod}"
+    idleTime="${ldap.pool.idleTime}"
+    maxPoolSize="${ldap.pool.maxSize}"
+    minPoolSize="${ldap.pool.minSize}"
+    useSSL="${ldap.use.ssl:false}"
+    prunePeriod="${ldap.pool.prunePeriod}"
+/>
 
-## Urls Configuration
+<bean id="ldapAuthorizationGeneratorUserSearchExecutor" class="org.ldaptive.SearchExecutor"
+      p:baseDn="${ldap.baseDn}"
+      p:searchFilter="${ldap.user.searchFilter}"
+      p:returnAttributes-ref="userDetailsUserAttributes" />
 
-The urls configuration of the CAS server and management applications can be done
-by overriding the default `WEB-INF/cas-management.properties` file:
+<bean id="ldapAuthorizationGeneratorRoleSearchExecutor" class="org.ldaptive.SearchExecutor"
+      p:baseDn="${ldap.role.baseDn}"
+      p:searchFilter="${ldap.role.searchFilter}"
+      p:returnAttributes-ref="userDetailsRoleAttributes" />
 
-{% highlight properties %}
-# CAS
-cas.host=http://localhost:8080
-cas.prefix=${cas.host}/cas
-cas.securityContext.casProcessingFilterEntryPoint.loginUrl=${cas.prefix}/login
-cas.securityContext.ticketValidator.casServerUrlPrefix=${cas.prefix}
+<util:list id="userDetailsUserAttributes">
+    <value>...</value>
+</util:list>
 
-# Management
-cas-management.host=${cas.host}
-cas-management.prefix=${cas-management.host}/cas-management
-cas-management.securityContext.serviceProperties.service=${cas-management.prefix}/login/cas
-cas-management.securityContext.serviceProperties.adminRoles=hasRole('ROLE_ADMIN')
+<util:list id="userDetailsRoleAttributes">
+    <value>...</value>
+</util:list>
 {% endhighlight %}
 
-When authenticating against a CAS server, the services management webapp will be processed as a
-regular CAS service and thus, needs to be defined in the services registry of the CAS server.
+The following properties are applicable to this configuration:
+
+{% highlight properties %}
+# ldap.authorizationgenerator.user.attr=uid
+# ldap.authorizationgenerator.role.attr=roleAttributeName
+# ldap.authorizationgenerator.role.prefix=ROLE_
+# ldap.authorizationgenerator.allow.multiple=false
+{% endhighlight %}
+

--- a/cas-server-documentation/installation/Service-Management.md
+++ b/cas-server-documentation/installation/Service-Management.md
@@ -22,7 +22,6 @@ to manage service registry data.
 ## Demo
 The Service Management web application is available for demo at [https://jasigcasmgmt.herokuapp.com](https://jasigcasmgmt.herokuapp.com)
 
-
 ## Considerations
 It is not required to use the service management facility explicitly. CAS ships with a default configuration that is
 suitable for deployments that do not need or want to leverage the capabilities above. The default configuration allows
@@ -46,19 +45,46 @@ Registered services present the following metadata:
 | `id`                              | Required unique identifier. In most cases this is managed automatically by the `ServiceRegistryDao`.
 | `name`                            | Required name (255 characters or less).
 | `description`                     | Optional free-text description of the service. (255 characters or less)
-| `logo`                              | Optional path to an image file that is the logo for this service. The image will be displayed on the login page along with the service description and name.  
-| `serviceId`                       | Required [Ant pattern](http://ant.apache.org/manual/dirtasks.html#patterns) or [regular expression](http://docs.oracle.com/javase/tutorial/essential/regex/) describing a logical service. A logical service defines one or more URLs where a service or services are located. The definition of the url pattern must be **done carefully** because it can open security breaches. For example, using Ant pattern, if you define the following service : `http://example.*/myService` to match `http://example.com/myService` and `http://example.fr/myService`, it's a bad idea as it can be tricked by `http://example.hostattacker.com/myService`. The best way to proceed is to define the more precise url patterns.
-| `theme`                           | Optional [Spring theme](http://static.springsource.org/spring/docs/3.2.x/spring-framework-reference/html/mvc.html#mvc-themeresolver) that may be used to customize the CAS UI when the service requests a ticket. See [this guide](User-Interface-Customization.html) for more details.
-| `proxyPolicy`                     | Determines whether the service is able to proxy authentication, not whether the service accepts proxy authentication.
-| `evaluationOrder`                 | Required value that determines relative order of evaluation of registered services. This flag is particularly important in cases where two service URL expressions cover the same services; evaluation order determines which registration is evaluated first.
-| `requiredHandlers`                | Set of authentication handler names that must successfully authenticate credentials in order to access the service.
-| `attributeReleasePolicy`          | The policy that describes the set of attributes allows to be released to the application, as well as any other filtering logic needed to weed some out. See [this guide](../integration/Attribute-Release.html) for more details on attribute release and filters.
-| `logoutType`                      | Defines how this service should be treated once the logout protocol is initiated. Acceptable values are `LogoutType.BACK_CHANNEL`, `LogoutType.FRONT_CHANNEL` or `LogoutType.NONE`. See [this guide](Logout-Single-Signout.html) for more details on logout.
-| `usernameAttributeProvider`       | The provider configuration which dictates what value as the "username" should be sent back to the application. See [this guide](../integration/Attribute-Release.html) for more details on attribute release and filters.
-| `accessStrategy`                  | The strategy configuration that outlines and access rules for this service. It describes whether the service is allowed, authorized to participate in SSO, or can be granted access from the CAS perspective based on a particular attribute-defined role, aka RBAC. See [this guide](../integration/Attribute-Release.html) for more details on attribute release and filters.  
-| `publicKey`                  		| The public key associated with this service that is used to authorize the request by encrypting certain elements and attributes in the CAS validation protocol response, such as [the PGT](Configuring-Proxy-Authentication.html) or [the credential](../integration/ClearPass.html). See [this guide](../integration/Attribute-Release.html) for more details on attribute release and filters.  
-| `logoutUrl`                  		| URL endpoint for this service to receive logout requests. See [this guide](Logout-Single-Signout.html) for more details
-| `properties`                  		| Extra metadata associated with this service in form of key/value pairs. This is used to inject custom fields into the service definition, to be used later by extension modules to define additional behavior on a per-service basis.
+| `logo`                              | Optional path to an image file that is the logo for this service. The image will be displayed on 
+the login page along with the service description and name.  
+| `serviceId`                       | Required [Ant pattern](http://ant.apache.org/manual/dirtasks.html#patterns) 
+or [regular expression](http://docs.oracle.com/javase/tutorial/essential/regex/) describing a logical service. A logical service 
+defines one or more URLs where a service or services are located. The definition of the url pattern must be **done carefully** because 
+it can open security breaches. For example, using Ant pattern, if you define the following service : `http://example.*/myService` 
+to match `http://example.com/myService` and `http://example.fr/myService`, it's a bad idea as it can be tricked 
+by `http://example.hostattacker.com/myService`. The best way to proceed is to define the more precise url patterns.
+| `theme`                           | Optional [Spring theme](http://bit.ly/1R7QeGZ) 
+that may be used to customize the CAS UI when the service requests a ticket. See [this guide](User-Interface-Customization.html) 
+for more details.
+| `proxyPolicy`                     | Determines whether the service is able to proxy authentication, not whether 
+the service accepts proxy authentication.
+| `evaluationOrder`                 | Required value that determines relative order of evaluation of registered services.
+ This flag is particularly important in cases where two service URL expressions cover the same services; evaluation order 
+ determines which registration is evaluated first.
+| `requiredHandlers`                | Set of authentication handler names that must successfully authenticate credentials 
+in order to access the service.
+| `attributeReleasePolicy`          | The policy that describes the set of attributes allows to be released to the application, 
+as well as any other filtering logic needed to weed some out. See [this guide](../integration/Attribute-Release.html) 
+for more details on attribute release and filters.
+| `logoutType`                      | Defines how this service should be treated once the logout protocol is initiated. 
+Acceptable values are `LogoutType.BACK_CHANNEL`, `LogoutType.FRONT_CHANNEL` or `LogoutType.NONE`. 
+See [this guide](Logout-Single-Signout.html) for more details on logout.
+| `usernameAttributeProvider`       | The provider configuration which dictates what value as the "username" 
+should be sent back to the application. See [this guide](../integration/Attribute-Release.html) for more details 
+on attribute release and filters.
+| `accessStrategy`                  | The strategy configuration that outlines and access rules for this service. 
+It describes whether the service is allowed, authorized to participate in SSO, or can be granted access from the 
+CAS perspective based on a particular attribute-defined role, aka RBAC. See [this guide](../integration/Attribute-Release.html) 
+for more details on attribute release and filters.  
+| `publicKey`                  		| The public key associated with this service that is used to authorize the 
+request by encrypting certain elements and attributes in the CAS validation protocol response, such 
+as [the PGT](Configuring-Proxy-Authentication.html) or [the credential](../integration/ClearPass.html). 
+See [this guide](../integration/Attribute-Release.html) for more details on attribute release and filters.  
+| `logoutUrl`                  		| URL endpoint for this service to receive logout requests. 
+See [this guide](Logout-Single-Signout.html) for more details
+| `properties`                  		| Extra metadata associated with this service in form of key/value pairs. 
+This is used to inject custom fields into the service definition, to be used later by extension 
+modules to define additional behavior on a per-service basis.
 
 ###Configure Service Access Strategy
 
@@ -113,6 +139,7 @@ service registry data and the UI will not be used.
 [See this guide](JPA-Service-Management.html) for more info please.
 
 ## Service Management Webapp
-The Services Management web application is a standalone application that helps one manage service registrations and entries via a customizable user interface. The management web application *MUST* share the same registry configuration as
+The Services Management web application is a standalone application that helps one manage service registrations and 
+entries via a customizable user interface. The management web application *MUST* share the same registry configuration as
 the CAS server itself so the entire system can load the same services data. To learn more about the management webapp,
 [please see this guide](Installing-ServicesMgmt-Webapp.html).


### PR DESCRIPTION
This pull:

1. Updates the documentation for the cas services management webapp
2. Presents a sample overlay for the webapp in the docs
3. Describes how access to the webapp may be granted via various options
4. Enabled access to the webapp by default, and authenticates against the heroku CAS instance. 