### PR TITLE
Remove double authentication when generating STs

### DIFF
--- a/cas-server-core-api-authentication/src/main/java/org/jasig/cas/authentication/AuthenticationException.java
+++ b/cas-server-core-api-authentication/src/main/java/org/jasig/cas/authentication/AuthenticationException.java
@@ -25,12 +25,21 @@ public class AuthenticationException extends Exception {
 
     /**
      * Creates a new instance for the case when no handlers were attempted, i.e. no successes or failures.
+     *
+     * @param msg the msg
      */
-    public AuthenticationException() {
+    public AuthenticationException(final String msg) {
         this(
-            "No supported authentication handlers found for given credentials.",
+            msg,
             Collections.<String, Class<? extends Exception>>emptyMap(),
             Collections.<String, HandlerResult>emptyMap());
+    }
+
+    /**
+     * Instantiates a new Authentication exception.
+     */
+    public AuthenticationException() {
+        this("No supported authentication handlers found for given credentials.");
     }
 
     /**

--- a/cas-server-core-api-authentication/src/main/java/org/jasig/cas/authentication/AuthenticationSystemSupport.java
+++ b/cas-server-core-api-authentication/src/main/java/org/jasig/cas/authentication/AuthenticationSystemSupport.java
@@ -35,6 +35,17 @@ public interface AuthenticationSystemSupport {
     /**
      * Initiate potential multi-transaction authentication event by handling the initial authentication transaction.
      *
+     * @param authentication a pre-established authentication object in a multi-legged authentication flow.
+     *
+     * @return authentication result builder used to accumulate authentication transactions in this authentication event.
+     *
+     * @since 4.3.0
+     */
+    AuthenticationResultBuilder establishAuthenticationContextFromInitial(Authentication authentication);
+
+    /**
+     * Initiate potential multi-transaction authentication event by handling the initial authentication transaction.
+     *
      * @param credential a credential for the initial authentication transaction.
      *
      * @return authentication result builder used to accumulate authentication transactions in this authentication event.

--- a/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/DefaultAuthenticationSystemSupport.java
+++ b/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/DefaultAuthenticationSystemSupport.java
@@ -56,6 +56,14 @@ public final class DefaultAuthenticationSystemSupport implements AuthenticationS
     }
 
     @Override
+    public AuthenticationResultBuilder establishAuthenticationContextFromInitial(final Authentication authentication){
+        final AuthenticationResultBuilder builder =
+                new DefaultAuthenticationResultBuilder(this.principalElectionStrategy).collect(authentication);
+        return builder;
+
+    }
+
+    @Override
     public AuthenticationResult handleAndFinalizeSingleAuthenticationTransaction(final Service service, final Credential... credential)
             throws AuthenticationException {
 

--- a/cas-server-core/src/test/java/org/jasig/cas/AbstractCentralAuthenticationServiceTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/AbstractCentralAuthenticationServiceTests.java
@@ -5,6 +5,7 @@ import org.jasig.cas.authentication.AuthenticationSystemSupport;
 import org.jasig.cas.authentication.DefaultAuthenticationSystemSupport;
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.ticket.registry.TicketRegistry;
+import org.jasig.cas.ticket.registry.TicketRegistrySupport;
 import org.jasig.cas.web.support.ArgumentExtractor;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -48,6 +49,9 @@ public abstract class AbstractCentralAuthenticationServiceTests {
     @Autowired
     private ArgumentExtractor argumentExtractor;
 
+    @Autowired
+    private TicketRegistrySupport ticketRegistrySupport;
+
     @NotNull
     @Autowired(required=false)
     @Qualifier("defaultAuthenticationSystemSupport")
@@ -79,5 +83,9 @@ public abstract class AbstractCentralAuthenticationServiceTests {
 
     public AuthenticationSystemSupport getAuthenticationSystemSupport() {
         return authenticationSystemSupport;
+    }
+
+    public TicketRegistrySupport getTicketRegistrySupport() {
+        return ticketRegistrySupport;
     }
 }

--- a/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/config/HazelcastInstanceConfiguration.java
+++ b/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/config/HazelcastInstanceConfiguration.java
@@ -67,20 +67,18 @@ public class HazelcastInstanceConfiguration {
      * @throws IOException if parsing of hazelcast xml configuration fails
      */
     private Config getConfig(final Resource configLocation) throws IOException {
-        Config config;
+        final Config config;
         //We have a valid config location for hazelcast xml. Try to parse it and configure Hazelcast instance according to that source
         if (configLocation.exists()) {
             final URL configUrl = configLocation.getURL();
             config = new XmlConfigBuilder(configUrl).build();
             if (ResourceUtils.isFileURL(configUrl)) {
                 config.setConfigurationFile(configLocation.getFile());
-            }
-            else {
+            } else {
                 config.setConfigurationUrl(configUrl);
             }
-        }
-        //No config location, so do a default config programmatically with handful of properties exposed by CAS
-        else {
+        } else {
+            //No config location, so do a default config programmatically with handful of properties exposed by CAS
             config = new Config();
             //TCP config
             final TcpIpConfig tcpIpConfig = new TcpIpConfig()

--- a/cas-server-webapp-actions/src/main/java/org/jasig/cas/web/flow/GenerateServiceTicketAction.java
+++ b/cas-server-webapp-actions/src/main/java/org/jasig/cas/web/flow/GenerateServiceTicketAction.java
@@ -65,6 +65,10 @@ public final class GenerateServiceTicketAction extends AbstractAction {
              * So we will simply grab the available authentication and produce the final result based on that.
              */
             final Authentication authentication = ticketRegistrySupport.getAuthenticationFrom(ticketGrantingTicket);
+            if (authentication == null) {
+                throw new InvalidTicketException(
+                        new AuthenticationException("No authentication found for ticket " + ticketGrantingTicket), ticketGrantingTicket);
+            }
             final AuthenticationResultBuilder authenticationResultBuilder = authenticationSystemSupport
                     .establishAuthenticationContextFromInitial(authentication);
             final AuthenticationResult authenticationResult = authenticationResultBuilder.build(service);
@@ -94,6 +98,10 @@ public final class GenerateServiceTicketAction extends AbstractAction {
 
     public void setAuthenticationSystemSupport(final AuthenticationSystemSupport authenticationSystemSupport) {
         this.authenticationSystemSupport = authenticationSystemSupport;
+    }
+
+    public void setTicketRegistrySupport(final TicketRegistrySupport ticketRegistrySupport) {
+        this.ticketRegistrySupport = ticketRegistrySupport;
     }
 
     /**

--- a/cas-server-webapp-actions/src/main/java/org/jasig/cas/web/flow/GenerateServiceTicketAction.java
+++ b/cas-server-webapp-actions/src/main/java/org/jasig/cas/web/flow/GenerateServiceTicketAction.java
@@ -49,9 +49,24 @@ public final class GenerateServiceTicketAction extends AbstractAction {
         final String ticketGrantingTicket = WebUtils.getTicketGrantingTicketId(context);
 
         try {
+            /**
+             * In the initial primary authentication flow, credentials are cached and available.
+             * Since they are authenticated as part of submission first, there is no need to doubly
+             * authenticate and verify credentials.
+             *
+             * In subsequent authentication flows where a TGT is available and only an ST needs to be
+             * created, there are no cached copies of the credential, since we do have a TGT available.
+             * So we will simply grab the available authentication and produce the final result based on that.
+             */
             final Credential credential = WebUtils.getCredential(context);
-            final AuthenticationResult authenticationResult =
-                    this.authenticationSystemSupport.handleAndFinalizeSingleAuthenticationTransaction(service, credential);
+
+            final AuthenticationResult authenticationResult;
+            if (credential == null) {
+
+            } else {
+                authenticationResult =
+                        this.authenticationSystemSupport.handleAndFinalizeSingleAuthenticationTransaction(service, credential);
+            }
 
             final ServiceTicket serviceTicketId = this.centralAuthenticationService
                     .grantServiceTicket(ticketGrantingTicket, service, authenticationResult);

--- a/cas-server-webapp-actions/src/test/java/org/jasig/cas/web/flow/GenerateServiceTicketActionTests.java
+++ b/cas-server-webapp-actions/src/test/java/org/jasig/cas/web/flow/GenerateServiceTicketActionTests.java
@@ -4,7 +4,6 @@ import org.jasig.cas.AbstractCentralAuthenticationServiceTests;
 import org.jasig.cas.authentication.AuthenticationResult;
 import org.jasig.cas.authentication.TestUtils;
 import org.jasig.cas.ticket.TicketGrantingTicket;
-import org.jasig.cas.ticket.registry.DefaultTicketRegistrySupport;
 import org.jasig.cas.web.support.WebUtils;
 import org.junit.Before;
 import org.junit.Test;

--- a/cas-server-webapp-actions/src/test/java/org/jasig/cas/web/flow/GenerateServiceTicketActionTests.java
+++ b/cas-server-webapp-actions/src/test/java/org/jasig/cas/web/flow/GenerateServiceTicketActionTests.java
@@ -4,6 +4,7 @@ import org.jasig.cas.AbstractCentralAuthenticationServiceTests;
 import org.jasig.cas.authentication.AuthenticationResult;
 import org.jasig.cas.authentication.TestUtils;
 import org.jasig.cas.ticket.TicketGrantingTicket;
+import org.jasig.cas.ticket.registry.DefaultTicketRegistrySupport;
 import org.jasig.cas.web.support.WebUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +34,7 @@ public final class GenerateServiceTicketActionTests extends AbstractCentralAuthe
         this.action = new GenerateServiceTicketAction();
         this.action.setCentralAuthenticationService(getCentralAuthenticationService());
         this.action.setAuthenticationSystemSupport(getAuthenticationSystemSupport());
+        this.action.setTicketRegistrySupport(getTicketRegistrySupport());
         this.action.afterPropertiesSet();
 
         final AuthenticationResult authnResult =
@@ -41,6 +43,7 @@ public final class GenerateServiceTicketActionTests extends AbstractCentralAuthe
                                 TestUtils.getCredentialsWithSameUsernameAndPassword());
 
         this.ticketGrantingTicket = getCentralAuthenticationService().createTicketGrantingTicket(authnResult);
+        getTicketRegistry().addTicket(this.ticketGrantingTicket);
     }
 
     @Test

--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -182,7 +182,9 @@
         <module name="EqualsAvoidNull">
             <property name="severity" value="error"/>
         </module>
-        <module name="RightCurly"/>
+        <module name="RightCurly">
+            <property name="severity" value="error"/>
+        </module>
         <module name="NoFinalizer">
             <property name="severity" value="error"/>
         </module>


### PR DESCRIPTION
Closes #1506 

Grabs the authentication object from the existing TGT and builds a result out of that, rather than authenticating the credentials again. 