### PR TITLE
mark CAS.getTicket() calls not readonly

### DIFF
--- a/cas-server-support-jpa-ticket-registry/src/main/resources/META-INF/spring/jpa-ticket-reg-context.xml
+++ b/cas-server-support-jpa-ticket-registry/src/main/resources/META-INF/spring/jpa-ticket-reg-context.xml
@@ -76,7 +76,7 @@
             <tx:method name="createProxyGrantingTicket" read-only="false" />
             <tx:method name="grantProxyTicket" read-only="false" />
 
-            <tx:method name="getTicket" read-only="true" />
+            <tx:method name="getTicket" read-only="false" />
             <tx:method name="getTickets" read-only="true" />
         </tx:attributes>
     </tx:advice>


### PR DESCRIPTION
When a TGT is loaded it is checked if it has expired, if it has it will be deleted which fails in a readonly TX