### PR TITLE
always use the root TGT for checking the AuthenticationPolicy

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -148,7 +148,7 @@ public final class CentralAuthenticationServiceImpl extends AbstractCentralAuthe
 
         // Perform security policy check by getting the authentication that satisfies the configured policy
         // This throws if no suitable policy is found
-        getAuthenticationSatisfiedByPolicy(ticketGrantingTicket, new ServiceContext(service, registeredService));
+        getAuthenticationSatisfiedByPolicy(ticketGrantingTicket.getRoot(), new ServiceContext(service, registeredService));
 
         final List<Authentication> authentications = ticketGrantingTicket.getChainedAuthentications();
         final Principal principal = authentications.get(authentications.size() - 1).getPrincipal();
@@ -208,7 +208,7 @@ public final class CentralAuthenticationServiceImpl extends AbstractCentralAuthe
 
         // Perform security policy check by getting the authentication that satisfies the configured policy
         // This throws if no suitable policy is found
-        getAuthenticationSatisfiedByPolicy(proxyGrantingTicketObject, new ServiceContext(service, registeredService));
+        getAuthenticationSatisfiedByPolicy(proxyGrantingTicketObject.getRoot(), new ServiceContext(service, registeredService));
 
         final List<Authentication> authentications = proxyGrantingTicketObject.getChainedAuthentications();
         final Principal principal = authentications.get(authentications.size() - 1).getPrincipal();


### PR DESCRIPTION
We store the original `Authentication` object only in the root `TGT`. In order for `AuthenticationPolicies` to be correctly enforced for issued `PT`s we need to check the policy against the root `Authentication` object.