### PR TITLE
Remove HTML escaping from the URL

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/serviceErrorSsoView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/serviceErrorSsoView.jsp
@@ -1,6 +1,6 @@
 <jsp:directive.include file="includes/top.jsp" />
   <c:url var="url" value="/login">
-    <c:param name="service" value="${fn:escapeXml(param.service)}" />
+    <c:param name="service" value="${param.service}" />
     <c:param name="renew" value="true" />
   </c:url>
   


### PR DESCRIPTION
You should not have to HTML escape here, and in fact it might even be buggy for some inputs. 

The `<c:url />` tag  (line 2) will URL encode the value so it generates a valid query string parameter value. 
The `${fn:escapeXml(url)}` on line 9 should then *HTML* escape the complete URL. (Actually you can probably use `htmlEscape="true"` as well on the `<spring:message />` tag.

That should do.