### PR TITLE
prevent an NPE when password is null

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
@@ -1,6 +1,7 @@
 package org.jasig.cas.authentication;
 
 import com.google.common.base.Functions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import org.jasig.cas.authentication.handler.support.AbstractUsernamePasswordAuthenticationHandler;
 import org.jasig.cas.authentication.principal.Principal;
@@ -152,7 +153,7 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
         final AuthenticationResponse response;
         try {
             logger.debug("Attempting LDAP authentication for {}", upc);
-            final String password = getPasswordEncoder().encode(upc.getPassword());
+            final String password = Strings.nullToEmpty(getPasswordEncoder().encode(upc.getPassword()));
             final AuthenticationRequest request = new AuthenticationRequest(upc.getUsername(),
                     new org.ldaptive.Credential(password),
                     this.authenticatedEntryAttributes);

--- a/cas-server-support-ldap/src/test/java/org/jasig/cas/authentication/LdapAuthenticationHandlerTests.java
+++ b/cas-server-support-ldap/src/test/java/org/jasig/cas/authentication/LdapAuthenticationHandlerTests.java
@@ -63,6 +63,16 @@ public class LdapAuthenticationHandlerTests extends AbstractLdapTests {
         }
     }
 
+    @Test(expected=FailedLoginException.class)
+    public void verifyNullPasswordAuthenticateFailure() throws Exception {
+        for (final LdapEntry entry : this.getEntries()) {
+            final String username = getUsername(entry);
+            this.handler.authenticate(new UsernamePasswordCredential(username, null));
+            fail("Should have thrown FailedLoginException.");
+
+        }
+    }
+
     @Test(expected=AccountNotFoundException.class)
     public void verifyAuthenticateNotFound() throws Exception {
         this.handler.authenticate(new UsernamePasswordCredential("notfound", "somepwd"));


### PR DESCRIPTION
I was seeing periodic random NPEs caused by a null password in CAS 4.1.4.

This should be backported to 4.1 and 4.2