### PR TITLE
Update X.509 Authentication Guide

### DIFF
--- a/cas-server-documentation/installation/X509-Authentication.md
+++ b/cas-server-documentation/installation/X509-Authentication.md
@@ -346,7 +346,7 @@ Use the following template to configure authentication in `deployerConfigContext
       p:maxPathLengthAllowUnspecified="true"
       p:checkKeyUsage="true"
       p:requireKeyUsage="true"
-      p:revocationChecker-ref="revocationChecker">
+      p:revocationChecker-ref="revocationChecker" />
 
 <bean id="x509PrincipalResolver"
       class="org.jasig.cas.adaptors.x509.authentication.principal.X509SubjectPrincipalResolver"

--- a/cas-server-documentation/installation/X509-Authentication.md
+++ b/cas-server-documentation/installation/X509-Authentication.md
@@ -373,7 +373,7 @@ Uncomment the `startAuthenticate` state in `login-webflow.xml`:
 
 {% highlight xml %}
 <action-state id="startAuthenticate">
-  <action bean="x509Check" />
+  <evaluate expression="x509Check" />
   <transition on="success" to="sendTicketGrantingTicket" />
   <transition on="warn" to="warn" />
   <transition on="error" to="generateLoginTicket" />


### PR DESCRIPTION
**NOTE:** This replaces PR #1431 
--------
When attempting to follow the X.509 Authentication Guide, I found some errors in the documentation and code snippets. This included:

* [x] mal-formed xml syntax
* [x] deprecated spring webflow properties and beans

This PR addresses these concerns. I have validated the included configurations worked on my clean configuration, of which the details are below:

* Fedora 23
* Oracle JRE 1.8.0_66
* Apache Tomcat 8
* Jasig CAS 4.1.3
* CAS X509 Handler 4.1.3