### PR TITLE
Allow more control over WS-FED principal resolver

### DIFF
--- a/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/principal/PersonDirectoryPrincipalResolver.java
+++ b/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/principal/PersonDirectoryPrincipalResolver.java
@@ -27,27 +27,33 @@ import java.util.Map;
  *
  * @author Marvin S. Addison
  * @since 4.0.0
- *
  */
 @Component("personDirectoryPrincipalResolver")
 public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
 
-    /** Log instance. */
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    /** Repository of principal attributes to be retrieved. */
+    /**
+     * Repository of principal attributes to be retrieved.
+     */
     @NotNull
     protected IPersonAttributeDao attributeRepository = new StubPersonAttributeDao(new HashMap<String, List<Object>>());
 
-    /** Factory to create the principal type. **/
+    /**
+     * Factory to create the principal type.
+     **/
     @NotNull
     protected PrincipalFactory principalFactory = new DefaultPrincipalFactory();
 
-    /** return null if no attributes are found. */
+    /**
+     * return null if no attributes are found.
+     */
     @Value("${cas.principal.resolver.persondir.return.null:false}")
     protected boolean returnNullIfNoAttributes;
 
-    /** Optional principal attribute name. */
+    /**
+     * Optional principal attribute name.
+     */
     protected String principalAttributeName;
 
     @Autowired
@@ -99,8 +105,8 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
 
         logger.debug("Creating SimplePrincipal for [{}]", principalId);
 
