### PR TITLE
force cookie only session tracking

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -220,10 +220,11 @@
         <servlet-name>cas</servlet-name>
         <url-pattern>/v1/*</url-pattern>
     </servlet-mapping>
-    
+
     <session-config>
         <!-- Default to 5 minute session timeouts -->
         <session-timeout>5</session-timeout>
+        <tracking-mode>COOKIE</tracking-mode>
     </session-config>
 
     <error-page>


### PR DESCRIPTION
Without this, occasionally, `/login` gets the `jsessionid` appended to the URL. Also some local javascript or css loads.