### PR TITLE
Quartz shutdown on 4.2

### DIFF
--- a/cas-server-core-services/src/main/java/org/jasig/cas/services/DefaultServicesManagerImpl.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/services/DefaultServicesManagerImpl.java
@@ -3,7 +3,6 @@ package org.jasig.cas.services;
 import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.support.events.CasRegisteredServiceDeletedEvent;
 import org.jasig.cas.support.events.CasRegisteredServiceSavedEvent;
-import org.jasig.cas.util.CasSpringBeanJobFactory;
 import org.jasig.inspektr.audit.annotation.Audit;
 import org.joda.time.DateTime;
 import org.quartz.Job;
@@ -12,12 +11,9 @@ import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.Scheduler;
-import org.quartz.SchedulerFactory;
 import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
-import org.quartz.impl.StdSchedulerFactory;
-import org.quartz.spi.JobFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +70,10 @@ public final class DefaultServicesManagerImpl implements ReloadableServicesManag
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Autowired(required = false)
+    @Qualifier("scheduler")
+    private Scheduler scheduler;
 
     /**
      * Instantiates a new default services manager impl.
@@ -208,14 +208,8 @@ public final class DefaultServicesManagerImpl implements ReloadableServicesManag
                         .withIntervalInSeconds(this.refreshInterval)
                         .repeatForever()).build();
 
-                final JobFactory jobFactory = new CasSpringBeanJobFactory(this.applicationContext);
-                final SchedulerFactory schFactory = new StdSchedulerFactory();
-                final Scheduler sch = schFactory.getScheduler();
-                sch.setJobFactory(jobFactory);
-
-                sch.start();
-                LOGGER.debug("Started {} scheduler", this.getClass().getName());
-                sch.scheduleJob(job, trigger);
+                LOGGER.debug("Scheduling {} job", this.getClass().getName());
+                scheduler.scheduleJob(job, trigger);
                 LOGGER.info("Services manager will reload service definitions every {} seconds",
                     this.refreshInterval);
             }
@@ -226,7 +220,7 @@ public final class DefaultServicesManagerImpl implements ReloadableServicesManag
     }
 
     private boolean shouldScheduleLoaderJob() {
-        if (this.startDelay > 0 && this.applicationContext.getParent() == null) {
+        if (this.startDelay > 0 && this.applicationContext.getParent() == null && scheduler != null) {
             LOGGER.debug("Found CAS servlet application context for service management");
             return true;
         }

--- a/cas-server-core-util/src/main/java/org/jasig/cas/util/CasSpringBeanJobFactory.java
+++ b/cas-server-core-util/src/main/java/org/jasig/cas/util/CasSpringBeanJobFactory.java
@@ -3,6 +3,7 @@ package org.jasig.cas.util;
 import org.quartz.spi.TriggerFiredBundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.quartz.SpringBeanJobFactory;
@@ -26,6 +27,7 @@ public class CasSpringBeanJobFactory extends SpringBeanJobFactory {
      *
      * @param applicationContext the application context
      */
+    @Autowired
     public CasSpringBeanJobFactory(final ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }

--- a/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
@@ -10,6 +10,7 @@ import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.TicketGrantingTicketImpl;
 import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 import org.jasig.cas.ticket.registry.support.LockingStrategy;
+import org.joda.time.DateTime;
 import org.quartz.Job;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
