### PR TITLE
Allow the ClientCredential to ignore the typedid if configured

### DIFF
--- a/cas-server-core/src/test/java/org/jasig/cas/CentralAuthenticationServiceImplTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/CentralAuthenticationServiceImplTests.java
@@ -227,15 +227,16 @@ public class CentralAuthenticationServiceImplTests extends AbstractCentralAuthen
 
     @Test(expected = UnauthorizedServiceException.class)
     public void verifyValidateServiceTicketWithInvalidService() throws Exception {
-        final AuthenticationContext ctx = TestUtils.getAuthenticationContext(getAuthenticationSystemSupport(), getService("test2"));
+        final Service service = getService("badtestservice");
+        final AuthenticationContext ctx = TestUtils.getAuthenticationContext(getAuthenticationSystemSupport(), service);
 
         final TicketGrantingTicket ticketGrantingTicket = getCentralAuthenticationService()
             .createTicketGrantingTicket(ctx);
         final ServiceTicket serviceTicket = getCentralAuthenticationService()
-            .grantServiceTicket(ticketGrantingTicket.getId(), getService(), ctx);
+            .grantServiceTicket(ticketGrantingTicket.getId(), service, ctx);
 
         getCentralAuthenticationService().validateServiceTicket(
-            serviceTicket.getId(), getService("test2"));
+            serviceTicket.getId(), service);
     }
 
     @Test(expected = AbstractTicketException.class)

--- a/cas-server-core/src/test/resources/core-context.xml
+++ b/cas-server-core/src/test/resources/core-context.xml
@@ -95,10 +95,10 @@
             </property>
         </bean>
 
-        <bean class="org.jasig.cas.services.RegisteredServiceImpl">
+        <bean class="org.jasig.cas.services.RegexRegisteredService">
             <property name="id" value="1"/>
             <property name="name" value="Test Default Service"/>
-            <property name="serviceId" value="testDefault"/>
+            <property name="serviceId" value="^test.*"/>
             <property name="evaluationOrder" value="2"/>
         </bean>
 

--- a/cas-server-core/src/test/resources/core-context.xml
+++ b/cas-server-core/src/test/resources/core-context.xml
@@ -95,13 +95,6 @@
             </property>
         </bean>
 
-        <bean class="org.jasig.cas.services.RegexRegisteredService">
-            <property name="id" value="1"/>
-            <property name="name" value="Test Default Service"/>
-            <property name="serviceId" value="^test.*"/>
-            <property name="evaluationOrder" value="2"/>
-        </bean>
-
         <bean class="org.jasig.cas.services.RegisteredServiceImpl">
             <property name="id" value="2"/>
             <property name="name" value="EduPerson Test Service"/>
@@ -117,11 +110,80 @@
 
         </bean>
 
+        <bean class="org.jasig.cas.services.RegexRegisteredService">
+            <property name="id" value="35"/>
+            <property name="name" value="Test Encryption of Attributes"/>
+            <property name="serviceId" value="testencryption$"/>
+            <property name="evaluationOrder" value="3"/>
+            <property name="publicKey">
+                <bean class="org.jasig.cas.services.RegisteredServicePublicKeyImpl"
+                      c:location="classpath:keys/RSA1024Public.key"
+                      c:algorithm="RSA"/>
+            </property>
+            <property name="attributeReleasePolicy">
+                <bean class="org.jasig.cas.services.ReturnAllowedAttributeReleasePolicy"
+                      p:authorizedToReleaseCredentialPassword="true"
+                      p:authorizedToReleaseProxyGrantingTicket="true"/>
+            </property>
+        </bean>
+
+        <bean class="org.jasig.cas.services.RegexRegisteredService">
+            <property name="id" value="111"/>
+            <property name="name" value="TestServiceAttributeForAuthzFails"/>
+            <property name="serviceId" value="^TestServiceAttributeForAuthzFails"/>
+            <property name="evaluationOrder" value="4"/>
+            <property name="accessStrategy">
+                <bean class="org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy">
+                    <property name="requiredAttributes">
+                        <map>
+                            <entry key="cn"
+                                   value="cnValue"/>
+                            <entry key="givenName"
+                                   value="gnameValue"/>
+                        </map>
+                    </property>
+                </bean>
+            </property>
+        </bean>
+
+        <bean class="org.jasig.cas.services.RegexRegisteredService">
+            <property name="id" value="222"/>
+            <property name="name" value="TestSsoFalse"/>
+            <property name="serviceId" value="^TestSsoFalse"/>
+            <property name="evaluationOrder" value="5"/>
+            <property name="accessStrategy">
+                <bean class="org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy"
+                      c:ssoEnabled="false"
+                      c:enabled="true"/>
+            </property>
+        </bean>
+
+        <bean class="org.jasig.cas.services.RegexRegisteredService">
+            <property name="id" value="100"/>
+            <property name="name" value="TestServiceAttributeForAuthzPasses"/>
+            <property name="serviceId" value="TestServiceAttributeForAuthzPasses"/>
+            <property name="evaluationOrder" value="6"/>
+            <property name="accessStrategy">
+                <bean class="org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy">
+                    <property name="requiredAttributes">
+                        <map>
+                            <entry key="groupMembership"
+                                   value="adopters"/>
+                        </map>
+                    </property>
+                </bean>
+            </property>
+            <property name="attributeReleasePolicy">
+                <bean class="org.jasig.cas.services.ReturnAllAttributeReleasePolicy"/>
+            </property>
+        </bean>
+
+
         <bean class="org.jasig.cas.services.RegisteredServiceImpl">
             <property name="id" value="3"/>
             <property name="name" value="EduPerson Test Invalid Service"/>
             <property name="serviceId" value="eduPersonTestInvalid"/>
