### PR TITLE
Objects should not be created to be dropped immediately without being used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ env:
   - secure: "iWPPLKSS3zBs2adqLPkMiHfCj2hSLyD5BoV3oodhR7Ne83Kpn1khRcEWFoHF3Ed11eSU+glNdPSzUpc8TzwTZGx5B3RU2Qp36hZFyjuzNWJARmoVPYMiEg3FFBQrUR75w+Tbtn6zPkiAk6nl0K5ewmY0/xixVdnTLXL5HjpE2rc="
   - secure: "f3mDIZ8m6NYJXI8KvWD/sZRSeCCyIyfgPRy3Q6o9u9WyHZuYaJf95Ia0eJQ3gxUDS1TKL31Vk08dhFKrfIcKgifFPa2uQ2uyJkvGxlarMTQ+tpqsZYp4zAJgKc9r4xdZasvF2k4xqr+pl9AFjlpXB4jDD59XPXt3DcRABOYA9sM="
 before_script:
+ - export JAVA_OPTS="-Xmx2048m -XX:MaxPermSize=512m"
  - echo $JAVA_OPTS
- - export JAVA_OPTS=-Xmx512m
 before_install:
 - chmod -R 777 ./travis/init-travis-build.sh
 - ./travis/init-travis-build.sh

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -100,10 +100,6 @@ public class KryoTranscoderTests {
                 new AcceptUsersAuthenticationHandler(),
                 new BasicCredentialMetaData(userPassCredential)));
 
-        new TicketGrantingTicketImpl(TGT_ID,
-                org.jasig.cas.authentication.TestUtils.getService(), null, bldr.build(),
-                new NeverExpiresExpirationPolicy());
-
         final TicketGrantingTicket expectedTGT =
                 new TicketGrantingTicketImpl(TGT_ID,
                         org.jasig.cas.services.TestUtils.getService(),

--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/view/Saml10SuccessResponseView.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/view/Saml10SuccessResponseView.java
@@ -96,7 +96,6 @@ public final class Saml10SuccessResponseView extends AbstractSaml10ResponseView 
      */
     private Map<String, Object> prepareSamlAttributes(final Map<String, Object> model, final Service service) {
         final Map<String, Object> authnAttributes = new HashMap<>(getAuthenticationAttributesAsMultiValuedAttributes(model));
-                new HashMap<>(getAuthenticationAttributesAsMultiValuedAttributes(model));
         if (isRememberMeAuthentication(model)) {
             authnAttributes.remove(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
             authnAttributes.put(this.rememberMeAttributeName, Boolean.TRUE.toString());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1848 - Objects should not be created to be dropped immediately without being used
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1848
Please let me know if you have any questions.
Kirill Vlasov