@@ -50,10 +51,10 @@ import java.util.concurrent.TimeUnit;
 @Component("jpaTicketRegistry")
 public final class JpaTicketRegistry extends AbstractDistributedTicketRegistry implements Job {
 
-    @Value("${ticket.registry.cleaner.repeatinterval:5000000}")
+    @Value("${ticket.registry.cleaner.repeatinterval:5000}")
     private int refreshInterval;
 
-    @Value("${ticket.registry.cleaner.startdelay:20000}")
+    @Value("${ticket.registry.cleaner.startdelay:20}")
     private int startDelay;
 
     @Autowired
@@ -246,9 +247,9 @@ public final class JpaTicketRegistry extends AbstractDistributedTicketRegistry i
 
                 final Trigger trigger = TriggerBuilder.newTrigger()
                     .withIdentity(this.getClass().getSimpleName().concat(UUID.randomUUID().toString()))
-                    .startAt(new Date(System.currentTimeMillis() + this.startDelay))
+                    .startAt(DateTime.now().plusSeconds(this.startDelay).toDate())
                     .withSchedule(SimpleScheduleBuilder.simpleSchedule()
-                        .withIntervalInMinutes(this.refreshInterval)
+                        .withIntervalInSeconds(this.refreshInterval)
                         .repeatForever()).build();
 
                 logger.debug("Scheduling {} job", this.getClass().getName());

--- a/cas-server-support-saml-mdui/src/main/java/org/jasig/cas/support/saml/web/flow/mdui/StaticMetadataResolverAdapter.java
+++ b/cas-server-support-saml-mdui/src/main/java/org/jasig/cas/support/saml/web/flow/mdui/StaticMetadataResolverAdapter.java
@@ -8,11 +8,11 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
-import org.quartz.SchedulerFactory;
 import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
-import org.quartz.impl.StdSchedulerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.Resource;
 
 import javax.annotation.PostConstruct;
@@ -34,6 +34,10 @@ public final class StaticMetadataResolverAdapter extends AbstractMetadataResolve
       * minutes by default.
       **/
     private int refreshIntervalInMinutes = DEFAULT_METADATA_REFRESH_INTERNAL_MINS;
+
+    @Autowired
+    @Qualifier("scheduler")
+    private Scheduler scheduler;
 
     /**
      * New ctor - required for serialization and job scheduling.
@@ -77,10 +81,7 @@ public final class StaticMetadataResolverAdapter extends AbstractMetadataResolve
                         .repeatForever()).build();
 
         try {
-            final SchedulerFactory schFactory = new StdSchedulerFactory();
-            final Scheduler sch = schFactory.getScheduler();
-            sch.start();
-            sch.scheduleJob(job, trigger);
+            scheduler.scheduleJob(job, trigger);
         } catch (final SchedulerException e) {
             throw new RuntimeException(e);
         }

--- a/cas-server-support-saml-mdui/src/test/resources/META-INF/spring/opensaml-config.xml
+++ b/cas-server-support-saml-mdui/src/test/resources/META-INF/spring/opensaml-config.xml
@@ -155,6 +155,8 @@
         </property>
     </bean>
 
+    <bean id="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean" />
+
     <bean id="validationAnnotationBeanPostProcessor" class="org.jasig.cas.util.CustomBeanValidationPostProcessor"
           p:afterInitialization="true"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -466,7 +466,7 @@ accept.authn.users=casuser::Mellon
 # cas.saml.ticketid.saml2=false
 
 ##
-# Drfault Ticket Registry
+# Default Ticket Registry
 #
 # default.ticket.registry.initialcapacity=1000
 # default.ticket.registry.loadfactor=1
@@ -475,8 +475,9 @@ accept.authn.users=casuser::Mellon
 ##
 # Ticket Registry Cleaner
 #
-# ticket.registry.cleaner.startdelay=20000
-# ticket.registry.cleaner.repeatinterval=5000000
+# Indicates how frequently the Ticket Registry cleaner should run. Configured in seconds.
+# ticket.registry.cleaner.startdelay=20
+# ticket.registry.cleaner.repeatinterval=5000
 
 ##
 # Ticket ID Generation

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -380,6 +380,15 @@ accept.authn.users=casuser::Mellon
 # service.registry.quartz.reloader.repeatInterval=120000
 
 ##
+# Background Scheduler
+#
+# Wait for scheduler to finish running before shutting down CAS.
+# scheduler.shutdown.wait=true
+#
+# Attempt to interrupt background jobs when shutting down CAS
+# scheduler.shutdown.interruptJobs=true
+
+##
 # Log4j
 # It is often time helpful to externalize log4j.xml to a system path to preserve settings between upgrades.
 # log4j.config.location=file:///etc/cas/log4j2.xml

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
@@ -69,4 +69,20 @@
           -->
     </bean>
 
+    <!-- The Quartz scheduler used by any scheduled tasks -->
+    <bean id="scheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean"
+        p:waitForJobsToCompleteOnShutdown="${scheduler.shutdown.wait:true}">
+        <property name="jobFactory">
+            <bean class="org.jasig.cas.util.CasSpringBeanJobFactory" />
+        </property>
+        <property name="quartzProperties">
+            <props>
+                <prop key="org.quartz.scheduler.interruptJobsOnShutdown">${scheduler.shutdown.interruptJobs:true}</prop>
+                <prop key="org.quartz.scheduler.interruptJobsOnShutdownWithWait">
+                    ${scheduler.shutdown.interruptJobs:true}
+                </prop>
+            </props>
+        </property>
+    </bean>
+
 </beans>


### PR DESCRIPTION
Centralize the Quartz scheduler in spring config to better be able to manage the scheduler lifecycle.