### PR TITLE
Allow alternative logger selection

### DIFF
--- a/cas-management-webapp/build.gradle
+++ b/cas-management-webapp/build.gradle
@@ -29,7 +29,8 @@ dependencies {
 }
 
 gretty {
-    jvmArgs = ["-Dorg.eclipse.jetty.annotations.maxWait=120","-Xdebug","-Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n"]
+    jvmArgs = ["-DloggerFactory=\"org.apache.logging.slf4j.Log4jLoggerFactory\"", "-Dorg.eclipse.jetty.annotations.maxWait=120","-Xdebug",
+               "-Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n"]
     scanInterval = 5
     contextPath = '/cas-management'
     httpsEnabled = project.ext.jettySslConfigEnabled

--- a/cas-server-core-logging/build.gradle
+++ b/cas-server-core-logging/build.gradle
@@ -1,6 +1,7 @@
 description = 'Apereo CAS Core Logging'
 dependencies {
     compile project(':cas-server-core-api-ticket')
+    compile project(':cas-server-core-web')
     compile libraries.spring
 }
 

--- a/cas-server-core-logging/src/main/java/org/jasig/cas/util/CasLoggerContextInitializer.java
+++ b/cas-server-core-logging/src/main/java/org/jasig/cas/util/CasLoggerContextInitializer.java
@@ -2,25 +2,27 @@ package org.jasig.cas.util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.jasig.cas.web.AbstractServletContextInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.ServletContextAware;
 
-import javax.servlet.ServletContext;
+import javax.servlet.annotation.WebListener;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Reinitializes the CAS logging framework by updating the location of the log configuration file.
+ * Initialize the CAS logging framework by updating the location of the log configuration file.
  * @author Misagh Moayyed
  * @since 4.1
  */
+@WebListener
 @Component("log4jInitialization")
-public final class CasLoggerContextInitializer implements ServletContextAware {
+public final class CasLoggerContextInitializer extends AbstractServletContextInitializer {
     private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CasLoggerContextInitializer.class);
@@ -31,7 +33,7 @@ public final class CasLoggerContextInitializer implements ServletContextAware {
     /**
      * Instantiates a new Cas logger context initializer.
      */
-    protected CasLoggerContextInitializer() {
+    public CasLoggerContextInitializer() {
         this.logConfigurationFile = null;
     }
 
@@ -47,7 +49,8 @@ public final class CasLoggerContextInitializer implements ServletContextAware {
     /**
      * Reinitialize the logger by updating the location for the logging config file.
      */
-    private void initialize() {
+    @Override
+    public void initializeApplicationContext(final ConfigurableApplicationContext configurableApplicationContext) {
         if (this.logConfigurationFile == null || !this.logConfigurationFile.exists()) {
             throw new RuntimeException("Log4j configuration file cannot be located");
         }
@@ -66,18 +69,5 @@ public final class CasLoggerContextInitializer implements ServletContextAware {
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>Reinitialize the logging config. Because the context
-     * may be initialized twice, there are safety checks
-     * added to ensure we don't reinitialize the log
-     * config multiple times.</p>
-     * @param servletContext the servlet context
-     */
-    @Override
-    public void setServletContext(final ServletContext servletContext) {
-        initialize();
     }
 }

--- a/cas-server-core-logging/src/main/java/org/slf4j/impl/CasLoggerFactory.java
+++ b/cas-server-core-logging/src/main/java/org/slf4j/impl/CasLoggerFactory.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class CasLoggerFactory implements ILoggerFactory {
 
-    private static final String DEFAULT_LOGGER_FACTORY_CLASS = "org.apache.logging.slf4j.Log4jLoggerFactory";
     private static final String ENVIRONMENT_VAR_LOGGER_FACTORY = "loggerFactory";
 
     private static final String PACKAGE_TO_SCAN = "org.slf4j.impl";
@@ -52,6 +51,9 @@ public final class CasLoggerFactory implements ILoggerFactory {
             for (final Class<? extends ILoggerFactory> c : loggerFactories) {
                 Util.report("* " + c.getCanonicalName());
             }
+            Util.report("This generally indicates a configuration problem which is a result of dependency conflicts.");
+            Util.report("If you wish to use a different logging framework, specify the ILoggerFactory binding via -D"
+                    + ENVIRONMENT_VAR_LOGGER_FACTORY + "=<binding-class> to the runtime environment");
         }
 
         if (loggerFactories.isEmpty()) {
@@ -64,6 +66,7 @@ public final class CasLoggerFactory implements ILoggerFactory {
         }
         this.realLoggerFactoryClass = null;
         for (final Class<? extends ILoggerFactory> factory : loggerFactories) {
+            Util.report("Attempting to locate ILoggerFactory instance from: " + factory.getName());
             if (getLoggerFactoryBeInstantiated(factory) != null) {
                 this.realLoggerFactoryClass = factory;
                 Util.report("ILoggerFactory to be used for logging is: " + this.realLoggerFactoryClass.getName());

--- a/cas-server-documentation/installation/Logging.md
+++ b/cas-server-documentation/installation/Logging.md
@@ -29,28 +29,15 @@ these levels to  `DEBUG`.
 <div class="alert alert-warning"><strong>Usage Warning!</strong><p>When in production though,
 you probably want to run them both as `WARN`.</p></div>
 
-
-##Components
-The log4j configuration is by default loaded using the following components
-at `cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/log4jConfiguration.xml`:
-
-{% highlight xml %}
-<bean id="log4jInitialization" class="org.jasig.cas.util.CasAsyncLoggerContextInitializer"
-    c:logConfigurationField="log4jConfiguration"
-    c:logConfigurationFile="${log4j.config.location:classpath:log4j2.xml}"
-    c:AsyncLoggerContextPackageName="org.apache.logging.log4j.web"/>
-{% endhighlight %}
-
+##Configuration
 It is often time helpful to externalize `log4j2.xml` to a system path to preserve settings between upgrades.
-The location of `log4j2.xml` file by default is on the runtime classpath and at minute intervals
-respective. These may be overridden by the `cas.properties` file
+The location of `log4j2.xml` file by default is on the runtime classpath. 
+These may be overridden by the `cas.properties` file
 
 {% highlight bash %}
 # log4j.config.location=classpath:log4j2.xml
 {% endhighlight %}
 
-
-##Configuration
 The `log4j2.xml` file by default at `WEB-INF/classes` provides the following `appender` elements that
 decide where and how messages from components should be displayed. Two are provided by default that
 output messages to the system console and a `cas.log` file:
@@ -159,9 +146,9 @@ troubleshooting and diagnostics. This is achieved by providing a specific bindin
 
 ##AsyncLoggers Shutdown with Tomcat
 
-Log4j automatically insert itself into the runtime application context in a Servlet 3 environment (i.e. Tomcat 8.x) and will clean up 
-the logging context once the container is instructed to shut down. However, Tomcat ignores all JAR files named log4j.jar, which prevents 
-this feature from working. You may need to change `catalina.properties` and remove "log4j.jar" from the `jarsToSkip` property. 
+Log4j automatically inserts itself into the runtime application context in a Servlet 3 environment (i.e. Tomcat 8.x) and will clean up 
+the logging context once the container is instructed to shut down. However, Tomcat ignores all JAR files named `log4j*.jar`, which prevents 
+this feature from working. You may need to change the `catalina.properties` and remove `log4j*.jar` from the `jarsToSkip` property. 
 You may need to do something similar on other containers if they skip scanning Log4j JAR files.
 
 Failure to do so will stop Tomcat to gracefully shut down and causes logger context threads to hang. 

--- a/cas-server-documentation/installation/Logging.md
+++ b/cas-server-documentation/installation/Logging.md
@@ -55,14 +55,21 @@ The `log4j2.xml` file by default at `WEB-INF/classes` provides the following `ap
 decide where and how messages from components should be displayed. Two are provided by default that
 output messages to the system console and a `cas.log` file:
 
-###Logger Selection
+### Multiple Logger Bindings
 CAS by default attempts to scan the runtime application context looking for suitable logger frameworks. 
-By default, the framework that is chosen is Log4j. However, if you wish to instruct CAS to opt for
-a different framework, provide the following JVM variable to the container of your choice:
+By default, the framework that is chosen is Log4j. If there are multiple logging frameworks found 
+on the application classpath at runtime, you can instruct CAS to specifically select Log4j as the logging framework
+via the following property passed to the JVM runtime instance:
 
 {% highlight bash %}
 -DloggerFactory="org.apache.logging.slf4j.Log4jLoggerFactory"
 {% endhighlight %}
+
+###Alternative Loggers
+If you wish to use an alternative logging framework other than Log4j, you will need to exclude
+all `log4j` JAR artifacts and the `cas-server-core-logging` module from your configuration. Ensure
+an alternative framework such as Logback is provided instead to the application runtime and the necessary
+configuration is available per the framework. 
 
 ###Refresh Interval
 The `log4j2.xml` itself controls the refresh interval of the logging configuration. Log4j has the ability

--- a/cas-server-documentation/installation/Logging.md
+++ b/cas-server-documentation/installation/Logging.md
@@ -55,6 +55,15 @@ The `log4j2.xml` file by default at `WEB-INF/classes` provides the following `ap
 decide where and how messages from components should be displayed. Two are provided by default that
 output messages to the system console and a `cas.log` file:
 
+###Logger Selection
+CAS by default attempts to scan the runtime application context looking for suitable logger frameworks. 
+By default, the framework that is chosen is Log4j. However, if you wish to instruct CAS to opt for
+a different framework, provide the following JVM variable to the container of your choice:
+
+{% highlight bash %}
+-DloggerFactory="org.apache.logging.slf4j.Log4jLoggerFactory"
+{% endhighlight %}
+
 ###Refresh Interval
 The `log4j2.xml` itself controls the refresh interval of the logging configuration. Log4j has the ability
 to automatically detect changes to the configuration file and reconfigure itself. If the `monitorInterval`
@@ -143,6 +152,9 @@ troubleshooting and diagnostics. This is achieved by providing a specific bindin
 
 ##AsyncLoggers Shutdown with Tomcat
 
-Log4j automatically insert itself into the runtime application context in a Servlet 3 environment (i.e. Tomcat 8.x) and will clean up the logging context once the container is instructed to shut down. However, Tomcat ignores all JAR files named log4j.jar, which prevents this feature from working. You may need to change `catalina.properties` and remove "log4j.jar" from the `jarsToSkip` property. You may need to do something similar on other containers if they skip scanning Log4j JAR files.
+Log4j automatically insert itself into the runtime application context in a Servlet 3 environment (i.e. Tomcat 8.x) and will clean up 
+the logging context once the container is instructed to shut down. However, Tomcat ignores all JAR files named log4j.jar, which prevents 
+this feature from working. You may need to change `catalina.properties` and remove "log4j.jar" from the `jarsToSkip` property. 
+You may need to do something similar on other containers if they skip scanning Log4j JAR files.
 
 Failure to do so will stop Tomcat to gracefully shut down and causes logger context threads to hang. 

--- a/cas-server-webapp/build.gradle
+++ b/cas-server-webapp/build.gradle
@@ -53,7 +53,8 @@ dependencies {
 }
 
 gretty {
-    jvmArgs = ["-Dorg.eclipse.jetty.annotations.maxWait=120","-Xdebug","-Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n"]
+    jvmArgs = ["-DloggerFactory=\"org.apache.logging.slf4j.Log4jLoggerFactory\"", "-Dorg.eclipse.jetty.annotations.maxWait=120","-Xdebug",
+               "-Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n"]
     scanInterval = 5
     contextPath = '/cas'
     httpsEnabled = project.ext.jettySslConfigEnabled

--- a/cas-server-webapp/src/main/resources/log4j2.xml
+++ b/cas-server-webapp/src/main/resources/log4j2.xml
@@ -51,6 +51,10 @@
             <AppenderRef ref="console"/>
             <AppenderRef ref="file"/>
         </AsyncLogger>
+        <AsyncLogger name="com.hazelcast" level="debug" additivity="false">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="file"/>
+        </AsyncLogger>
         -->
 
         <AsyncLogger name="perfStatsLogger" level="info" additivity="false" includeLocation="true">


### PR DESCRIPTION
Closes https://github.com/Jasig/cas/issues/1493

- Add support for a `loggerFactory` environment property to allow specific selection of logger binding, in cases where CAS ends up with more than one binding and the environment is not amenable to changes. This should also help with faster startup times rather than initial context scans. The property is optional and if none is provided, CAS will fallback to the current behavior. 
- Reorganize the logger initialization logic to be consistent with the remaining servlet initializers.
- Updated docs to explain how an alternative framework such as Logback can be used. 