### PR TITLE
Registered Service properties backported to 4.1

### DIFF
--- a/cas-server-core-api/src/main/java/org/jasig/cas/services/RegisteredService.java
+++ b/cas-server-core-api/src/main/java/org/jasig/cas/services/RegisteredService.java
@@ -22,6 +22,7 @@ import org.jasig.cas.authentication.principal.Service;
 
 import java.io.Serializable;
 import java.net.URL;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -179,5 +180,14 @@ public interface RegisteredService extends Cloneable, Serializable {
      * @since 4.1
      */
     RegisteredServicePublicKey getPublicKey();
+
+    /**
+     * Describes extra metadata about the service; custom fields
+     * that could be used by submodules implementing additional
+     * behavior on a per-service basis.
+     * @return map of custom metadata.
+     * @since 4.2
+     */
+    Map<String, RegisteredServiceProperty> getProperties();
     
 }

--- a/cas-server-core-api/src/main/java/org/jasig/cas/services/RegisteredServiceProperty.java
+++ b/cas-server-core-api/src/main/java/org/jasig/cas/services/RegisteredServiceProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jasig.cas.services;
 
 import java.io.Serializable;

--- a/cas-server-core-api/src/main/java/org/jasig/cas/services/RegisteredServiceProperty.java
+++ b/cas-server-core-api/src/main/java/org/jasig/cas/services/RegisteredServiceProperty.java
@@ -1,0 +1,37 @@
+package org.jasig.cas.services;
+
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * The {@link RegisteredServiceProperty} defines a single custom
+ * property that is associated with a service.
+ *
+ * @author Misagh Moayyed
+ * @since 4.1
+ */
+public interface RegisteredServiceProperty extends Serializable {
+
+    /**
+     * Gets values.
+     *
+     * @return the values
+     */
+    Set<String> getValues();
+
+    /**
+     * Gets the first single value.
+     *
+     *
+     * @return the value, or null if the collection is empty.
+     */
+    String getValue();
+
+    /**
+     * Contains elements?
+     *
+     * @param value the value
+     * @return true/false
+     */
+    boolean contains(String value);
+}

--- a/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
@@ -27,21 +27,27 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.DiscriminatorType;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
+import javax.persistence.JoinTable;
 import javax.persistence.Lob;
+import javax.persistence.OneToMany;
 import javax.persistence.PostLoad;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -134,6 +140,11 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
     @Column(name = "public_key", nullable = true, length = Integer.MAX_VALUE)
     private RegisteredServicePublicKey publicKey;
 
+
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JoinTable(name="RegisteredServiceImpl_Properties")
+    private Map<String, DefaultRegisteredServiceProperty> properties = new HashMap<>();
+
     @Override
     public long getId() {
         return this.id;
@@ -199,6 +210,9 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
         if (this.attributeReleasePolicy == null) {
             this.attributeReleasePolicy = new ReturnAllowedAttributeReleasePolicy();
         }
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
     }
 
     @Override
@@ -233,6 +247,7 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
                 .append(this.publicKey, that.publicKey)
                 .append(this.logoutUrl, that.logoutUrl)
                 .append(this.requiredHandlers, that.requiredHandlers)
+                .append(this.properties, that.properties)
                 .isEquals();
     }
 
@@ -253,6 +268,7 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
                 .append(this.publicKey)
                 .append(this.logoutUrl)
                 .append(this.requiredHandlers)
+                .append(this.properties)
                 .toHashCode();
     }
 
@@ -359,7 +375,7 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
         this.setLogoutUrl(source.getLogoutUrl());
         this.setPublicKey(source.getPublicKey());
         this.setRequiredHandlers(source.getRequiredHandlers());