-        final Map<String, List<Object>> attributes = retrievePersonAttributes(principalId);
-            logger.debug("Principal id [{}] could not be found", principalId);
+        final Map<String, List<Object>> attributes = retrievePersonAttributes(principalId, credential);
+        logger.debug("Principal id [{}] could not be found", principalId);
 
         if (attributes == null || attributes.isEmpty()) {
             logger.debug("Principal id [{}] did not specify any attributes", principalId);
@@ -135,10 +141,9 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
             final String key = entry.getKey();
 
             logger.debug("Found attribute [{}]", key);
-
             final List<Object> values = entry.getValue();
             if (StringUtils.isNotBlank(this.principalAttributeName)
-                        && key.equalsIgnoreCase(this.principalAttributeName)) {
+                    && key.equalsIgnoreCase(this.principalAttributeName)) {
                 if (values.isEmpty()) {
                     logger.debug("{} is empty, using {} for principal", this.principalAttributeName, extractedPrincipalId);
                 } else {
@@ -160,9 +165,11 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
      * Retrieve person attributes map.
      *
      * @param principalId the principal id
+     * @param credential  the credential whose id we have extracted. This is passed so that implementations
+     *                    can extract useful bits of authN info such as attributes into the principal.
      * @return the map
      */
-    protected Map<String, List<Object>> retrievePersonAttributes(final String principalId) {
+    protected Map<String, List<Object>> retrievePersonAttributes(final String principalId, final Credential credential) {
         final IPersonAttributes personAttributes = this.attributeRepository.getPerson(principalId);
         final Map<String, List<Object>> attributes;
 

--- a/cas-server-core-webflow/src/main/java/org/jasig/cas/web/flow/AbstractCasWebflowConfigurer.java
+++ b/cas-server-core-webflow/src/main/java/org/jasig/cas/web/flow/AbstractCasWebflowConfigurer.java
@@ -16,8 +16,12 @@ import org.springframework.binding.expression.support.LiteralExpression;
 import org.springframework.binding.mapping.Mapper;
 import org.springframework.binding.mapping.impl.DefaultMapper;
 import org.springframework.binding.mapping.impl.DefaultMapping;
+import org.springframework.context.expression.BeanExpressionContextAccessor;
+import org.springframework.context.expression.EnvironmentAccessor;
+import org.springframework.context.expression.MapAccessor;
 import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
@@ -234,6 +238,7 @@ public abstract class AbstractCasWebflowConfigurer {
         return decisionState;
 
     }
+
     /**
      * Sets start state.
      *
@@ -264,7 +269,7 @@ public abstract class AbstractCasWebflowConfigurer {
      * @param clazz         the exception class
      */
     protected void createGlobalTransition(final Flow flow, final String targetStateId,
-                                                             final Class<? extends Throwable> clazz) {
+                                          final Class<? extends Throwable> clazz) {
 
         try {
             final TransitionExecutingFlowExecutionExceptionHandler handler = new TransitionExecutingFlowExecutionExceptionHandler();
@@ -325,13 +330,14 @@ public abstract class AbstractCasWebflowConfigurer {
                 .parseExpression(expression, ctx);
         final EvaluateAction newAction = new EvaluateAction(action, null);
 
-        logger.debug("Created evaluate action for expression", action.getExpressionString());
+        logger.debug("Created evaluate action for expression {}", action.getExpressionString());
         return newAction;
     }
 
     /**
      * Add a default transition to a given state.
-     * @param state the state to include the default transition
+     *
+     * @param state       the state to include the default transition
      * @param targetState the id of the destination state to which the flow should transfer
      */
     protected void createStateDefaultTransition(final TransitionableState state, final String targetState) {
@@ -346,12 +352,12 @@ public abstract class AbstractCasWebflowConfigurer {
     /**
      * Add transition to action state.
      *
-     * @param state     the action state
+     * @param state           the action state
      * @param criteriaOutcome the criteria outcome
      * @param targetState     the target state
      */
     protected void createTransitionForState(final TransitionableState state,
-                                               final String criteriaOutcome, final String targetState) {
+                                            final String criteriaOutcome, final String targetState) {
         try {
             final Transition transition = createTransition(criteriaOutcome, targetState);
             state.getTransitionSet().add(transition);
@@ -434,13 +440,19 @@ public abstract class AbstractCasWebflowConfigurer {
         parser.addPropertyAccessor(new MapAdaptablePropertyAccessor());
         parser.addPropertyAccessor(new MessageSourcePropertyAccessor());
         parser.addPropertyAccessor(new ScopeSearchingPropertyAccessor());
+        parser.addPropertyAccessor(new BeanExpressionContextAccessor());
+        parser.addPropertyAccessor(new MapAccessor());
+        parser.addPropertyAccessor(new MapAdaptablePropertyAccessor());
+        parser.addPropertyAccessor(new EnvironmentAccessor());
+        parser.addPropertyAccessor(new ReflectivePropertyAccessor());
         return parser;
 
     }
+
     /**
      * Create transition without a criteria.
      *
-     * @param targetState     the target state
+     * @param targetState the target state
      * @return the transition
      */
     protected Transition createTransition(final String targetState) {
@@ -456,19 +468,41 @@ public abstract class AbstractCasWebflowConfigurer {
      * @param viewId the view id
      */
     protected void createEndState(final Flow flow, final String id, final String viewId) {
+        createEndState(flow, id, new LiteralExpression(viewId));
+    }
+
+    /**
+     * Add end state backed by view.
+     *
+     * @param flow       the flow
+     * @param id         the id
+     * @param expression the expression
+     */
+    protected void createEndState(final Flow flow, final String id, final Expression expression) {
+        final ViewFactory viewFactory = this.flowBuilderServices.getViewFactoryCreator().createViewFactory(
+                expression,
+                this.flowBuilderServices.getExpressionParser(),
+                this.flowBuilderServices.getConversionService(),
+                null,
+                this.flowBuilderServices.getValidator(),
+                this.flowBuilderServices.getValidationHintResolver());
+
+        createEndState(flow, id, viewFactory);
+    }
+
+    /**
+     * Add end state backed by view.
+     *
+     * @param flow        the flow
+     * @param id          the id
+     * @param viewFactory the view factory
+     */
+    protected void createEndState(final Flow flow, final String id, final ViewFactory viewFactory) {
         try {
             final EndState endState = new EndState(flow, id);
-            final ViewFactory viewFactory = this.flowBuilderServices.getViewFactoryCreator().createViewFactory(
-                    new LiteralExpression(viewId),
-                    this.flowBuilderServices.getExpressionParser(),
-                    this.flowBuilderServices.getConversionService(),
-                    null,
-                    this.flowBuilderServices.getValidator(),
-                    this.flowBuilderServices.getValidationHintResolver());
-
             final Action finalResponseAction = new ViewFactoryActionAdapter(viewFactory);
             endState.setFinalResponseAction(finalResponseAction);
-            logger.debug("Created end state state {} on flow id {}, backed by view {}", id, flow.getId(), viewId);
+            logger.debug("Created end state state {} on flow id {}, backed by view factory {}", id, flow.getId(), viewFactory);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
         }
@@ -477,15 +511,15 @@ public abstract class AbstractCasWebflowConfigurer {
     /**
      * Add view state.
      *
-     * @param flow   the flow
-     * @param id     the id
-     * @param viewId the view id
+     * @param flow       the flow
+     * @param id         the id
+     * @param expression the expression
      * @return the view state
      */
-    protected ViewState createViewState(final Flow flow, final String id, final String viewId) {
+    protected ViewState createViewState(final Flow flow, final String id, final Expression expression) {
         try {
             final ViewFactory viewFactory = this.flowBuilderServices.getViewFactoryCreator().createViewFactory(
-                    new LiteralExpression(viewId),
+                    expression,
                     this.flowBuilderServices.getExpressionParser(),
                     this.flowBuilderServices.getConversionService(),
                     null,
@@ -502,11 +536,23 @@ public abstract class AbstractCasWebflowConfigurer {
     }
 
     /**
+     * Add view state.
+     *
+     * @param flow   the flow
+     * @param id     the id
+     * @param viewId the view id
+     * @return the view state
+     */
+    protected ViewState createViewState(final Flow flow, final String id, final String viewId) {
+        return createViewState(flow, id, new LiteralExpression(viewId));
+    }
+
+    /**
      * Create subflow state.
      *
-     * @param flow the flow
-     * @param id the id
-     * @param subflow the subflow
+     * @param flow        the flow
+     * @param id          the id
+     * @param subflow     the subflow
      * @param entryAction the entry action
      * @return the subflow state
      */
@@ -538,10 +584,10 @@ public abstract class AbstractCasWebflowConfigurer {
     /**
      * Create mapping to subflow state.
      *
-     * @param name the name
-     * @param value the value
+     * @param name     the name
+     * @param value    the value
      * @param required the required
-     * @param type the type
+     * @param type     the type
      * @return the default mapping
      */
     protected DefaultMapping createMappingToSubflowState(final String name, final String value,
@@ -564,7 +610,7 @@ public abstract class AbstractCasWebflowConfigurer {
     /**
      * Create subflow attribute mapper.
      *
-     * @param inputMapper the input mapper
+     * @param inputMapper  the input mapper
      * @param outputMapper the output mapper
      * @return the subflow attribute mapper
      */

--- a/cas-server-documentation/integration/ADFS-Integration.md
+++ b/cas-server-documentation/integration/ADFS-Integration.md
@@ -4,7 +4,8 @@ title: CAS - ADFS Integration
 ---
 
 #Overview
-The integration between the CAS Server and ADFS delegates user authentication from CAS Server to ADFS, making CAS Server a WS-Federation client. Claims released from ADFS are made available as attributes to CAS Server, and by extension CAS Clients.
+The integration between the CAS Server and ADFS delegates user authentication from CAS Server to ADFS, making CAS Server a WS-Federation client. 
+Claims released from ADFS are made available as attributes to CAS Server, and by extension CAS Clients.
 
 Support is enabled by including the following dependency in the Maven WAR overlay:
 
@@ -43,6 +44,9 @@ cas.wsfed.idp.signingcerts=classpath:adfs-signing.crt
 #
 # Slack dealing with time-drift between the ADFS Server and the CAS Server.
 # cas.wsfed.idp.tolerance=10000
+
+# cas.wsfed.idp.attribute.resolver.enabled=true
+# cas.wsfed.idp.attribute.resolver.type=WSFED
 {% endhighlight %}
 
 
@@ -54,7 +58,7 @@ to put together an implementation of `WsFederationAttributeMutator` that changes
 package org.jasig.cas.support.wsfederation;
 
 public class WsFederationAttributeMutatorImpl implements WsFederationAttributeMutator {
-    public void modifyAttributes(final Map<String, Object> attributes) {
+    public void modifyAttributes(...) {
         ...
     }
 }
@@ -70,7 +74,6 @@ The mutator then needs to be declared in your configuration:
 
 Finally, ensure that the attributes sent from ADFS are available and mapped in
 your `attributeRepository` configuration.
-
 
 ### Handling CAS Logout
 

--- a/cas-server-support-wsfederation-webflow/src/main/java/org/jasig/cas/web/flow/WsFederationWebflowConfigurer.java
+++ b/cas-server-support-wsfederation-webflow/src/main/java/org/jasig/cas/web/flow/WsFederationWebflowConfigurer.java
@@ -1,11 +1,14 @@
 package org.jasig.cas.web.flow;
 
+import org.springframework.binding.expression.Expression;
 import org.springframework.stereotype.Component;
+import org.springframework.webflow.action.ExternalRedirectAction;
 import org.springframework.webflow.engine.ActionState;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.TargetStateResolver;
 import org.springframework.webflow.engine.Transition;
 import org.springframework.webflow.engine.TransitionableState;
+import org.springframework.webflow.engine.support.ActionExecutingViewFactory;
 
 import java.util.Iterator;
 
@@ -23,7 +26,12 @@ public class WsFederationWebflowConfigurer extends AbstractCasWebflowConfigurer 
     protected void doInitialize() throws Exception {
         final Flow flow = getLoginFlow();
 
-        createViewState(flow, "wsFederationRedirect", "externalRedirect:#{flowScope.WsFederationIdentityProviderUrl}");
+
+        final Expression expression = createExpression(flow, "flowScope.WsFederationIdentityProviderUrl", String.class);
+        final ActionExecutingViewFactory viewFactory = new ActionExecutingViewFactory(
+                new ExternalRedirectAction(expression));
+
+        createEndState(flow, "wsFederationRedirect", viewFactory);
         final ActionState actionState = createActionState(flow, "wsFederationAction", createEvaluateAction("wsFederationAction"));
         actionState.getTransitionSet().add(createTransition(TRANSITION_ID_SUCCESS, TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
         actionState.getTransitionSet().add(createTransition(TRANSITION_ID_ERROR, getStartState(flow).getId()));

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFedServletContextListener.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFedServletContextListener.java
@@ -6,6 +6,7 @@ import org.jasig.cas.authentication.principal.PrincipalResolver;
 import org.jasig.cas.web.AbstractServletContextInitializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.annotation.WebListener;
@@ -28,10 +29,16 @@ public class WsFedServletContextListener extends AbstractServletContextInitializ
     @Qualifier("adfsPrincipalResolver")
     private PrincipalResolver adfsPrincipalResolver;
 
+    @Value("${cas.wsfed.idp.attribute.resolver.enabled:true}")
+    private boolean useResolver;
 
     @Override
     protected void initializeRootApplicationContext() {
-        addAuthenticationHandlerPrincipalResolver(adfsAuthNHandler, adfsPrincipalResolver);
+        if (!this.useResolver) {
+            addAuthenticationHandler(adfsAuthNHandler);
+        } else {
+            addAuthenticationHandlerPrincipalResolver(adfsAuthNHandler, adfsPrincipalResolver);
+        }
     }
 }
 

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationAttributeMutator.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationAttributeMutator.java
@@ -1,6 +1,7 @@
 package org.jasig.cas.support.wsfederation;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -17,5 +18,5 @@ public interface WsFederationAttributeMutator extends Serializable {
      *
      * @param attributes the attribute returned by the IdP.
      */
-    void modifyAttributes(Map<String, Object> attributes);
+    void modifyAttributes(Map<String, List<Object>> attributes);
 }

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationHelper.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationHelper.java
@@ -92,21 +92,17 @@ public final class WsFederationHelper {
         }
 
         //retrieve an attributes from the assertion
-        final HashMap<String, Object> attributes = new HashMap<String, Object>();
+        final HashMap<String, List<Object>> attributes = new HashMap<>();
         for (final Attribute item : assertion.getAttributeStatements().get(0).getAttributes()) {
             LOGGER.debug("Processed attribute: {}", item.getAttributeName());
 
-            if (item.getAttributeValues().size() == 1) {
-                attributes.put(item.getAttributeName(), ((XSAny) item.getAttributeValues().get(0)).getTextContent());
-            } else {
-                final List<String> itemList = new ArrayList<String>();
-                for (int i = 0; i < item.getAttributeValues().size(); i++) {
-                    itemList.add(((XSAny) item.getAttributeValues().get(i)).getTextContent());
-                }
+            final List<Object> itemList = new ArrayList<>();
+            for (int i = 0; i < item.getAttributeValues().size(); i++) {
+                itemList.add(((XSAny) item.getAttributeValues().get(i)).getTextContent());
+            }
 
-                if (!itemList.isEmpty()) {
-                    attributes.put(item.getAttributeName(), itemList);
-                }
+            if (!itemList.isEmpty()) {
+                attributes.put(item.getAttributeName(), itemList);
             }
         }
         credential.setAttributes(attributes);

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/authentication/handler/support/WsFederationAuthenticationHandler.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/authentication/handler/support/WsFederationAuthenticationHandler.java
@@ -1,17 +1,18 @@
 package org.jasig.cas.support.wsfederation.authentication.handler.support;
 
-import org.jasig.cas.support.wsfederation.authentication.principal.WsFederationCredential;
-import org.jasig.cas.authentication.MessageDescriptor;
 import org.jasig.cas.authentication.Credential;
 import org.jasig.cas.authentication.HandlerResult;
+import org.jasig.cas.authentication.MessageDescriptor;
 import org.jasig.cas.authentication.PreventedException;
 import org.jasig.cas.authentication.handler.support.AbstractPreAndPostProcessingAuthenticationHandler;
 import org.jasig.cas.authentication.principal.Principal;
+import org.jasig.cas.support.wsfederation.authentication.principal.WsFederationCredential;
 import org.springframework.stereotype.Component;
 
 import javax.security.auth.login.FailedLoginException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Map;
 
 /**
  * This handler authenticates Security token/credentials.
@@ -37,8 +38,8 @@ public final class WsFederationAuthenticationHandler extends AbstractPreAndPostP
     protected HandlerResult doAuthentication(final Credential credential) throws GeneralSecurityException, PreventedException {
         final WsFederationCredential wsFederationCredentials = (WsFederationCredential) credential;
         if (wsFederationCredentials != null) {
-            final Principal principal = this.principalFactory.createPrincipal(wsFederationCredentials.getId(),
-                    wsFederationCredentials.getAttributes());
+            final Map attributes = wsFederationCredentials.getAttributes();
+            final Principal principal = this.principalFactory.createPrincipal(wsFederationCredentials.getId(), attributes);
 
             return this.createHandlerResult(wsFederationCredentials, principal, new ArrayList<MessageDescriptor>());
         }

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/authentication/principal/WsFederationCredential.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/authentication/principal/WsFederationCredential.java
@@ -7,6 +7,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,7 +27,7 @@ public final class WsFederationCredential implements Credential {
     private DateTime notBefore;
     private DateTime notOnOrAfter;
     private DateTime retrievedOn;
-    private Map<String, Object> attributes;
+    private Map<String, List<Object>> attributes;
 
     public String getAuthenticationMethod() {
         return this.authenticationMethod;
@@ -44,11 +45,11 @@ public final class WsFederationCredential implements Credential {
         this.audience = audience;
     }
 
-    public Map<String, Object> getAttributes() {
+    public Map<String, List<Object>> getAttributes() {
         return this.attributes;
     }
 
-    public void setAttributes(final Map<String, Object> attributes) {
+    public void setAttributes(final Map<String, List<Object>> attributes) {
         this.attributes = attributes;
     }
 

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/web/flow/WsFederationAction.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/web/flow/WsFederationAction.java
@@ -88,50 +88,60 @@ public final class WsFederationAction extends AbstractAction {
                 final String wresult = request.getParameter(WRESULT);
                 logger.debug("Parameter [{}] received: {}", WRESULT, wresult);
 
+                if (StringUtils.isBlank(wresult)) {
+                    logger.error("No {} parameter is found", WRESULT);
+                    return error();
+                }
+
                 // create credentials
                 final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult);
 
-                //Validate the signature
-                if (wsFederationHelper.validateSignature(assertion, configuration)) {
-                    try {
+                if (assertion == null) {
+                    logger.error("Could not validate assertion via parsing the token from {}", WRESULT);
+                    return error();
+                }
 
-                        final WsFederationCredential credential = wsFederationHelper.createCredentialFromToken(assertion);
-                        if (credential != null && credential.isValid(configuration.getRelyingPartyIdentifier(),
-                                configuration.getIdentityProviderIdentifier(),
-                                configuration.getTolerance())) {
-
-                            if (configuration.getAttributeMutator() != null) {
-                                configuration.getAttributeMutator().modifyAttributes(credential.getAttributes());
-                            }
-                        } else {
-                            logger.warn("SAML assertions are blank or no longer valid.");
-                            return error();
-                        }
-
-                        final Service service = (Service) session.getAttribute(SERVICE);
-                        context.getFlowScope().put(SERVICE, service);
-                        restoreRequestAttribute(request, session, THEME);
-                        restoreRequestAttribute(request, session, LOCALE);
-                        restoreRequestAttribute(request, session, METHOD);
-
-                        final AuthenticationResult authenticationResult =
-                                this.authenticationSystemSupport.handleAndFinalizeSingleAuthenticationTransaction(service, credential);
-
-                        WebUtils.putTicketGrantingTicketInScopes(context,
-                                this.centralAuthenticationService.createTicketGrantingTicket(authenticationResult));
-
-                        logger.info("Token validated and new {} created: {}", credential.getClass().getName(), credential);
-                        return success();
-
-                    } catch (final AbstractTicketException e) {
-                        logger.error(e.getMessage(), e);
-                        return error();
-                    }
-
-                } else {
+                if (!wsFederationHelper.validateSignature(assertion, configuration)) {
                     logger.error("WS Requested Security Token is blank or the signature is not valid.");
                     return error();
                 }
+
+                try {
+
+                    final WsFederationCredential credential = wsFederationHelper.createCredentialFromToken(assertion);
+                    if (credential != null && credential.isValid(configuration.getRelyingPartyIdentifier(),
+                            configuration.getIdentityProviderIdentifier(),
+                            configuration.getTolerance())) {
+
+                        if (configuration.getAttributeMutator() != null) {
+                            configuration.getAttributeMutator().modifyAttributes(credential.getAttributes());
+                        }
+                    } else {
+                        logger.warn("SAML assertions are blank or no longer valid.");
+                        return error();
+                    }
+
+                    final Service service = (Service) session.getAttribute(SERVICE);
+                    context.getFlowScope().put(SERVICE, service);
+                    restoreRequestAttribute(request, session, THEME);
+                    restoreRequestAttribute(request, session, LOCALE);
+                    restoreRequestAttribute(request, session, METHOD);
+
+                    final AuthenticationResult authenticationResult =
+                            this.authenticationSystemSupport.handleAndFinalizeSingleAuthenticationTransaction(service, credential);
+
+                    WebUtils.putTicketGrantingTicketInScopes(context,
+                            this.centralAuthenticationService.createTicketGrantingTicket(authenticationResult));
+
+                    logger.info("Token validated and new {} created: {}", credential.getClass().getName(), credential);
+                    return success();
+
+                } catch (final AbstractTicketException e) {
+                    logger.error(e.getMessage(), e);
+                    return error();
+                }
+
+
 
             } else { // no authentication : go to login page
 

--- a/cas-server-support-wsfederation/src/test/java/org/jasig/cas/support/wsfederation/WsFederationAttributeMutatorTests.java
+++ b/cas-server-support-wsfederation/src/test/java/org/jasig/cas/support/wsfederation/WsFederationAttributeMutatorTests.java
@@ -2,7 +2,9 @@ package org.jasig.cas.support.wsfederation;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -16,28 +18,33 @@ public class WsFederationAttributeMutatorTests extends AbstractWsFederationTests
 
     @Test
     public void verifyModifyAttributes() {
-        final Map<String, Object> attributes = new HashMap<String, Object>();
-        attributes.put("upn", "test@example.com");
+        final Map<String, List<Object>> attributes = new HashMap<>();
+
+        final List values = new ArrayList();
+        values.add("test@example.com");
+        attributes.put("upn", values);
         
         final WsFederationAttributeMutator instance = new WsFederationAttributeMutatorImpl();
         instance.modifyAttributes(attributes);
-        assertTrue("testModifyAttributes() - true", attributes.containsKey("test"));
-        assertTrue("testModifyAttributes() - true",
-                "newtest".equalsIgnoreCase(attributes.get("test").toString()));
 
-        assertTrue("testModifyAttributes() - true",
-                attributes.containsKey("upn"));
-        assertTrue("testModifyAttributes() - true",
-                "testing".equalsIgnoreCase(attributes.get("upn").toString()));
+        assertTrue(attributes.containsKey("test"));
+        assertTrue("newtest".equalsIgnoreCase(attributes.get("test").get(0).toString()));
+        assertTrue(attributes.containsKey("upn"));
+        assertTrue("testing".equalsIgnoreCase(attributes.get("upn").get(0).toString()));
     }
 
     private static class WsFederationAttributeMutatorImpl implements WsFederationAttributeMutator {
         private static final long serialVersionUID = -1858140387002752668L;
 
         @Override
-        public void modifyAttributes(final Map<String, Object> attributes) {
-            attributes.put("test", "newtest");
-            attributes.put("upn", "testing");
+        public void modifyAttributes(final Map<String, List<Object>> attributes) {
+            List values = new ArrayList();
+            values.add("newtest");
+            attributes.put("test", values);
+
+            values = new ArrayList();
+            values.add("testing");
+            attributes.put("upn", values);
         }
     }
 }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -148,7 +148,7 @@ tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dW
 # create.sso.missing.service=true
 
 ##
-# CAS Authentication POlicy
+# CAS Authentication Policy
 #
 # cas.authn.policy.any.tryall=false
 # cas.authn.policy.req.tryall=false
@@ -531,6 +531,10 @@ accept.authn.users=casuser::Mellon
 #
 # Slack dealing with time-drift between the ADFS Server and the CAS Server.
 # cas.wsfed.idp.tolerance=10000
+#
+# Decides which bundle of attributes should be resolved during WS-FED authentication.
+# cas.wsfed.idp.attribute.resolver.enabled=true
+# cas.wsfed.idp.attribute.resolver.type=WSFED
 
 ##
 # LDAP User Details


### PR DESCRIPTION
Closes #1483 

- Make use the WSFED principal resolver optional
- Fix flow bug with redirect to the IDP
- When/If WSFED resolver is used, provide options to dictate how attributes should be resolved. 
