### PR TITLE
Move ticket cleaner process up the chain

### DIFF
--- a/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
@@ -11,23 +11,11 @@ import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.TicketGrantingTicketImpl;
 import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 import org.jasig.cas.ticket.registry.support.LockingStrategy;
-import org.quartz.Job;
-import org.quartz.JobBuilder;
-import org.quartz.JobDetail;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.Scheduler;
-import org.quartz.SimpleScheduleBuilder;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
-import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.PersistenceContext;
@@ -35,10 +23,7 @@ import javax.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 /**
  * JPA implementation of a CAS {@link TicketRegistry}. This implementation of
@@ -49,21 +34,7 @@ import java.util.concurrent.TimeUnit;
  * @since 3.2.1
  */
 @Component("jpaTicketRegistry")
-public final class JpaTicketRegistry extends AbstractTicketRegistry implements Job {
-
-    @Value("${ticket.registry.cleaner.repeatinterval:5000}")
-    private int refreshInterval;
-
-    @Value("${ticket.registry.cleaner.startdelay:20}")
-    private int startDelay;
-
-    @Autowired
-    @NotNull
-    private ApplicationContext applicationContext;
-
-    @Autowired(required = false)
-    @Qualifier("scheduler")
-    private Scheduler scheduler;
+public final class JpaTicketRegistry extends AbstractTicketRegistry {
 
     @Autowired
     @Qualifier("jpaLockingStrategy")
@@ -248,66 +219,21 @@ public final class JpaTicketRegistry extends AbstractTicketRegistry implements J
         return intval;
     }
 
-
-    /**
-     * Schedule reloader job.
-     */
-    @PostConstruct
-    public void scheduleCleanerJob() {
-        try {
-            if (shouldScheduleCleanerJob()) {
-                logger.info("Preparing to schedule cleaner job");
-                final JobDetail job = JobBuilder.newJob(this.getClass())
-                        .withIdentity(this.getClass().getSimpleName().concat(UUID.randomUUID().toString()))
-                        .build();
-
-                final Trigger trigger = TriggerBuilder.newTrigger()
-                        .withIdentity(this.getClass().getSimpleName().concat(UUID.randomUUID().toString()))
-                        .startAt(Date.from(ZonedDateTime.now().plusSeconds(this.startDelay).toInstant()))
-                        .withSchedule(SimpleScheduleBuilder.simpleSchedule()
-                                .withIntervalInSeconds(this.refreshInterval)
-                                .repeatForever()).build();
-
-                logger.debug("Scheduling {} job", this.getClass().getName());
-                scheduler.scheduleJob(job, trigger);
-                logger.info("{} will clean tickets every {} seconds",
-                        this.getClass().getSimpleName(),
-                        TimeUnit.MILLISECONDS.toSeconds(this.refreshInterval));
-            }
-        } catch (final Exception e) {
-            logger.warn(e.getMessage(), e);
-        }
-
+    @Override
+    protected void postCleanupTickets() {
+        logger.debug("Releasing ticket cleanup lock.");
+        this.jpaLockingStrategy.release();
+        logger.info("Finished ticket cleanup.");
     }
 
     @Override
-    public void execute(final JobExecutionContext jobExecutionContext) throws JobExecutionException {
-        SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
-
-        try {
-            logger.debug("Attempting to acquire ticket cleanup lock.");
-            if (!this.jpaLockingStrategy.acquire()) {
-                logger.info("Could not obtain lock. Aborting cleanup.");
-                return;
-            }
-            logger.debug("Acquired lock. Proceeding with cleanup.");
-            cleanupTickets();
-        } catch (final Exception e) {
-            logger.error(e.getMessage(), e);
-        } finally {
-            logger.debug("Releasing ticket cleanup lock.");
-            this.jpaLockingStrategy.release();
-            logger.info("Finished ticket cleanup.");
+    protected boolean preCleanupTickets() {
+        logger.debug("Attempting to acquire ticket cleanup lock.");
+        if (!this.jpaLockingStrategy.acquire()) {
+            logger.warn("Could not obtain lock. Aborting cleanup.");
+            return false;
         }
-
-    }
-
-    private boolean shouldScheduleCleanerJob() {
-        if (this.startDelay > 0 && this.applicationContext.getParent() == null && scheduler != null) {
-            logger.debug("Found CAS servlet application context for ticket management");
-            return true;
-        }
-
-        return false;
+        logger.debug("Acquired lock. Proceeding with cleanup.");
+        return super.preCleanupTickets();
     }
 }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -491,6 +491,7 @@ accept.authn.users=casuser::Mellon
 # Ticket Registry Cleaner
 #
 # Indicates how frequently the Ticket Registry cleaner should run. Configured in seconds.
+# ticket.registry.cleaner.enabled=true
 # ticket.registry.cleaner.startdelay=20
 # ticket.registry.cleaner.repeatinterval=5000
 


### PR DESCRIPTION
so it can be supported by all registries when/if needed. 

This partially handles #1254 . There have also been a number of reports, particularly be Ehcache (and some for Hazelcast) where expired entries are not immediately removed from the cache. Also, in certain cases if the eviction policy of the cache is different from the ticket expiration policy of CAS, where the latter is quicker to expire elements, we'd want entries in the cache gone as soon as possible and not rely on the cache policy to consume and allocate memory for what would effectively be dead objects for CAS. 

This cleaning behavior is on by default, but for certain registries that do not need it, can be disabled. 