### PR TITLE
Allow CAS configuration to be defined via Groovy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ ext.libraries = [
                 "commons-io:commons-io:$commonsIoVersion",
                 dependencies.create("commons-jexl:commons-jexl:$commonsJexlVersion") {
                     exclude(group: 'commons-logging', module: 'commons-logging')
+                    exclude(group: 'commons-lang', module: 'commons-lang')
                     exclude(group: 'junit', module: 'junit')
                     force = true
                 },

--- a/cas-server-documentation/installation/Maven-Overlay-Installation.md
+++ b/cas-server-documentation/installation/Maven-Overlay-Installation.md
@@ -31,9 +31,62 @@ file contains a straightforward description of states and transitions in the flo
 the most common configuration concern beyond component configuration in the Spring XML configuration files. 
 
 ## Spring Configuration
-CAS server depends heavily on the Spring framework. There are exact and specific XML configuration files under `spring-configuration` directory that control various properties of CAS as well as `deployerConfigContext.xml` which is mostly expected by CAS adopters to be included in the overlay for environment-specific CAS settings.
+CAS server depends heavily on the Spring framework. Two modes of configuration are available. Note that both modes
+can be used at the same time. 
 
-XML configuration files can be overwritten to change behavior if need be via the Maven overlay process. The XML file can be obtained from source for the CAS version and placed at the same exact path by the same exact name in the Maven overlay build. If configured correctly, the build will use the locally-provided XML file rather than the default.
+### XML
+There are exact and specific XML configuration files under `spring-configuration` 
+directory that control various properties of CAS as well as `deployerConfigContext.xml` which is mostly expected by CAS adopters to be 
+included in the overlay for environment-specific CAS settings.
+
+XML configuration files can be overwritten to change behavior if need be via the Maven overlay process. The XML file can be obtained 
+from source for the CAS version and placed at the same exact path by the same exact name in the Maven overlay build. If configured 
+correctly, the build will use the locally-provided XML file rather than the default.
+
+### Groovy
+The CAS application context is able to load any `.groovy` file under the `spring-configuration` directory. 
+For advanced use cases, CAS beans can be dynamically defined via the Groovy programming language. 
+As an example, here is an `exampleBean` defined inside a `applicationContext.groovy` file:
+
+```groovy
+beans {
+    xmlns([context:'http://www.springframework.org/schema/context'])
+    xmlns([lang:'http://www.springframework.org/schema/lang'])
+    xmlns([util:'http://www.springframework.org/schema/util'])
+
+    exampleBean(org.jasig.cas.example.ExampleBean) {
+        beanProperty = propertyValue
+    }
+}
+```
+
+Additionally, dynamic reloadable Groovy beans can be defined in `deployerConfigContext.xml`. These definitions
+are directly read from a `.groovy` script which is monitored for changes and reloaded automatically.
+Here is a dynamic `messenger` bean defined whose definition is read from a `Messenger.groovy` file,
+and is monitored for changes every 5 seconds. 
+
+```
+<lang:groovy id="messenger"
+    refresh-check-delay="5000" 
+    script-source="classpath:Messenger.groovy">
+    <lang:property name="message" value="Hello, CAS!" />
+</lang:groovy>
+```
+
+The contents of the `Messenger.groovy` must resolve to a valid Java class:
+
+```groovy
+class ExampleMessenger implements Messenger {
+    String message = "Welcome"
+    
+    String getMessage() {
+        this.message
+    }
+    void setMessage(String message) {
+        this.message = message
+    }
+}
+```
 
 ## Custom and Third-Party Source
 It is common to customize or extend the functionality of CAS by developing Java components that implement CAS APIs or
@@ -85,7 +138,8 @@ under a `src/java/main` directory in the overlay project source tree.
     │   │   │                           └── UrlBuilder.java
 
 
-Also, note that for any custom Java component to compile and be included in the final `cas.war` file, the `pom.xml` in the Maven overlay must include a reference to the Maven Java compiler so classes can compiled. Here is a *sample* build configuration:
+Also, note that for any custom Java component to compile and be included in the final `cas.war` file, the `pom.xml` 
+in the Maven overlay must include a reference to the Maven Java compiler so classes can compiled. Here is a *sample* build configuration:
 
 
 ```xml

--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -1,18 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-| deployerConfigContext.xml centralizes into one file some of the declarative configuration that
-| all CAS deployers will need to modify.
-|
-| This file declares some of the Spring-managed JavaBeans that make up a CAS deployment.
-| The beans declared in this file are instantiated at context initialization time by the Spring
-| ContextLoaderListener declared in web.xml.  It finds this file because this
-| file is among those declared in the context parameter "contextConfigLocation".
-|
-| By far the most common change you will need to make in this file is to change the last bean
-| declaration to replace the default authentication handler with
-| one implementing your approach for authenticating usernames and passwords.
-+-->
-
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
@@ -20,6 +6,7 @@
        xmlns:c="http://www.springframework.org/schema/c"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:lang="http://www.springframework.org/schema/lang"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:sec="http://www.springframework.org/schema/security"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
@@ -27,6 +14,7 @@
        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
+       http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 
@@ -67,8 +55,7 @@
     <alias name="defaultTicketRegistry" alias="ticketRegistry" />
 
     <alias name="ticketGrantingTicketExpirationPolicy" alias="grantingTicketExpirationPolicy" />
-
-
+    
     <alias name="anyAuthenticationPolicy" alias="authenticationPolicy" />
     <alias name="acceptAnyAuthenticationPolicyFactory" alias="authenticationPolicyFactory" />
 
@@ -87,4 +74,5 @@
     <alias name="defaultPrincipalFactory" alias="principalFactory" />
     <alias name="defaultAuthenticationTransactionManager" alias="authenticationTransactionManager" />
     <alias name="defaultPrincipalElectionStrategy" alias="principalElectionStrategy" />
+    
 </beans>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.groovy
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.groovy
@@ -1,0 +1,6 @@
+beans {
+    xmlns([context:'http://www.springframework.org/schema/context'])
+    xmlns([lang:'http://www.springframework.org/schema/lang'])
+    xmlns([util:'http://www.springframework.org/schema/util'])
+    
+}

--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -14,12 +14,16 @@
     </listener>
 
     <context-param>
+        <param-name>contextClass</param-name>
+        <param-value>org.springframework.web.context.support.GroovyWebApplicationContext</param-value>
+    </context-param>
+    
+    <context-param>
         <param-name>contextConfigLocation</param-name>
         <param-value>
             /WEB-INF/spring-configuration/*.xml
+            /WEB-INF/spring-configuration/*.groovy
             /WEB-INF/deployerConfigContext.xml
-            <!-- this enables extensions and addons to contribute to overall CAS' application context
-                 by loading spring context files from classpath i.e. found in classpath jars, etc. -->
             classpath*:/META-INF/spring/*.xml
         </param-value>
     </context-param>


### PR DESCRIPTION
Closes #1130 

The following changes are packed in this patch:

1. Add the `lang` namespace to the deployer file so that dynamic refreshable beans via Groovy can be defined via `lang:groovy`
2. Allow `.groovy` files to be loaded as part of the Spring web application context. 
