### PR TITLE
Adjustments to @Configuration of DispatcherServlet context

### DIFF
--- a/cas-management-webapp-support/src/main/java/org/jasig/cas/config/CasManagementWebAppConfiguration.java
+++ b/cas-management-webapp-support/src/main/java/org/jasig/cas/config/CasManagementWebAppConfiguration.java
@@ -281,15 +281,6 @@ public class CasManagementWebAppConfiguration {
         return resolver;
     }
 
-    /**
-     * Locale change interceptor locale change interceptor.
-     *
-     * @return the locale change interceptor
-     */
-    @Bean(name = "localeChangeInterceptor")
-    public LocaleChangeInterceptor localeChangeInterceptor() {
-        return new LocaleChangeInterceptor();
-    }
 
     /**
      * Credentials validator local validator factory bean.

--- a/cas-management-webapp-support/src/main/java/org/jasig/cas/config/CasManagementWebAppConfiguration.java
+++ b/cas-management-webapp-support/src/main/java/org/jasig/cas/config/CasManagementWebAppConfiguration.java
@@ -19,13 +19,13 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.i18n.CookieLocaleResolver;
-import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.mvc.UrlFilenameViewController;
 import org.springframework.web.servlet.view.InternalResourceView;
 import org.springframework.web.servlet.view.ResourceBundleViewResolver;
@@ -43,6 +43,7 @@ import java.util.Properties;
  * @since 4.3.0
  */
 @Configuration("casManagementWebAppConfiguration")
