### PR TITLE
Update the OAuth error view name

### DIFF
--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
@@ -65,7 +65,7 @@ public interface OAuthConstants {
     String CONFIRM_VIEW = "oauthConfirmView";
 
     /** The error view. */
-    String ERROR_VIEW = "viewServiceErrorView";
+    String ERROR_VIEW = "serviceErrorView";
 
     /** The invalid request. */
     String INVALID_REQUEST = "invalid_request";


### PR DESCRIPTION
the error view names were changed in https://github.com/Jasig/cas/commit/c941a083875e96b79a951dec5b8cf1c44e8ea03c but not updated for OAuth.

This will need to be backported to 4.1 and 4.2