### PR TITLE
Let TokenAuthenticationHandler pick the correct signing secret. 

### DIFF
--- a/cas-server-support-token/src/main/java/org/jasig/cas/authentication/handler/support/TokenAuthenticationHandler.java
+++ b/cas-server-support-token/src/main/java/org/jasig/cas/authentication/handler/support/TokenAuthenticationHandler.java
@@ -79,7 +79,7 @@ public class TokenAuthenticationHandler extends AbstractTokenWrapperAuthenticati
     * @return the registered service jwt secret
     */
     private String getRegisteredServiceJwtSigningSecret(final RegisteredService service) {
-        return getRegisteredServiceJwtSecret(service, TokenConstants.PROPERTY_NAME_TOKEN_SECRET_ENCRYPTION);
+        return getRegisteredServiceJwtSecret(service, TokenConstants.PROPERTY_NAME_TOKEN_SECRET_SIGNING);
     }
 
     /**

--- a/cas-server-support-token/src/main/java/org/jasig/cas/authentication/handler/support/TokenAuthenticationHandler.java
+++ b/cas-server-support-token/src/main/java/org/jasig/cas/authentication/handler/support/TokenAuthenticationHandler.java
@@ -39,7 +39,7 @@ public class TokenAuthenticationHandler extends AbstractTokenWrapperAuthenticati
 
         final RegisteredService service = this.servicesManager.findServiceBy(tokenCredential.getService());
         final String signingSecret = getRegisteredServiceJwtSigningSecret(service);
-        final String encryptionSecret = getRegisteredServiceJwtSigningSecret(service);
+        final String encryptionSecret = getRegisteredServiceJwtEncryptionSecret(service);
 
         if (StringUtils.isNotBlank(signingSecret)) {
             if (StringUtils.isBlank(encryptionSecret)) {


### PR DESCRIPTION
Closes #1555 

Fix Description:

- _getAuthenticator_ method calls correct _getRegisteredServiceJwtEncryptionSecret_ method to retrieve _encryptionSecret_ value.

- _getRegisteredServiceJwtSigningSecret_ method uses correct constant value _TokenConstants.PROPERTY_NAME_TOKEN_SECRET_SIGNING_.

Tested using generated war including these modifications wrapped with cas-overlay on apache-tomee-jaxrs-1.7.3. Using a JWT generated with JwtGenerator. Login request result: AUTHENTICATION_SUCCESS.