-            <property name="evaluationOrder" value="4"/>
+            <property name="evaluationOrder" value="7"/>
             <property name="usernameAttributeProvider">
                 <bean class="org.jasig.cas.services.PrincipalAttributeRegisteredServiceUsernameProvider"
                       c:usernameAttribute="nonExistentAttributeName"/>
@@ -141,18 +203,19 @@
             <property name="id" value="333"/>
             <property name="name" value="proxyService"/>
             <property name="serviceId" value="proxyService"/>
-            <property name="evaluationOrder" value="333"/>
+            <property name="evaluationOrder" value="8"/>
         </bean>
 
         <bean class="org.jasig.cas.services.RegisteredServiceImpl">
             <property name="id" value="4"/>
             <property name="name" value="Test Service anonymous"/>
             <property name="serviceId" value="testAnonymous"/>
-            <property name="evaluationOrder" value="5"/>
+            <property name="evaluationOrder" value="9"/>
             <property name="usernameAttributeProvider">
                 <bean class="org.jasig.cas.services.AnonymousRegisteredServiceUsernameAttributeProvider" />
             </property>
         </bean>
+
 
         <bean class="org.jasig.cas.services.RegexRegisteredService">
             <property name="id" value="10"/>
@@ -169,7 +232,7 @@
             <property name="id" value="100"/>
             <property name="name" value="TestProxyService"/>
             <property name="serviceId" value="proxyService"/>
-            <property name="evaluationOrder" value="100"/>
+            <property name="evaluationOrder" value="11"/>
             <property name="proxyPolicy">
                 <bean class="org.jasig.cas.services.RegexMatchingRegisteredServiceProxyPolicy"
                       c:pgtUrlPattern="^https://.+"/>
@@ -177,72 +240,14 @@
         </bean>
 
         <bean class="org.jasig.cas.services.RegexRegisteredService">
-            <property name="id" value="222"/>
-            <property name="name" value="TestSsoFalse"/>
-            <property name="serviceId" value="^TestSsoFalse"/>
-            <property name="evaluationOrder" value="555"/>
-            <property name="accessStrategy">
-                <bean class="org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy"
-                      c:ssoEnabled="false"
-                      c:enabled="true"/>
-            </property>
+            <property name="id" value="1"/>
+            <property name="name" value="Test Default Service"/>
+            <property name="serviceId" value="^test.*"/>
+            <property name="evaluationOrder" value="100"/>
         </bean>
 
-        <bean class="org.jasig.cas.services.RegexRegisteredService">
-            <property name="id" value="111"/>
-            <property name="name" value="TestServiceAttributeForAuthzFails"/>
-            <property name="serviceId" value="^TestServiceAttributeForAuthzFails"/>
-            <property name="evaluationOrder" value="600"/>
-            <property name="accessStrategy">
-                <bean class="org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy">
-                    <property name="requiredAttributes">
-                        <map>
-                            <entry key="cn"
-                                   value="cnValue"/>
-                            <entry key="givenName"
-                                   value="gnameValue"/>
-                        </map>
-                    </property>
-                </bean>
-            </property>
-        </bean>
 
