### PR TITLE
no need to include cas-server-support-saml as a compile and test dependency

### DIFF
--- a/cas-server-support-saml-idp/build.gradle
+++ b/cas-server-support-saml-idp/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     testCompile libraries.metrics
     testCompile libraries.log4j
     testCompile project(':cas-server-core-util')
-    testCompile project(path: ":cas-server-support-saml", configuration: "tests") 
     testCompile project(path: ":cas-server-core-authentication", configuration: "tests")
     testCompile project(':cas-server-core')
     testCompile project(':cas-server-core-logout')


### PR DESCRIPTION
closes #1481 