### PR TITLE
Duplicate RegisteredService

### DIFF
--- a/cas-management-webapp/src/main/resources/messages.properties
+++ b/cas-management-webapp/src/main/resources/messages.properties
@@ -44,6 +44,7 @@ management.services.table.details.attrPolicy=Attribute Policy Option
 management.services.table.details.releaseCred=Release Credential
 management.services.table.details.releaseProxy=Release Proxy ID
 management.services.table.button.edit=edit
+management.services.table.button.duplicate=duplicate
 management.services.table.button.delete=delete
 management.services.table.modal.delete.header=Confirm Delete
 management.services.table.modal.delete.msgPt1=You are about to permanently delete

--- a/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/header.jsp
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/header.jsp
@@ -15,7 +15,7 @@
     <meta name="_csrf" content="${pac4jCsrfToken}"/>
     <meta name="_csrf_header" content="pac4jCsrfToken"/>
     <link rel="icon" href="<c:url value="/images/favicon.ico" />" type="image/x-icon" />
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.37/css/bootstrap-datetimepicker.min.css">
     <link rel="stylesheet" href="<c:url value="/css/cas-management.css" />" type="text/css" />
 

--- a/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/services.jsp
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/services.jsp
@@ -71,7 +71,7 @@
 
                     <table class="table-service">
                         <tr class="main-row">
-                            <td class="col-sm-3">
+                            <td class="col-sm-2">
                                 <div class="grabber-icon"><i class="fa fa-lg fa-ellipsis-v"></i></div>
 <%-- TODO: How does uiSortable deal with keyboard accessibility requirements for drag-and-drop? --%>
                                 <span ng-bind="item.name"></span>
@@ -86,6 +86,12 @@
                                 <button class="btn btn-success" ng-click="action.serviceEdit( item.assignedId )">
                                     <i class="fa fa-lg fa-pencil"></i>
                                     <spring:message code="management.services.table.button.edit" />
+                                </button>
+                            </td>
+                            <td class="col-sm-1">
+                                <button class="btn btn-warning" ng-click="action.serviceDuplicate( item.assignedId )">
+                                    <i class="fa fa-lg fa-clone"></i>
+                                    <spring:message code="management.services.table.button.duplicate" />
                                 </button>
                             </td>
                             <td class="col-sm-1">

--- a/cas-server-core-services/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
@@ -374,6 +374,7 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
                   .append(this.getEvaluationOrder(), other.getEvaluationOrder())
                   .append(this.getName().toLowerCase(), other.getName().toLowerCase())
                   .append(this.getServiceId(), other.getServiceId())
+                  .append(this.getId(), other.getId())
                   .toComparison();
     }
 

--- a/cas-server-core-services/src/test/java/org/jasig/cas/services/DefaultServicesManagerImplTests.java
+++ b/cas-server-core-services/src/test/java/org/jasig/cas/services/DefaultServicesManagerImplTests.java
@@ -53,7 +53,7 @@ public class DefaultServicesManagerImplTests  {
     }
 
     @Test
-    public void verifyMultiServicesBySameName() {
+    public void verifyMultiServicesBySameNameAndServiceId() {
         RegisteredServiceImpl r = new RegisteredServiceImpl();
         r.setId(666);
         r.setName("testServiceName");
@@ -64,7 +64,7 @@ public class DefaultServicesManagerImplTests  {
         r = new RegisteredServiceImpl();
         r.setId(999);
         r.setName("testServiceName");
-        r.setServiceId("testServiceB");
+        r.setServiceId("testServiceA");
 
         this.defaultServicesManagerImpl.save(r);
 


### PR DESCRIPTION
Closes #1581 

This adds a duplicate button to the CAS management UI. This allows quick configuration of a new service off of a pre-existing service.

I had to update `AbstractRegisteredService` because the `TreeSet` used in `DefaultServicesManagerImpl` eliminates any services that compare as equal (same eval order, name, & serviceId).

This corner case in a properly configured CAS server should never exist, but the duplicate service functionality exposed the corner case when those values aren't updated in the new duplicate service definition. This led to the new duplicate service not appearing on the admin UI.