-        <bean class="org.jasig.cas.services.RegexRegisteredService">
-            <property name="id" value="100"/>
-            <property name="name" value="TestServiceAttributeForAuthzPasses"/>
-            <property name="serviceId" value="TestServiceAttributeForAuthzPasses"/>
-            <property name="evaluationOrder" value="610"/>
-            <property name="accessStrategy">
-                <bean class="org.jasig.cas.services.DefaultRegisteredServiceAccessStrategy">
-                    <property name="requiredAttributes">
-                        <map>
-                            <entry key="groupMembership"
-                                   value="adopters"/>
-                        </map>
-                    </property>
-                </bean>
-            </property>
-            <property name="attributeReleasePolicy">
-                <bean class="org.jasig.cas.services.ReturnAllAttributeReleasePolicy"/>
-            </property>
-        </bean>
 
-        <bean class="org.jasig.cas.services.RegexRegisteredService">
-            <property name="id" value="35"/>
-            <property name="name" value="Test Encryption of Attributes"/>
-            <property name="serviceId" value="testencryption$"/>
-            <property name="evaluationOrder" value="1"/>
-            <property name="publicKey">
-                <bean class="org.jasig.cas.services.RegisteredServicePublicKeyImpl"
-                      c:location="classpath:keys/RSA1024Public.key"
-                      c:algorithm="RSA"/>
-            </property>
-            <property name="attributeReleasePolicy">
-                <bean class="org.jasig.cas.services.ReturnAllowedAttributeReleasePolicy"
-                      p:authorizedToReleaseCredentialPassword="true"
-                      p:authorizedToReleaseProxyGrantingTicket="true"/>
-            </property>
-        </bean>
 
     </util:list>
 

--- a/cas-server-integration-pac4j-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractPac4jAuthenticationHandler.java
+++ b/cas-server-integration-pac4j-core/src/main/java/org/jasig/cas/authentication/handler/support/AbstractPac4jAuthenticationHandler.java
@@ -47,6 +47,7 @@ public abstract class AbstractPac4jAuthenticationHandler extends AbstractPreAndP
             }
             if (StringUtils.isNotBlank(id)) {
                 credentials.setUserProfile(profile);
+                credentials.setTypedIdUsed(typedIdUsed);
                 return new DefaultHandlerResult(
                         this,
                         new BasicCredentialMetaData(credentials),

--- a/cas-server-integration-pac4j-core/src/main/java/org/jasig/cas/authentication/principal/ClientCredential.java
+++ b/cas-server-integration-pac4j-core/src/main/java/org/jasig/cas/authentication/principal/ClientCredential.java
@@ -1,9 +1,9 @@
 package org.jasig.cas.authentication.principal;
 
-import java.io.Serializable;
-
 import org.jasig.cas.authentication.Credential;
 import org.pac4j.core.profile.UserProfile;
+
+import java.io.Serializable;
 
 /**
  * This class represents client credentials and (after authentication) a user profile.
@@ -17,6 +17,8 @@ public final class ClientCredential implements Credential, Serializable {
      * The servialVersionUID.
      */
     private static final long serialVersionUID = -7883301304291894763L;
+
+    private boolean typedIdUsed = true;
 
     /**
      * The user profile after authentication.
@@ -67,8 +69,15 @@ public final class ClientCredential implements Credential, Serializable {
     @Override
     public String getId() {
         if (this.userProfile != null) {
-            return this.userProfile.getTypedId();
+            if (this.typedIdUsed) {
+                return this.userProfile.getTypedId();
+            }
+            return this.userProfile.getId();
         }
         return null;
+    }
+
+    public void setTypedIdUsed(final boolean typedIdUsed) {
+        this.typedIdUsed = typedIdUsed;
     }
 }


### PR DESCRIPTION
Closes https://github.com/Jasig/cas/issues/1413

The ClientCredential does always use the typedId, which causes issues down the road for PrincipalResolvers that work separately from the Principal produced by the ClientAuthenticationHandler. 

This should be ported back to 4.2 and 4.1,