### PR TITLE
Remove session sharing requirement from saml idp impl

### DIFF
--- a/cas-server-core-util/src/main/java/org/jasig/cas/util/SerializationUtils.java
+++ b/cas-server-core-util/src/main/java/org/jasig/cas/util/SerializationUtils.java
@@ -109,18 +109,8 @@ public final class SerializationUtils {
      */
     public static byte[] serializeAndEncodeObject(final CipherExecutor<byte[], byte[]> cipher,
                                                   final Serializable object) {
-        final byte[] outBytes = serializeAndEncodeObject(object);
+        final byte[] outBytes = serialize(object);
         return cipher.encode(outBytes);
-    }
-
-    /**
-     * Serialize object.
-     *
-     * @param obj the object
-     * @return the byte []
-     */
-    public static byte[] serializeAndEncodeObject(final Serializable obj) {
-        return serialize(obj);
     }
 
     /**

--- a/cas-server-support-saml-idp/src/main/java/org/jasig/cas/support/saml/web/idp/profile/SSOPostProfileHandlerController.java
+++ b/cas-server-support-saml-idp/src/main/java/org/jasig/cas/support/saml/web/idp/profile/SSOPostProfileHandlerController.java
@@ -89,8 +89,6 @@ public class SSOPostProfileHandlerController extends AbstractSamlProfileHandlerC
         }
 
         SamlIdPUtils.logSamlObject(this.configBean, authnRequest);
-
-        storeAuthnRequest(request, authnRequest);
         issueAuthenticationRequestRedirect(authnRequest, request, response);
     }
 


### PR DESCRIPTION
Closes https://github.com/Jasig/cas/issues/1570

Removes the need to store the authn request into the websession. Instead, passes it back to the CAS login endpoint, and picks it up on the return again, as an encoded parameter, as if the parameter was originally sent to the login endpoint to begin with. 
