### PR TITLE
Fix for ba-debug JS dependency

### DIFF
--- a/cas-server-webapp/src/main/webapp/js/cas.js
+++ b/cas-server-webapp/src/main/webapp/js/cas.js
@@ -20,7 +20,7 @@
 var scripts = [ "https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js",
     "https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js",
     "https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js",
-    "https://rawgithub.com/cowboy/javascript-debug/master/ba-debug.min.js"];
+    "https://cdn.rawgit.com/cowboy/javascript-debug/master/ba-debug.min.js"];
 
 head.ready(document, function() {
     head.load(scripts, resourceLoadedSuccessfully);


### PR DESCRIPTION
Rawgit recomends use: https://cdn.rawgit.com/cowboy/javascript-debug/master/ba-debug.min.js instead of https://rawgithub.com/cowboy/javascript-debug/master/ba-debug.min.js

Extract from https://rawgit.com/faq FAQ:
 
Can I use a rawgit.com URL on a production website?
No. Please use cdn.rawgit.com for anything that might result in heavy traffic. Only use rawgit.com URLs for low-traffic testing and sharing temporary examples or demos during development. When people misuse rawgit.com, it costs me money. Please don't be a jerk.