### PR TITLE
Cas 1550

### DIFF
--- a/cas-server-support-openid/src/main/java/org/jasig/cas/support/openid/authentication/principal/OpenIdServiceResponseBuilder.java
+++ b/cas-server-support-openid/src/main/java/org/jasig/cas/support/openid/authentication/principal/OpenIdServiceResponseBuilder.java
@@ -79,7 +79,7 @@ public class OpenIdServiceResponseBuilder extends AbstractWebApplicationServiceR
 
         Assertion assertion = null;
         try {
-            if (associated && associationValid) {
+            if (associated && associationValid || !associated) {
                 assertion = centralAuthenticationService.validateServiceTicket(ticketId, service);
                 logger.debug("Validated openid ticket {} for {}", ticketId, service);
             } else {

--- a/cas-server-support-openid/src/main/java/org/jasig/cas/support/openid/authentication/principal/OpenIdServiceResponseBuilder.java
+++ b/cas-server-support-openid/src/main/java/org/jasig/cas/support/openid/authentication/principal/OpenIdServiceResponseBuilder.java
@@ -79,7 +79,7 @@ public class OpenIdServiceResponseBuilder extends AbstractWebApplicationServiceR
 
         Assertion assertion = null;
         try {
-            if (associated && associationValid || !associated) {
+            if ((associated && associationValid) || !associated) {
                 assertion = centralAuthenticationService.validateServiceTicket(ticketId, service);
                 logger.debug("Validated openid ticket {} for {}", ticketId, service);
             } else {

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/openid/casOpenIdAssociationSuccessView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/openid/casOpenIdAssociationSuccessView.jsp
@@ -1,1 +1,8 @@
-%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<c:out value="ns:${parameters['ns']}" />
+<c:out value="enc_mac_key:${parameters['enc_mac_key']}" />
+<c:out value="assoc_type:${parameters['assoc_type']}" />
+<c:out value="dh_server_public:${parameters['dh_server_public']}" />
+<c:out value="session_type:${parameters['session_type']}" />
+<c:out value="expires_in:${parameters['expires_in']}" />
+<c:out value="assoc_handle:${parameters['assoc_handle']}" />


### PR DESCRIPTION
Allows Stateless mode to work in OpenID 2.0

Adds the required parameters to the 'success' Association View and allows stateless mode by skipping association validation when there is no association.
NOTE: Stateless mode will only work if number of uses of service ticket is at least '2' (st.numberOfUses in cas.properties) . This is a temporary fix.