### PR TITLE
jstl 1.2 embeds the taglibs/standard dependency

### DIFF
--- a/cas-management-webapp-support/build.gradle
+++ b/cas-management-webapp-support/build.gradle
@@ -64,7 +64,6 @@ dependencies {
         exclude(module: 'validation-api')
     }
     runtime group: 'org.apache.logging.log4j', name: 'log4j-web', version: log4jVersion
-    runtime group: 'taglibs', name: 'standard', version: taglibsVersion
     runtime(group: 'org.hibernate', name: 'hibernate-validator', version: hibernateValidatorVersion) {
         exclude(module: 'slf4j-api')
         exclude(module: 'jboss-logging')

--- a/cas-server-webapp/build.gradle
+++ b/cas-server-webapp/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     compile group: 'com.lmax', name: 'disruptor', version: disruptorVersion
     runtime group: 'org.springframework', name: 'spring-expression', version: springVersion
     runtime group: 'javax.servlet', name: 'jstl', version: javaxJstlVersion
-    runtime group: 'taglibs', name: 'standard', version: taglibsVersion
     runtime group: 'org.jasig.cas', name: 'cas-server-security-filter', version: casSecurityFilterVersion
     runtime(group: 'com.ryantenney.metrics', name: 'metrics-spring', version: dropwizardMetricsVersion) {
         exclude(module: 'slf4j-api')

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@ javaxSevletVersion=3.1.0
 javaxElVersion=3.0.0
 javaxElImplVersion=2.2.6
 javaxValidationVersion=1.1.0.Final
-taglibsVersion=1.1.2
 javassistVersion=3.12.1.GA
 javaxJstlVersion=1.2
 


### PR DESCRIPTION
taglibs/standard is no longer necessary since it is in the jstl 1.2 jar

see: http://stackoverflow.com/tags/jstl/info