-
+        this.setProperties(source.getProperties());
     }
 
     /**
@@ -396,6 +412,7 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
         toStringBuilder.append("logo", this.logo);
         toStringBuilder.append("logoutUrl", this.logoutUrl);
         toStringBuilder.append("requiredHandlers", this.requiredHandlers);
+        toStringBuilder.append("properties", this.properties);
 
         return toStringBuilder.toString();
     }
@@ -460,5 +477,14 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
 
     public void setPublicKey(@NotNull final RegisteredServicePublicKey publicKey) {
         this.publicKey = publicKey;
+    }
+
+    @Override
+    public Map<String, RegisteredServiceProperty> getProperties() {
+        return (Map) this.properties;
+    }
+
+    public void setProperties(final Map<String, RegisteredServiceProperty> properties) {
+        this.properties = (Map) properties;
     }
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/services/DefaultRegisteredServiceProperty.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/DefaultRegisteredServiceProperty.java
@@ -1,0 +1,98 @@
+package org.jasig.cas.services;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The {@link DefaultRegisteredServiceProperty} represents
+ * a single property associated with a registered service.
+ * Properties are assumed to be a set a String values.
+ *
+ * @author Misagh Moayyed
+ * @since 4.1
+ */
+@Entity
+@Table(name="RegisteredServiceImplProperty")
+public class DefaultRegisteredServiceProperty implements RegisteredServiceProperty {
+    private static final long serialVersionUID = 1349556364689133211L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    @Lob
+    @Column(name = "property_values")
+    private HashSet<String> values = new HashSet<>();
+
+    @Override
+    public Set<String> getValues() {
+        if (this.values == null) {
+            this.values = new HashSet<>();
+        }
+        return values;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getValue() {
+        if (this.values.isEmpty()) {
+            return null;
+        }
+        return this.values.iterator().next();
+    }
+
+    @Override
+    public boolean contains(final String value) {
+        return this.values.contains(value);
+    }
+
+    /**
+     * Sets values.
+     *
+     * @param values the values
+     */
+    public void setValues(final Set<String> values) {
+        getValues().clear();
+        if (values == null) {
+            return;
+        }
+        for (final String handler : values) {
+            getValues().add(handler);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        final DefaultRegisteredServiceProperty rhs = (DefaultRegisteredServiceProperty) obj;
+        return new EqualsBuilder()
+                .append(this.values, rhs.values)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(this.values)
+                .toHashCode();
+    }
+}

--- a/cas-server-core/src/main/java/org/jasig/cas/services/DefaultRegisteredServiceProperty.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/DefaultRegisteredServiceProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jasig.cas.services;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/cas-server-core/src/test/java/org/jasig/cas/services/JsonServiceRegistryDaoTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/JsonServiceRegistryDaoTests.java
@@ -391,4 +391,39 @@ public class JsonServiceRegistryDaoTests {
         assertEquals(r.getTheme(), r3.getTheme());
         this.dao.delete(r);
     }
+
+    @Test
+    public void persistCustomServiceProperties() throws Exception {
+        final RegexRegisteredService r = new RegexRegisteredService();
+        r.setServiceId("^https://.+");
+        r.setName("persistCustomServiceProperties");
+        r.setId(4245);
+
+        final Map<String, RegisteredServiceProperty> properties = new HashMap<>();
+        final DefaultRegisteredServiceProperty property = new DefaultRegisteredServiceProperty();
+        final Set<String> values = new HashSet<>();
+        values.add("value1");
+        values.add("value2");
+        property.setValues(values);
+        properties.put("field1", property);
+
+
+        final DefaultRegisteredServiceProperty property2 = new DefaultRegisteredServiceProperty();
+        final Set<String> values2 = new HashSet<>();
+        values2.add("value12");
+        values2.add("value22");
+        property2.setValues(values2);
+        properties.put("field2", property2);
+
+        r.setProperties(properties);
+
+        this.dao.save(r);
+        final List<RegisteredService> list = this.dao.load();
+        assertNotNull(this.dao.findServiceById(r.getId()));
+        assertEquals(r.getProperties().size(), 2);
+        assertNotNull(r.getProperties().get("field1"));
+
+        final RegisteredServiceProperty prop = r.getProperties().get("field1");
+        assertEquals(prop.getValues().size(), 2);
+    }
 }

--- a/cas-server-documentation/installation/Configuring-LongTerm-Authentication.md
+++ b/cas-server-documentation/installation/Configuring-LongTerm-Authentication.md
@@ -20,14 +20,8 @@ by weighing convenience against security risks. The length of the long term auth
 
 The use of long term authentication sessions dramatically increases the length of time ticket-granting tickets are
 stored in the ticket registry. Loss of a ticket-granting ticket corresponding to a long-term SSO session would require
-the user to reauthenticate to CAS. A security policy that requires that long term authentication sessions MUST NOT
-be terminated prior to their natural expiration would mandate a ticket registry component that provides for durable storage. Memcached is a notable example of a store that has no facility for durable storage. In many cases loss of
-ticket-granting tickets is acceptable, even for long term authentication sessions.
-
-It's important to note that ticket-granting tickets and service tickets can be stored in separate registries, where
-the former provides durable storage for persistent long-term authentication tickets and the latter provides less
-durable storage for ephemeral service tickets. Thus deployers could mix `JpaTicketRegistry` and
-`MemcachedTicketRegistry`, for example, to take advantage of their strengths, durability and speed respectively.
+the user to re-authenticate to CAS. A security policy that requires that long term authentication sessions MUST NOT
+be terminated prior to their natural expiration would mandate a ticket registry component that provides for durable storage, such as the `JpaTicketRegistry`.
 
 
 ### Component Configuration

--- a/cas-server-documentation/installation/Service-Management.md
+++ b/cas-server-documentation/installation/Service-Management.md
@@ -58,6 +58,9 @@ Registered services present the following metadata:
 | `accessStrategy`                  | The strategy configuration that outlines and access rules for this service. It describes whether the service is allowed, authorized to participate in SSO, or can be granted access from the CAS perspective based on a particular attribute-defined role, aka RBAC. See [this guide](../integration/Attribute-Release.html) for more details on attribute release and filters.  
 | `publicKey`                       | The public key associated with this service that is used to authorize the request by encrypting certain elements and attributes in the CAS validation protocol response, such as [the PGT](Configuring-Proxy-Authentication.html) or [the credential](../integration/ClearPass.html). See [this guide](../integration/Attribute-Release.html) for more details on attribute release and filters.  
 | `logoutUrl`                       | URL endpoint for this service to receive logout requests. See [this guide](Logout-Single-Signout.html) for more details
+| `properties`                  		| Extra metadata associated with this service in form of key/value pairs. 
+This is used to inject custom fields into the service definition, to be used later by extension 
+modules to define additional behavior on a per-service basis.
 
 ###Configure Service Access Strategy
 The access strategy of a registered service provides fine-grained control over the service authorization rules. it describes whether the service is allowed to use the CAS server, allowed to participate in single sign-on authentication, etc. Additionally, it may be configured to require a certain set of principal attributes that must exist before access can be granted to the service. This behavior allows one to configure various attributes in terms of access roles for the application and define rules that would be enacted and validated when an authentication request from the application arrives.


### PR DESCRIPTION
This is a change backported from 4.1 allowing a service to carry arbitrary properties. This is required to support cas-MFA's upgrade to 4.1