+@Lazy(true)
 public class CasManagementWebAppConfiguration {
 
     /**

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasApplicationContextConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasApplicationContextConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.scheduling.quartz.SpringBeanJobFactory;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
@@ -31,6 +32,7 @@ import java.util.Properties;
  * @since 4.3.0
  */
 @Configuration("casApplicationContextConfiguration")
+@Lazy(true)
 public class CasApplicationContextConfiguration {
 
     /**

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasAuditTrailConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasAuditTrailConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import javax.annotation.Resource;
 import java.util.Map;
@@ -23,6 +24,7 @@ import java.util.Map;
  * @since 4.3.0
  */
 @Configuration("casAuditTrailConfiguration")
+@Lazy(true)
 public class CasAuditTrailConfiguration {
     /**
      * The App code.

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasFiltersConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasFiltersConfiguration.java
@@ -6,6 +6,7 @@ import org.jasig.cas.security.ResponseHeadersEnforcementFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
@@ -17,6 +18,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
  * @since 4.3.0
  */
 @Configuration("casFiltersConfiguration")
+@Lazy(true)
 public class CasFiltersConfiguration {
 
     /**

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasProtocolViewsConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasProtocolViewsConfiguration.java
@@ -3,6 +3,7 @@ package org.jasig.cas.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.web.servlet.view.JstlView;
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.web.servlet.view.JstlView;
  * @since 4.3.0
  */
 @Configuration("casProtocolViewsConfiguration")
+@Lazy(true)
 public class CasProtocolViewsConfiguration {
 
     /**

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasSecurityContextConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasSecurityContextConfiguration.java
@@ -7,6 +7,7 @@ import org.pac4j.springframework.web.RequiresAuthenticationInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * This is {@link CasSecurityContextConfiguration} that attempts to create Spring-managed beans
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 4.3.0
  */
 @Configuration("casSecurityContextConfiguration")
+@Lazy(true)
 public class CasSecurityContextConfiguration {
 
     /**

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebAppConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebAppConfiguration.java
@@ -2,13 +2,12 @@ package org.jasig.cas.config;
 
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.services.web.RegisteredServiceThemeBasedViewResolver;
-import org.jasig.cas.web.flow.CasDefaultFlowUrlHandler;
-import org.jasig.cas.web.flow.SelectiveFlowHandlerAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.Resource;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.servlet.i18n.CookieLocaleResolver;
@@ -21,7 +20,6 @@ import org.springframework.web.servlet.view.InternalResourceView;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import org.springframework.web.servlet.view.XmlViewResolver;
 import org.springframework.web.servlet.view.script.ScriptTemplateViewResolver;
-import org.springframework.webflow.executor.FlowExecutor;
 
 import javax.validation.MessageInterpolator;
 import java.util.Locale;
@@ -33,6 +31,7 @@ import java.util.Locale;
  * @since 4.3.0
  */
 @Configuration("casWebAppConfiguration")
+@Lazy(true)
 public class CasWebAppConfiguration {
 
     /**
@@ -192,6 +191,11 @@ public class CasWebAppConfiguration {
     }
 
 
+    /**
+     * Simple controller handler adapter.
+     *
+     * @return the simple controller handler adapter
+     */
     @Bean(name = "simpleControllerHandlerAdapter")
     public SimpleControllerHandlerAdapter simpleControllerHandlerAdapter() {
         return new SimpleControllerHandlerAdapter();

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebAppConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebAppConfiguration.java
@@ -2,6 +2,8 @@ package org.jasig.cas.config;
 
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.services.web.RegisteredServiceThemeBasedViewResolver;
+import org.jasig.cas.web.flow.CasDefaultFlowUrlHandler;
+import org.jasig.cas.web.flow.SelectiveFlowHandlerAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +13,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.servlet.i18n.CookieLocaleResolver;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
+import org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter;
 import org.springframework.web.servlet.theme.ThemeChangeInterceptor;
 import org.springframework.web.servlet.view.AbstractCachingViewResolver;
 import org.springframework.web.servlet.view.BeanNameViewResolver;
@@ -18,6 +21,7 @@ import org.springframework.web.servlet.view.InternalResourceView;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import org.springframework.web.servlet.view.XmlViewResolver;
 import org.springframework.web.servlet.view.script.ScriptTemplateViewResolver;
+import org.springframework.webflow.executor.FlowExecutor;
 
 import javax.validation.MessageInterpolator;
 import java.util.Locale;
@@ -68,7 +72,7 @@ public class CasWebAppConfiguration {
     @Autowired
     @Qualifier("servicesManager")
     private ServicesManager servicesManager;
-
+    
     /**
      * The Default locale.
      */
@@ -186,4 +190,11 @@ public class CasWebAppConfiguration {
         bean.setParamName(this.localeParamName);
         return bean;
     }
+
+
+    @Bean(name = "simpleControllerHandlerAdapter")
+    public SimpleControllerHandlerAdapter simpleControllerHandlerAdapter() {
+        return new SimpleControllerHandlerAdapter();
+    }
+
 }

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebflowContextConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebflowContextConfiguration.java
@@ -209,11 +209,21 @@ public class CasWebflowContextConfiguration {
         }
     }
 
+    /**
+     * Login flow url handler cas default flow url handler.
+     *
+     * @return the cas default flow url handler
+     */
     @Bean(name = "loginFlowUrlHandler")
     public CasDefaultFlowUrlHandler loginFlowUrlHandler() {
         return new CasDefaultFlowUrlHandler();
     }
 
+    /**
+     * Logout flow url handler cas default flow url handler.
+     *
+     * @return the cas default flow url handler
+     */
     @Bean(name = "logoutFlowUrlHandler")
     public CasDefaultFlowUrlHandler logoutFlowUrlHandler() {
         final CasDefaultFlowUrlHandler handler = new CasDefaultFlowUrlHandler();
@@ -221,6 +231,11 @@ public class CasWebflowContextConfiguration {
         return handler;
     }
 
+    /**
+     * Logout handler adapter selective flow handler adapter.
+     *
+     * @return the selective flow handler adapter
+     */
     @Bean(name = "logoutHandlerAdapter")
     public SelectiveFlowHandlerAdapter logoutHandlerAdapter() {
         final SelectiveFlowHandlerAdapter handler = new SelectiveFlowHandlerAdapter();
@@ -230,6 +245,11 @@ public class CasWebflowContextConfiguration {
         return handler;
     }
 
+    /**
+     * Login flow state transcoder encrypted transcoder.
+     *
+     * @return the encrypted transcoder
+     */
     @Bean(name = "loginFlowStateTranscoder")
     public EncryptedTranscoder loginFlowStateTranscoder() {
         try {
@@ -239,6 +259,11 @@ public class CasWebflowContextConfiguration {
         }
     }
 
+    /**
+     * Login handler adapter selective flow handler adapter.
+     *
+     * @return the selective flow handler adapter
+     */
     @Bean(name = "loginHandlerAdapter")
     public SelectiveFlowHandlerAdapter loginHandlerAdapter() {
         final SelectiveFlowHandlerAdapter handler = new SelectiveFlowHandlerAdapter();
@@ -258,6 +283,11 @@ public class CasWebflowContextConfiguration {
         return new LocaleChangeInterceptor();
     }
 
+    /**
+     * Logout flow handler mapping flow handler mapping.
+     *
+     * @return the flow handler mapping
+     */
     @Bean(name = "logoutFlowHandlerMapping")
     public FlowHandlerMapping logoutFlowHandlerMapping() {
         final FlowHandlerMapping handler = new FlowHandlerMapping();
@@ -268,6 +298,11 @@ public class CasWebflowContextConfiguration {
         return handler;
     }
 
+    /**
+     * Login flow handler mapping flow handler mapping.
+     *
+     * @return the flow handler mapping
+     */
     @Bean(name = "loginFlowHandlerMapping")
     public FlowHandlerMapping loginFlowHandlerMapping() {
         final FlowHandlerMapping handler = new FlowHandlerMapping();

--- a/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebflowContextConfiguration.java
+++ b/cas-server-webapp-config/src/main/java/org/jasig/cas/config/CasWebflowContextConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.webflow.mvc.servlet.FlowHandlerMapping;
  * @since 4.3.0
  */
 @Configuration("casWebflowContextConfiguration")
+@Lazy(true)
 public class CasWebflowContextConfiguration {
 
     private static final int LOGOUT_FLOW_HANDLER_ORDER = 3;

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -12,56 +12,10 @@
        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
        http://www.springframework.org/schema/webflow-config http://www.springframework.org/schema/webflow-config/spring-webflow-config.xsd">
-    
-    <bean class="org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter"/>
 
-    <!-- login webflow configuration -->
-    <bean id="loginFlowHandlerMapping" class="org.springframework.webflow.mvc.servlet.FlowHandlerMapping"
-          p:flowRegistry-ref="loginFlowRegistry" p:order="2">
-        <property name="interceptors">
-            <array value-type="org.springframework.web.servlet.HandlerInterceptor">
-                <ref bean="localeChangeInterceptor"/>
-                <ref bean="authenticationThrottle"/>
-            </array>
-        </property>
-    </bean>
 
-    <bean id="loginHandlerAdapter" class="org.jasig.cas.web.flow.SelectiveFlowHandlerAdapter"
-          p:supportedFlowId="login" p:flowExecutor-ref="loginFlowExecutor" p:flowUrlHandler-ref="loginFlowUrlHandler"/>
 
-    <bean id="loginFlowUrlHandler" class="org.jasig.cas.web.flow.CasDefaultFlowUrlHandler"/>
 
-    <bean name="loginFlowExecutor" class="org.springframework.webflow.executor.FlowExecutorImpl"
-          c:definitionLocator-ref="loginFlowRegistry"
-          c:executionFactory-ref="loginFlowExecutionFactory"
-          c:executionRepository-ref="loginFlowExecutionRepository"/>
 
-    <bean name="loginFlowExecutionFactory" class="org.springframework.webflow.engine.impl.FlowExecutionImplFactory"
-          p:executionKeyFactory-ref="loginFlowExecutionRepository"/>
-
-    <bean id="loginFlowExecutionRepository" class="org.jasig.spring.webflow.plugin.ClientFlowExecutionRepository"
-          c:flowExecutionFactory-ref="loginFlowExecutionFactory"
-          c:flowDefinitionLocator-ref="loginFlowRegistry"
-          c:transcoder-ref="loginFlowStateTranscoder"/>
-    
-    <bean id="loginFlowStateTranscoder" class="org.jasig.spring.webflow.plugin.EncryptedTranscoder"
-          c:cipherBean-ref="loginFlowCipherBean"/>
-        
-    <!-- logout webflow configuration -->
-    <bean id="logoutFlowHandlerMapping" class="org.springframework.webflow.mvc.servlet.FlowHandlerMapping"
-          p:flowRegistry-ref="logoutFlowRegistry" p:order="3">
-        <property name="interceptors">
-            <array value-type="org.springframework.web.servlet.HandlerInterceptor">
-                <ref bean="localeChangeInterceptor"/>
-            </array>
-        </property>
-    </bean>
-
-    <bean id="logoutHandlerAdapter" class="org.jasig.cas.web.flow.SelectiveFlowHandlerAdapter"
-          p:supportedFlowId="logout" p:flowExecutor-ref="logoutFlowExecutor"
-          p:flowUrlHandler-ref="logoutFlowUrlHandler"/>
-
-    <bean id="logoutFlowUrlHandler" class="org.jasig.cas.web.flow.CasDefaultFlowUrlHandler"
-          p:flowExecutionKeyParameter="RelayState"/>
     
 </beans>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:webflow="http://www.springframework.org/schema/webflow-config"
        xmlns:context="http://www.springframework.org/schema/context"
@@ -12,7 +14,7 @@
         http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
         http://www.ryantenney.com/schema/metrics http://www.ryantenney.com/schema/metrics/metrics-3.0.xsd
-        http://www.springframework.org/schema/webflow-config http://www.springframework.org/schema/webflow-config/spring-webflow-config-2.4.xsd
+        http://www.springframework.org/schema/webflow-config http://www.springframework.org/schema/webflow-config/spring-webflow-config.xsd
         http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
     <description>
         This is the main Spring configuration file with some of the main "core" classes defined. You shouldn't really
@@ -40,7 +42,8 @@
     <mvc:annotation-driven />
     
     <!--
-    Security configuration for sensitive areas of CAS : status and statistics.
+    Security configuration for sensitive areas of CAS: status and statistics.
+    Modules individually may declare their own interceptors.
     -->
     <mvc:interceptors>
         <mvc:interceptor>
@@ -55,7 +58,7 @@
     </mvc:interceptors>
     
     <!-- 
-    Spring Webflow Configuration
+    Spring Webflow configuration. 
     -->
     <webflow:flow-builder-services id="builder" view-factory-creator="viewFactoryCreator"
                                    expression-parser="expressionParser"/>
@@ -74,7 +77,20 @@
     <webflow:flow-registry id="logoutFlowRegistry" flow-builder-services="builder" base-path="/WEB-INF/webflow">
         <webflow:flow-location-pattern value="/logout/*-webflow.xml"/>
     </webflow:flow-registry>
-    
+
+    <bean name="loginFlowExecutor" class="org.springframework.webflow.executor.FlowExecutorImpl"
+          c:definitionLocator-ref="loginFlowRegistry"
+          c:executionFactory-ref="loginFlowExecutionFactory"
+          c:executionRepository-ref="loginFlowExecutionRepository"/>
+
+    <bean name="loginFlowExecutionFactory" class="org.springframework.webflow.engine.impl.FlowExecutionImplFactory"
+          p:executionKeyFactory-ref="loginFlowExecutionRepository"/>
+
+    <bean id="loginFlowExecutionRepository" class="org.jasig.spring.webflow.plugin.ClientFlowExecutionRepository"
+          c:flowExecutionFactory-ref="loginFlowExecutionFactory"
+          c:flowDefinitionLocator-ref="loginFlowRegistry"
+          c:transcoder-ref="loginFlowStateTranscoder"/>
+
     <!--
     CAS Metrics Configuration
     -->
@@ -99,7 +115,7 @@
     </metrics:register>
     
     <!--
-    Audit Trail Context
+    Audit Trail Mapping Context
     -->
     <util:map id="auditActionResolverMap">
         <entry key="AUTHENTICATION_RESOLVER">


### PR DESCRIPTION
Follow up to the previous PR, this patch does the following:

1. Opts for lazy evaluation of the application context for webapp and management webapp
2. Moves a number of other beans defined in cas-servlet over to @Configuration class.
3. Moves remaining beans defined in cas-servlet.xml over to the applicationContext, so the root parent has access to all beans which may be required by modules. 
4. The cas-servlet.xml serves as an empty placeholder for config changes, if/when needed. 

Given the circular dependency injection of the following beans, they continue to live in the XML context, where Spring is able to "take care of references":

```xml
    <bean name="loginFlowExecutor" class="org.springframework.webflow.executor.FlowExecutorImpl"
          c:definitionLocator-ref="loginFlowRegistry"
          c:executionFactory-ref="loginFlowExecutionFactory"
          c:executionRepository-ref="loginFlowExecutionRepository"/>

    <bean name="loginFlowExecutionFactory" class="org.springframework.webflow.engine.impl.FlowExecutionImplFactory"
          p:executionKeyFactory-ref="loginFlowExecutionRepository"/>

    <bean id="loginFlowExecutionRepository" class="org.jasig.spring.webflow.plugin.ClientFlowExecutionRepository"
          c:flowExecutionFactory-ref="loginFlowExecutionFactory"
          c:flowDefinitionLocator-ref="loginFlowRegistry"
          c:transcoder-ref="loginFlowStateTranscoder"/>
```