### PR TITLE
Allow ticket registries to use the ticket's expiration policy 

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Closes #IssueNumber
 
-Ensure that you have reported the following:
+Ensure that you include the following:
 
 1. Brief description of changes applied
 2. Any documentation on how to configure, test

--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/ExpirationPolicy.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/ExpirationPolicy.java
@@ -28,16 +28,16 @@ public interface ExpirationPolicy extends Serializable {
     /**
      * Describes the time duration where this policy should consider the item alive.
      * Once this time passes, the item is considered expired and dead.
-     * @return alive time in seconds. A negative value indicates the time duration
-     * is not supported.
+     * @return alive time in seconds. A zero value indicates the time duration
+     * is not supported or is inactive.
      */
     Long getTimeToLive();
 
     /**
      * Describes the idle time duration for the item.
      *
-     * @return idle time in seconds. A negative value indicates the time duration
-     * is not supported.
+     * @return idle time in seconds. A zero value indicates the time duration
+     * is not supported or is inactive.
      */
     Long getTimeToIdle();
 }

--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/ExpirationPolicy.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/ExpirationPolicy.java
@@ -28,16 +28,16 @@ public interface ExpirationPolicy extends Serializable {
     /**
      * Describes the time duration where this policy should consider the item alive.
      * Once this time passes, the item is considered expired and dead.
-     * @return alive time in milliseconds. A negative value indicates the time duration
+     * @return alive time in seconds. A negative value indicates the time duration
      * is not supported.
      */
-    long getTimeToLive();
+    Long getTimeToLive();
 
     /**
      * Describes the idle time duration for the item.
      *
-     * @return idle time in milliseconds. A negative value indicates the time duration
+     * @return idle time in seconds. A negative value indicates the time duration
      * is not supported.
      */
-    long getTimeToIdle();
+    Long getTimeToIdle();
 }

--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/ExpirationPolicy.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/ExpirationPolicy.java
@@ -24,4 +24,20 @@ public interface ExpirationPolicy extends Serializable {
      * @return true if the ticket is expired, false otherwise.
      */
     boolean isExpired(TicketState ticketState);
+
+    /**
+     * Describes the time duration where this policy should consider the item alive.
+     * Once this time passes, the item is considered expired and dead.
+     * @return alive time in milliseconds. A negative value indicates the time duration
+     * is not supported.
+     */
+    long getTimeToLive();
+
+    /**
+     * Describes the idle time duration for the item.
+     *
+     * @return idle time in milliseconds. A negative value indicates the time duration
+     * is not supported.
+     */
+    long getTimeToIdle();
 }

--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/Ticket.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/Ticket.java
@@ -45,4 +45,10 @@ public interface Ticket extends Serializable {
      * @return the number of times this ticket was used.
      */
     int getCountOfUses();
+
+    /**
+     * Get expiration policy associated with ticket.
+     */
+    ExpirationPolicy getExpirationPolicy();
+    
 }

--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/Ticket.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/Ticket.java
@@ -42,12 +42,16 @@ public interface Ticket extends Serializable {
     ZonedDateTime getCreationTime();
 
     /**
+     * Gets count of uses.
+     *
      * @return the number of times this ticket was used.
      */
     int getCountOfUses();
 
     /**
      * Get expiration policy associated with ticket.
+     *
+     * @return the expiration policy
      */
     ExpirationPolicy getExpirationPolicy();
     

--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/registry/TicketRegistryState.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/registry/TicketRegistryState.java
@@ -15,7 +15,7 @@ public interface TicketRegistryState {
      * @return Number of ticket-granting tickets in the registry at time of invocation
      *         or {@link Integer#MIN_VALUE} if unknown.
      */
-    int sessionCount();
+    long sessionCount();
 
 
     /**
@@ -24,5 +24,5 @@ public interface TicketRegistryState {
      * @return Number of service tickets in the registry at time of invocation
      *         or {@link Integer#MIN_VALUE} if unknown.
      */
-    int serviceTicketCount();
+    long serviceTicketCount();
 }

--- a/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/PolicyBasedAuthenticationManager.java
+++ b/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/PolicyBasedAuthenticationManager.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Provides an authentication manager that is inherently aware of multiple credentials and supports pluggable

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/AbstractTicket.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/AbstractTicket.java
@@ -143,4 +143,9 @@ public abstract class AbstractTicket implements Ticket, TicketState {
     public final String toString() {
         return this.getId();
     }
+
+    @Override
+    public ExpirationPolicy getExpirationPolicy() {
+        return this.expirationPolicy;
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketDelegator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketDelegator.java
@@ -1,5 +1,6 @@
 package org.jasig.cas.ticket.registry;
 
+import org.jasig.cas.ticket.ExpirationPolicy;
 import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 
@@ -94,6 +95,11 @@ public abstract class AbstractTicketDelegator<T extends Ticket> implements Ticke
     @Override
     public boolean equals(final Object o) {
         return this.ticket.equals(o);
+    }
+
+    @Override
+    public ExpirationPolicy getExpirationPolicy() {
+        return ticket.getExpirationPolicy();
     }
 
     /**

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -122,14 +122,14 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
     }
 
     @Override
-    public int sessionCount() {
+    public long sessionCount() {
       logger.debug("sessionCount() operation is not implemented by the ticket registry instance {}. Returning unknown as {}",
                 this.getClass().getName(), Integer.MIN_VALUE);
       return Integer.MIN_VALUE;
     }
 
     @Override
-    public int serviceTicketCount() {
+    public long serviceTicketCount() {
       logger.debug("serviceTicketCount() operation is not implemented by the ticket registry instance {}. Returning unknown as {}",
                 this.getClass().getName(), Integer.MIN_VALUE);
       return Integer.MIN_VALUE;

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -277,13 +277,14 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
         if (ticket == null) {
             return ticket;
         }
-
+        
         logger.info("Encoding [{}]", ticket);
         final byte[] encodedTicketObject = SerializationUtils.serializeAndEncodeObject(
                 this.cipherExecutor, ticket);
         final String encodedTicketId = encodeTicketId(ticket.getId());
         final Ticket encodedTicket = new EncodedTicket(
-                ByteSource.wrap(encodedTicketObject), encodedTicketId);
+                ByteSource.wrap(encodedTicketObject), 
+                encodedTicketId);
         logger.info("Created [{}]", encodedTicket);
         return encodedTicket;
     }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
@@ -88,12 +88,12 @@ public final class DefaultTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public int sessionCount() {
+    public long sessionCount() {
         return (int) this.cache.values().stream().filter(t -> t instanceof TicketGrantingTicket).count();
     }
 
     @Override
-    public int serviceTicketCount() {
+    public long serviceTicketCount() {
         return (int) this.cache.values().stream().filter(t -> t instanceof ServiceTicket).count();
     }
 

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/EncodedTicket.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/EncodedTicket.java
@@ -1,12 +1,12 @@
 package org.jasig.cas.ticket.registry;
 
 
-import org.jasig.cas.ticket.Ticket;
-import org.jasig.cas.ticket.TicketGrantingTicket;
-
 import com.google.common.io.ByteSource;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.jasig.cas.ticket.ExpirationPolicy;
+import org.jasig.cas.ticket.Ticket;
+import org.jasig.cas.ticket.TicketGrantingTicket;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
@@ -47,6 +47,11 @@ public final class EncodedTicket implements Ticket {
     @Override
     public int getCountOfUses() {
         throw new UnsupportedOperationException("getCountOfUses() operation not supported");
+    }
+
+    @Override
+    public ExpirationPolicy getExpirationPolicy() {
+        throw new UnsupportedOperationException("getExpirationPolicy() operation not supported");
     }
 
     @Override

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/AlwaysExpiresExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/AlwaysExpiresExpirationPolicy.java
@@ -26,4 +26,14 @@ public final class AlwaysExpiresExpirationPolicy extends AbstractCasExpirationPo
     public boolean isExpired(final TicketState ticketState) {
         return true;
     }
+
+    @Override
+    public long getTimeToLive() {
+        return Long.MIN_VALUE;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return Long.MIN_VALUE;
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/AlwaysExpiresExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/AlwaysExpiresExpirationPolicy.java
@@ -28,12 +28,12 @@ public final class AlwaysExpiresExpirationPolicy extends AbstractCasExpirationPo
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return Long.MIN_VALUE;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return Long.MIN_VALUE;
     }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/AlwaysExpiresExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/AlwaysExpiresExpirationPolicy.java
@@ -29,11 +29,11 @@ public final class AlwaysExpiresExpirationPolicy extends AbstractCasExpirationPo
 
     @Override
     public Long getTimeToLive() {
-        return Long.MIN_VALUE;
+        return 0L;
     }
 
     @Override
     public Long getTimeToIdle() {
-        return Long.MIN_VALUE;
+        return 0L;
     }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/HardTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/HardTimeoutExpirationPolicy.java
@@ -67,12 +67,12 @@ public final class HardTimeoutExpirationPolicy extends AbstractCasExpirationPoli
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return this.timeToKillInMilliSeconds;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return Long.MIN_VALUE;
     }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/HardTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/HardTimeoutExpirationPolicy.java
@@ -65,4 +65,14 @@ public final class HardTimeoutExpirationPolicy extends AbstractCasExpirationPoli
         return (ticketState == null) || ticketState.getCreationTime()
           .plus(this.timeToKillInMilliSeconds, ChronoUnit.MILLIS).isAfter(ZonedDateTime.now(ZoneOffset.UTC));
     }
+
+    @Override
+    public long getTimeToLive() {
+        return this.timeToKillInMilliSeconds;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return Long.MIN_VALUE;
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/HardTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/HardTimeoutExpirationPolicy.java
@@ -73,6 +73,6 @@ public final class HardTimeoutExpirationPolicy extends AbstractCasExpirationPoli
 
     @Override
     public Long getTimeToIdle() {
-        return Long.MIN_VALUE;
+        return 0L;
     }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/MultiTimeUseOrTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/MultiTimeUseOrTimeoutExpirationPolicy.java
@@ -102,7 +102,7 @@ public class MultiTimeUseOrTimeoutExpirationPolicy extends AbstractCasExpiration
 
     @Override
     public Long getTimeToIdle() {
-        return Long.MIN_VALUE;
+        return 0L;
     }
 
     /**

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/MultiTimeUseOrTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/MultiTimeUseOrTimeoutExpirationPolicy.java
@@ -96,12 +96,12 @@ public class MultiTimeUseOrTimeoutExpirationPolicy extends AbstractCasExpiration
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return this.timeToKillInMilliSeconds;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return Long.MIN_VALUE;
     }
 

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/MultiTimeUseOrTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/MultiTimeUseOrTimeoutExpirationPolicy.java
@@ -95,6 +95,16 @@ public class MultiTimeUseOrTimeoutExpirationPolicy extends AbstractCasExpiration
         return false;
     }
 
+    @Override
+    public long getTimeToLive() {
+        return this.timeToKillInMilliSeconds;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return Long.MIN_VALUE;
+    }
+
     /**
      * The Proxy ticket expiration policy.
      */

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/NeverExpiresExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/NeverExpiresExpirationPolicy.java
@@ -28,12 +28,12 @@ public final class NeverExpiresExpirationPolicy extends AbstractCasExpirationPol
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return Long.MIN_VALUE;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return Long.MIN_VALUE;
     }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/NeverExpiresExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/NeverExpiresExpirationPolicy.java
@@ -26,4 +26,14 @@ public final class NeverExpiresExpirationPolicy extends AbstractCasExpirationPol
     public boolean isExpired(final TicketState ticketState) {
         return false;
     }
+
+    @Override
+    public long getTimeToLive() {
+        return Long.MIN_VALUE;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return Long.MIN_VALUE;
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/NeverExpiresExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/NeverExpiresExpirationPolicy.java
@@ -29,11 +29,11 @@ public final class NeverExpiresExpirationPolicy extends AbstractCasExpirationPol
 
     @Override
     public Long getTimeToLive() {
-        return Long.MIN_VALUE;
+        return new Long(Integer.MAX_VALUE);
     }
 
     @Override
     public Long getTimeToIdle() {
-        return Long.MIN_VALUE;
+        return new Long(Integer.MAX_VALUE);
     }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
@@ -77,6 +77,16 @@ public final class RememberMeDelegatingExpirationPolicy extends AbstractCasExpir
         return false;
     }
 
+    @Override
+    public long getTimeToLive() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return Long.MAX_VALUE;
+    }
+
     public void setRememberMeExpirationPolicy(
         final ExpirationPolicy rememberMeExpirationPolicy) {
         this.rememberMeExpirationPolicy = rememberMeExpirationPolicy;

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
@@ -79,12 +79,18 @@ public final class RememberMeDelegatingExpirationPolicy extends AbstractCasExpir
 
     @Override
     public Long getTimeToLive() {
-        return Long.MAX_VALUE;
+        if (this.rememberMeExpirationPolicy != null) {
+            return rememberMeExpirationPolicy.getTimeToLive();
+        }
+        return 0L;
     }
 
     @Override
     public Long getTimeToIdle() {
-        return Long.MAX_VALUE;
+        if (this.rememberMeExpirationPolicy != null) {
+            return rememberMeExpirationPolicy.getTimeToIdle();
+        }
+        return 0L;
     }
 
     public void setRememberMeExpirationPolicy(

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
@@ -78,12 +78,12 @@ public final class RememberMeDelegatingExpirationPolicy extends AbstractCasExpir
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return Long.MAX_VALUE;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return Long.MAX_VALUE;
     }
 

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/ThrottledUseAndTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/ThrottledUseAndTimeoutExpirationPolicy.java
@@ -79,4 +79,14 @@ public final class ThrottledUseAndTimeoutExpirationPolicy extends AbstractCasExp
 
         return false;
     }
+
+    @Override
+    public long getTimeToLive() {
+        return this.timeToKillInMilliSeconds;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return this.timeInBetweenUsesInMilliSeconds;
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/ThrottledUseAndTimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/ThrottledUseAndTimeoutExpirationPolicy.java
@@ -81,12 +81,12 @@ public final class ThrottledUseAndTimeoutExpirationPolicy extends AbstractCasExp
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return this.timeToKillInMilliSeconds;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return this.timeInBetweenUsesInMilliSeconds;
     }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
@@ -84,4 +84,14 @@ public final class TicketGrantingTicketExpirationPolicy extends AbstractCasExpir
         return false;
     }
 
+    @Override
+    public long getTimeToLive() {
+        return this.maxTimeToLiveInMilliSeconds;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return this.timeToKillInMilliSeconds;
+    }
+
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
@@ -85,12 +85,12 @@ public final class TicketGrantingTicketExpirationPolicy extends AbstractCasExpir
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return this.maxTimeToLiveInMilliSeconds;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return this.timeToKillInMilliSeconds;
     }
 

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TimeoutExpirationPolicy.java
@@ -1,7 +1,6 @@
 package org.jasig.cas.ticket.support;
 
 import org.jasig.cas.ticket.TicketState;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -59,13 +58,12 @@ public final class TimeoutExpirationPolicy extends AbstractCasExpirationPolicy {
     public boolean isExpired(final TicketState ticketState) {
         final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
         final ZonedDateTime expirationTime = now.plus(this.timeToKillInMilliSeconds, ChronoUnit.MILLIS);
-        return (ticketState == null)
-            || (now.isAfter(expirationTime));
+        return ticketState == null || now.isAfter(expirationTime);
     }
 
     @Override
     public Long getTimeToLive() {
-        return Long.MAX_VALUE;
+        return new Long(Integer.MAX_VALUE);
     }
 
     @Override

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TimeoutExpirationPolicy.java
@@ -62,4 +62,14 @@ public final class TimeoutExpirationPolicy extends AbstractCasExpirationPolicy {
         return (ticketState == null)
             || (now.isAfter(expirationTime));
     }
+
+    @Override
+    public long getTimeToLive() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return this.timeToKillInMilliSeconds;
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TimeoutExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TimeoutExpirationPolicy.java
@@ -64,12 +64,12 @@ public final class TimeoutExpirationPolicy extends AbstractCasExpirationPolicy {
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return Long.MAX_VALUE;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return this.timeToKillInMilliSeconds;
     }
 }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
@@ -59,6 +59,11 @@ public class MockServiceTicket implements ServiceTicket {
     }
 
     @Override
+    public ExpirationPolicy getExpirationPolicy() {
+        throw new UnsupportedOperationException("getExpirationPolicy() is not supported");
+    }
+
+    @Override
     public String getId() {
         return id;
     }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
@@ -135,6 +135,11 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
     }
 
     @Override
+    public ExpirationPolicy getExpirationPolicy() {
+        throw new UnsupportedOperationException("getExpirationPolicy() is not supported");
+    }
+
+    @Override
     public Map<String, Service> getServices() {
         return this.services;
     }

--- a/cas-server-documentation/installation/Ehcache-Ticket-Registry.md
+++ b/cas-server-documentation/installation/Ehcache-Ticket-Registry.md
@@ -14,12 +14,13 @@ Ehcache integration is enabled by including the following dependency in the Mave
 </dependency>
 ```
 
-`EhCacheTicketRegistry` stores tickets in an [Ehcache](http://ehcache.org/) instance.
+This registry stores tickets in an [Ehcache](http://ehcache.org/) instance.
 
 
 ## Distributed Cache
 Distributed caches are recommended for HA architectures since they offer fault tolerance in the ticket storage
-subsystem.
+subsystem. A single cache instance is created to house all types of tickets, and is synchronously replicated 
+across the cluster of nodes that are defined in the configuration. 
 
 
 ### RMI Replication
@@ -88,7 +89,7 @@ The Ehcache configuration for `ehcache-replicated.xml` mentioned in the config f
 ```
 
 ### Eviction Policy
-Ehcache manages the internal eviction policy of cached objects via `timeToIdle` and `timeToLive` settings.
+Ehcache manages the internal eviction policy of cached objects via the idle and alive settings.
 These settings control the general policy of the cache that is used to store various ticket types. In general,
 you need to ensure the cache is alive long enough to support the individual expiration policy of tickets, and let
 CAS clean the tickets as part of its own cleaner. 

--- a/cas-server-documentation/installation/Ehcache-Ticket-Registry.md
+++ b/cas-server-documentation/installation/Ehcache-Ticket-Registry.md
@@ -19,11 +19,7 @@ Ehcache integration is enabled by including the following dependency in the Mave
 
 ## Distributed Cache
 Distributed caches are recommended for HA architectures since they offer fault tolerance in the ticket storage
-subsystem. The registry maintains service tickets and ticket-granting tickets in two separate caches, so that:
-
-* Ticket Granting Tickets remain valid for a long time, replicated asynchronously
-* Service Tickets are short lived and must be replicated right away because the requests
-to validate them may very likely arrive at different CAS cluster nodes
+subsystem.
 
 
 ### RMI Replication
@@ -49,12 +45,6 @@ Enable the registry via:
 # ehcache.max.elements.disk=0
 # ehcache.eviction.policy=LRU
 # ehcache.overflow.disk=false
-# ehcache.cache.st.name=org.jasig.cas.ticket.ServiceTicket
-# ehcache.cache.st.timeIdle=0
-# ehcache.cache.st.timeAlive=300
-# ehcache.cache.tgt.name=org.jasig.cas.ticket.TicketGrantingTicket
-# ehcache.cache.tgt.timeIdle=7201
-# ehcache.cache.tgt.timeAlive=0
 # ehcache.cache.loader.async=true
 # ehcache.cache.loader.chunksize=5000000
 # ehcache.repl.async.interval=10000
@@ -64,57 +54,44 @@ Enable the registry via:
 # ehcache.repl.sync.updates=true
 # ehcache.repl.sync.updatescopy=true
 # ehcache.repl.sync.removals=true
+# ehcache.cache.name=org.jasig.cas.ticket.ServiceTicket
+# ehcache.cache.timeIdle=0
+# ehcache.cache.timeAlive=9000
 ```
 
 The Ehcache configuration for `ehcache-replicated.xml` mentioned in the config follows.
 
 ```xml
+
 <ehcache name="ehCacheTicketRegistryCache"
     updateCheck="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://ehcache.org/ehcache.xsd">
 
-  <diskStore path="java.io.tmpdir/cas"/>
+        <diskStore path="java.io.tmpdir/cas"/>
 
-  <!--
-     | Automatic peer discovery
-     | See http://ehcache.org/documentation/user-guide/rmi-replicated-caching#automatic-peer-discovery
-     | for more information.
-     -->
-  <!--
-  <cacheManagerPeerProviderFactory
+        <!-- Automatic Peer Discovery
+        <cacheManagerPeerProviderFactory
         class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
         properties="peerDiscovery=automatic, multicastGroupAddress=230.0.0.1, multicastGroupPort=4446, timeToLive=32"
         propertySeparator="," />
-  -->
+        -->
 
-  <!--
-     | Manual peer discovery
-     | See http://ehcache.org/documentation/user-guide/rmi-replicated-caching#manual-peer-discovery-manual-peer-discovery
-     | for more information
-     -->
-  <cacheManagerPeerProviderFactory
-      class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
-      properties="peerDiscovery=manual,rmiUrls=//peer-2:41001/cas_st|//peer-3:41001/cas_st|//peer-2:41001/cas_tgt|//peer-3:41001/cas_tgt" />
-  <cacheManagerPeerListenerFactory
-      class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
-      properties="port=41001,remoteObjectPort=41002" />
+        <!-- Manual Peer Discovery -->
+        <cacheManagerPeerProviderFactory
+            class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+            properties="peerDiscovery=manual,rmiUrls=//localhost:41001/org.jasig.cas.ticket.TicketCache" />
+        <cacheManagerPeerListenerFactory
+            class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
+            properties="port=41001,remoteObjectPort=41002" />
 </ehcache>
 ```
 
 ### Eviction Policy
 Ehcache manages the internal eviction policy of cached objects via `timeToIdle` and `timeToLive` settings.
-The default CAS ticket registry cleaner is then not needed, but could be used to enable
-[CAS single logout functionality](Logout-Single-Logout.html), if required.
-
-There have been reports of cache eviction problems when tickets are expired, but haven't been
-removed from the cache due to ehache configuration. This can be a problem because old ticket
-references "hang around" in the cache despite being expired. In other words,
-Ehcache does [inline eviction](http://lists.terracotta.org/pipermail/ehcache-list/2011-November/000423.html)
-where expired objects in the cache object won't be collected from memory until the cache max size is reached
-or the expired entry is explicitly accessed. To reclaim memory on expired tickets, cache eviction
-policies are must be carefully configured to avoid memory creep. Disk offload and/or a more
-aggressive eviction could provide a suitable workaround.
+These settings control the general policy of the cache that is used to store various ticket types. In general,
+you need to ensure the cache is alive long enough to support the individual expiration policy of tickets, and let
+CAS clean the tickets as part of its own cleaner. 
 
 
 ### Troubleshooting Guidelines

--- a/cas-server-documentation/installation/Ignite-Ticket-Registry.md
+++ b/cas-server-documentation/installation/Ignite-Ticket-Registry.md
@@ -18,12 +18,7 @@ This registry stores tickets in an [Ignite](http://ignite.apache.org/) instance.
 
 
 ## Distributed Cache
-Distributed caches are recommended for HA architectures since they offer fault tolerance in the ticket storage subsystem. The registry
-maintains service tickets and ticket-granting tickets in two separate caches, so that:
-
-* Ticket Granting Tickets remain valid for a long time, replicated asynchronously
-* Service Tickets are short lived and must be replicated right away because the requests
-  to validate them may very likely arrive at different CAS cluster nodes
+Distributed caches are recommended for HA architectures since they offer fault tolerance in the ticket storage subsystem. 
 
 Enable the registry via:
 
@@ -60,23 +55,15 @@ Additional TLS context configuration if performed by setting the following prope
 
 #### Configuration
 ```properties
-# ignite.servicesCache.name=serviceTicketsCache
-# ignite.servicesCache.cacheMode=REPLICATED
-# ignite.servicesCache.atomicityMode=TRANSACTIONAL
-# ignite.servicesCache.writeSynchronizationMode=FULL_SYNC
 # ignite.ticketsCache.name=ticketGrantingTicketsCache
 # ignite.ticketsCache.cacheMode=REPLICATED
 # ignite.ticketsCache.atomicityMode=TRANSACTIONAL
 # ignite.ticketsCache.writeSynchronizationMode=FULL_SYNC
+# ignite.ticketsCache.timeout=7200
 
 # Comma delimited list of addresses for distributed caches.
 # ignite.adresses=localhost:47500
 ```
-
-### Eviction Policy
-Ignite manages the internal eviction policy of cached objects via `timeToIdle` and `timeToLive` settings.
-The default CAS ticket registry cleaner is then not needed, but could be used to enable
-[CAS single logout functionality](Logout-Single-Logout.html), if required.
 
 ### Troubleshooting Guidelines
 

--- a/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/TicketRegistryDecorator.java
+++ b/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/TicketRegistryDecorator.java
@@ -67,7 +67,7 @@ public final class TicketRegistryDecorator extends AbstractTicketRegistry {
     }
 
     @Override
-    public int sessionCount() {
+    public long sessionCount() {
         if (this.ticketRegistry instanceof TicketRegistryState) {
             return ((TicketRegistryState) this.ticketRegistry).sessionCount();
         }
@@ -77,7 +77,7 @@ public final class TicketRegistryDecorator extends AbstractTicketRegistry {
     }
 
     @Override
-    public int serviceTicketCount() {
+    public long serviceTicketCount() {
         if (this.ticketRegistry instanceof TicketRegistryState) {
             return ((TicketRegistryState) this.ticketRegistry).serviceTicketCount();
         }

--- a/cas-server-extension-clearpass/src/test/java/org/jasig/cas/extension/clearpass/TicketRegistryDecoratorTests.java
+++ b/cas-server-extension-clearpass/src/test/java/org/jasig/cas/extension/clearpass/TicketRegistryDecoratorTests.java
@@ -33,15 +33,13 @@ public class TicketRegistryDecoratorTests {
     @Test
     public void verifyEhCacheTicketRegistryWithClearPass() {
         final Cache serviceTicketsCache = new Cache("serviceTicketsCache", 200, false, false, 100, 100);
-        final Cache ticketGrantingTicketCache = new Cache("ticketGrantingTicketCache", 200, false, false, 100, 100);
 
         final CacheManager manager = new CacheManager(this.getClass().getClassLoader().getResourceAsStream("ehcacheClearPass.xml"));
         manager.addCache(serviceTicketsCache);
-        manager.addCache(ticketGrantingTicketCache);
 
         final Map<String, String> map = new HashMap<>();
 
-        final TicketRegistry ticketRegistry = new EhCacheTicketRegistry(serviceTicketsCache, ticketGrantingTicketCache);
+        final TicketRegistry ticketRegistry = new EhCacheTicketRegistry(serviceTicketsCache);
         final TicketRegistryDecorator decorator = new TicketRegistryDecorator(ticketRegistry, map);
         assertNotNull(decorator);
 

--- a/cas-server-integration-ehcache-monitor/src/main/java/org/jasig/cas/monitor/EhCacheMonitor.java
+++ b/cas-server-integration-ehcache-monitor/src/main/java/org/jasig/cas/monitor/EhCacheMonitor.java
@@ -12,7 +12,6 @@ import java.util.List;
 /**
  * Monitors a {@link Cache} instance.
  * The accuracy of statistics is governed by the value of {@link Cache#getStatistics()}.
- * <p>
  * <p>NOTE: computation of highly accurate statistics is expensive.</p>
  *
  * @author Marvin S. Addison
@@ -42,8 +41,7 @@ public class EhCacheMonitor extends AbstractCacheMonitor {
      */
     public EhCacheMonitor() {
     }
-
-
+    
     /**
      * Instantiates a new Eh cache monitor.
      *

--- a/cas-server-integration-ehcache/src/main/java/org/jasig/cas/config/EhcacheTicketRegistryConfiguration.java
+++ b/cas-server-integration-ehcache/src/main/java/org/jasig/cas/config/EhcacheTicketRegistryConfiguration.java
@@ -143,7 +143,7 @@ public class EhcacheTicketRegistryConfiguration {
     @Value("${ehcache.timeIdle:0}")
     private int cacheTimeToIdle;
 
-    @Value("${ehcache.timeAlive:" + Integer.MAX_VALUE + "}")
+    @Value("${ehcache.timeAlive:" + Integer.MAX_VALUE + '}')
     private int cacheTimeToLive;
 
     /**

--- a/cas-server-integration-ehcache/src/main/java/org/jasig/cas/config/EhcacheTicketRegistryConfiguration.java
+++ b/cas-server-integration-ehcache/src/main/java/org/jasig/cas/config/EhcacheTicketRegistryConfiguration.java
@@ -2,7 +2,6 @@ package org.jasig.cas.config;
 
 import com.google.common.collect.ImmutableSet;
 import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.distribution.RMIAsynchronousCacheReplicator;
 import net.sf.ehcache.distribution.RMIBootstrapCacheLoader;
 import net.sf.ehcache.distribution.RMISynchronousCacheReplicator;
 import org.springframework.beans.factory.annotation.Value;
@@ -96,39 +95,9 @@ public class EhcacheTicketRegistryConfiguration {
     /**
      * The Service tickets cache name.
      */
-    @Value("${ehcache.cache.st.name:org.jasig.cas.ticket.ServiceTicket}")
-    private String serviceTicketsCacheName;
-
-    /**
-     * The Service tickets cache time to idle.
-     */
-    @Value("${ehcache.cache.st.timeIdle:0}")
-    private int serviceTicketsCacheTimeToIdle;
-
-    /**
-     * The Service tickets cache time to live.
-     */
-    @Value("${ehcache.cache.st.timeAlive:300}")
-    private int serviceTicketsCacheTimeToLive;
-
-    /**
-     * The Ticket granting tickets cache time to live.
-     */
-    @Value("${ehcache.cache.tgt.timeAlive:0}")
-    private int ticketGrantingTicketsCacheTimeToLive;
-
-    /**
-     * The Ticket granting tickets cache time to idle.
-     */
-    @Value("${ehcache.cache.tgt.timeIdle:7201}")
-    private int ticketGrantingTicketsCacheTimeToIdle;
-
-    /**
-     * The Ticket granting tickets cache name.
-     */
-    @Value("${ehcache.cache.tgt.name:org.jasig.cas.ticket.TicketGrantingTicket}")
-    private String ticketGrantingTicketsCacheName;
-
+    @Value("${ehcache.cache.name:org.jasig.cas.ticket.TicketCache}")
+    private String cacheName;
+    
     /**
      * The Disk expiry thread interval seconds.
      */
@@ -171,18 +140,11 @@ public class EhcacheTicketRegistryConfiguration {
     @Value("${ehcache.overflow.disk:false}")
     private boolean overflowToDisk;
 
+    @Value("${ehcache.timeIdle:0}")
+    private int cacheTimeToIdle;
 
-    /**
-     * Ticket rmi asynchronous cache replicator rmi asynchronous cache replicator.
-     *
-     * @return the rmi asynchronous cache replicator
-     */
-    @Bean(name = "ticketRMIAsynchronousCacheReplicator")
-    public RMIAsynchronousCacheReplicator ticketRMIAsynchronousCacheReplicator() {
-        return new RMIAsynchronousCacheReplicator(this.replicatePuts, this.replicatePutsViaCopy,
-                this.replicateUpdates, this.replicateUpdatesViaCopy, this.replicateRemovals,
-                this.replicationInterval, this.maximumBatchSize);
-    }
+    @Value("${ehcache.timeAlive:" + Integer.MAX_VALUE + "}")
+    private int cacheTimeToLive;
 
     /**
      * Ticket rmi synchronous cache replicator rmi synchronous cache replicator.
@@ -227,13 +189,13 @@ public class EhcacheTicketRegistryConfiguration {
      * @param manager the manager
      * @return the eh cache factory bean
      */
-    @Bean(name = "serviceTicketsCache")
-    public EhCacheFactoryBean serviceTicketsCache(final CacheManager manager) {
+    @Bean(name = "ehcacheTicketsCache")
+    public EhCacheFactoryBean ehcacheTicketsCache(final CacheManager manager) {
         final EhCacheFactoryBean bean = new EhCacheFactoryBean();
-        bean.setCacheName(this.serviceTicketsCacheName);
+        bean.setCacheName(this.cacheName);
         bean.setCacheEventListeners(ImmutableSet.of(ticketRMISynchronousCacheReplicator()));
-        bean.setTimeToIdle(this.serviceTicketsCacheTimeToIdle);
-        bean.setTimeToLive(this.serviceTicketsCacheTimeToLive);
+        bean.setTimeToIdle(this.cacheTimeToIdle);
+        bean.setTimeToLive(this.cacheTimeToLive);
 
         bean.setCacheManager(manager);
         bean.setBootstrapCacheLoader(ticketCacheBootstrapCacheLoader());
@@ -248,34 +210,6 @@ public class EhcacheTicketRegistryConfiguration {
         
         return bean;
     }
-
-
-    /**
-     * Ticket granting tickets cache eh cache factory bean.
-     *
-     * @param manager the manager
-     * @return the eh cache factory bean
-     */
-    @Bean(name = "ticketGrantingTicketsCache")
-    public EhCacheFactoryBean ticketGrantingTicketsCache(final CacheManager manager) {
-        final EhCacheFactoryBean bean = new EhCacheFactoryBean();
-        bean.setCacheName(this.ticketGrantingTicketsCacheName);
-        bean.setCacheEventListeners(ImmutableSet.of(ticketRMIAsynchronousCacheReplicator()));
-        bean.setTimeToIdle(this.ticketGrantingTicketsCacheTimeToIdle);
-        bean.setTimeToLive(this.ticketGrantingTicketsCacheTimeToLive);
-
-        bean.setCacheManager(manager);
-        bean.setBootstrapCacheLoader(ticketCacheBootstrapCacheLoader());
-
-        bean.setDiskExpiryThreadIntervalSeconds(this.diskExpiryThreadIntervalSeconds);
-        bean.setDiskPersistent(this.diskPersistent);
-        bean.setEternal(this.eternal);
-        bean.setMaxElementsInMemory(this.maxElementsInMemory);
-        bean.setMaxElementsOnDisk(this.maxElementsOnDisk);
-        bean.setMemoryStoreEvictionPolicy(this.memoryStoreEvictionPolicy);
-        bean.setOverflowToDisk(this.overflowToDisk);
-        
-        return bean;
-    }
+    
 
 }

--- a/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
+++ b/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
@@ -69,8 +69,12 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry {
     public void addTicket(final Ticket ticketToAdd) {
         final Ticket ticket = encodeTicket(ticketToAdd);
         final Element element = new Element(ticket.getId(), ticket);
-        element.setTimeToIdle(ticketToAdd.getExpirationPolicy().getTimeToIdle().intValue());
-        element.setTimeToLive(ticketToAdd.getExpirationPolicy().getTimeToIdle().intValue());
+        
+        final int idleValue = ticketToAdd.getExpirationPolicy().getTimeToIdle().intValue();
+        element.setTimeToIdle(idleValue);
+        
+        final int aliveValue = ticketToAdd.getExpirationPolicy().getTimeToIdle().intValue();
+        element.setTimeToLive(aliveValue);
 
         logger.debug("Adding ticket {} to the cache {}", ticket.getId(), this.ehcacheTicketsCache.getName());
         this.ehcacheTicketsCache.put(element);
@@ -128,9 +132,6 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public Collection<Ticket> getTickets() {
-        this.ehcacheTicketsCache.evictExpiredElements();
-        this.ehcacheTicketsCache.flush();
-        
         final Collection<Element> cacheTickets = this.ehcacheTicketsCache.getAll(
                 this.ehcacheTicketsCache.getKeysWithExpiryCheck()).values();
         final Collection<Ticket> allTickets = new HashSet<>(cacheTickets.size());

--- a/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
+++ b/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
@@ -1,20 +1,18 @@
 package org.jasig.cas.ticket.registry;
 
-import org.jasig.cas.ticket.ServiceTicket;
-import org.jasig.cas.ticket.Ticket;
-import org.jasig.cas.ticket.TicketGrantingTicket;
-
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
 import net.sf.ehcache.config.CacheConfiguration;
-import org.apache.commons.lang3.BooleanUtils;
-import org.springframework.beans.BeanInstantiationException;
-import org.springframework.beans.factory.InitializingBean;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.jasig.cas.ticket.ServiceTicket;
+import org.jasig.cas.ticket.Ticket;
+import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.style.ToStringCreator;
 import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
 
+import javax.annotation.PostConstruct;
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -23,28 +21,17 @@ import java.util.HashSet;
  * <a href="http://ehcache.org/">Ehcache</a> based distributed ticket registry.
  * </p>
  *
- * <p>
- * Use distinct caches for ticket granting tickets (TGT) and service tickets (ST) for:
- * <ul>
- *   <li>Tuning : use cache level time to live with different values for TGT an ST.</li>
- *   <li>Monitoring : follow separately the number of TGT and ST.</li>
- * </ul>
- *
  * @author <a href="mailto:cleclerc@xebia.fr">Cyrille Le Clerc</a>
  * @author Adam Rybicki
  * @author Andrew Tillinghast
  * @since 3.5
  */
 @Component("ehcacheTicketRegistry")
-public final class EhCacheTicketRegistry extends AbstractTicketRegistry implements InitializingBean {
+public final class EhCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Autowired
-    @Qualifier("serviceTicketsCache")
-    private Cache serviceTicketsCache;
-
-    @Autowired
-    @Qualifier("ticketGrantingTicketsCache")
-    private Cache ticketGrantingTicketsCache;
+    @Qualifier("ehcacheTicketsCache")
+    private Cache ehcacheTicketsCache;
 
     /**
      * @see #setSupportRegistryState(boolean)
@@ -60,24 +47,21 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry implemen
     /**
      * Instantiates a new EhCache ticket registry.
      *
-     * @param serviceTicketsCache the service tickets cache
-     * @param ticketGrantingTicketsCache the ticket granting tickets cache
+     * @param ticketCache the ticket cache
      */
-    public EhCacheTicketRegistry(final Cache serviceTicketsCache, final Cache ticketGrantingTicketsCache) {
-        setServiceTicketsCache(serviceTicketsCache);
-        setTicketGrantingTicketsCache(ticketGrantingTicketsCache);
+    public EhCacheTicketRegistry(final Cache ticketCache) {
+        setEhcacheTicketsCache(ticketCache);
     }
 
     /**
      * Instantiates a new EhCache ticket registry.
      *
-     * @param serviceTicketsCache the service tickets cache
-     * @param ticketGrantingTicketsCache the ticket granting tickets cache
+     * @param ticketCache          the ticket cache
      * @param supportRegistryState the support registry state
      */
-    public EhCacheTicketRegistry(final Cache serviceTicketsCache, final Cache ticketGrantingTicketsCache,
+    public EhCacheTicketRegistry(final Cache ticketCache,
             final boolean supportRegistryState) {
-        this(serviceTicketsCache, ticketGrantingTicketsCache);
+        this(ticketCache);
         setSupportRegistryState(supportRegistryState);
     }
 
@@ -85,16 +69,9 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry implemen
     public void addTicket(final Ticket ticketToAdd) {
         final Ticket ticket = encodeTicket(ticketToAdd);
         final Element element = new Element(ticket.getId(), ticket);
-        if (ticket instanceof ServiceTicket) {
-            logger.debug("Adding service ticket {} to the cache {}", ticket.getId(), this.serviceTicketsCache.getName());
-            this.serviceTicketsCache.put(element);
-        } else if (ticket instanceof TicketGrantingTicket) {
-            logger.debug("Adding ticket granting ticket {} to the cache {}", ticket.getId(),
-                    this.ticketGrantingTicketsCache.getName());
-            this.ticketGrantingTicketsCache.put(element);
-        } else {
-            throw new IllegalArgumentException("Invalid ticket type " + ticket);
-        }
+
+        logger.debug("Adding ticket {} to the cache {}", ticket.getId(), this.ehcacheTicketsCache.getName());
+        this.ehcacheTicketsCache.put(element);
     }
 
     /**
@@ -112,14 +89,8 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry implemen
             return true;
         }
 
-        if (ticket instanceof ServiceTicket) {
-            if (this.serviceTicketsCache.remove(ticket.getId())) {
-                logger.debug("Service ticket {} is removed", ticket.getId());
-            }
-        } else {
-            if (this.ticketGrantingTicketsCache.remove(ticket.getId())) {
-                logger.debug("Ticket-granting ticket {} is removed", ticket.getId());
-            }
+        if (this.ehcacheTicketsCache.remove(ticket.getId())) {
+            logger.debug("Ticket {} is removed", ticket.getId());
         }
         return true;
     }
@@ -131,10 +102,7 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry implemen
             return null;
         }
 
-        Element element = this.serviceTicketsCache.get(ticketId);
-        if (element == null) {
-            element = this.ticketGrantingTicketsCache.get(ticketId);
-        }
+        final Element element = this.ehcacheTicketsCache.get(ticketId);
         if (element == null) {
             logger.debug("No ticket by id [{}] is found in the registry", ticketId);
             return null;
@@ -147,33 +115,13 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry implemen
 
     @Override
     public Collection<Ticket> getTickets() {
-        final Collection<Element> serviceTickets = this.serviceTicketsCache.getAll(
-                this.serviceTicketsCache.getKeysWithExpiryCheck()).values();
-        final Collection<Element> tgtTicketsTickets = this.ticketGrantingTicketsCache.getAll(
-                this.ticketGrantingTicketsCache.getKeysWithExpiryCheck()).values();
-
-        final Collection<Ticket> allTickets = new HashSet<>(serviceTickets.size() + tgtTicketsTickets.size());
-
-        serviceTickets.stream().forEach(ticket -> allTickets.add(getProxiedTicketInstance((Ticket) ticket.getObjectValue())));
-
-        tgtTicketsTickets.stream().forEach(ticket -> allTickets.add(getProxiedTicketInstance((Ticket) ticket.getObjectValue())));
-
+        final Collection<Element> cacheTickets = this.ehcacheTicketsCache.getAll(
+                this.ehcacheTicketsCache.getKeysWithExpiryCheck()).values();
+        final Collection<Ticket> allTickets = new HashSet<>(cacheTickets.size());
+        cacheTickets.stream().forEach(ticket -> allTickets.add(getProxiedTicketInstance((Ticket) ticket.getObjectValue())));
         return decodeTickets(allTickets);
     }
 
-    public void setServiceTicketsCache(final Cache serviceTicketsCache) {
-        this.serviceTicketsCache = serviceTicketsCache;
-    }
-
-    public void setTicketGrantingTicketsCache(final Cache ticketGrantingTicketsCache) {
-        this.ticketGrantingTicketsCache = ticketGrantingTicketsCache;
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringCreator(this).append("ticketGrantingTicketsCache", this.ticketGrantingTicketsCache)
-                .append("serviceTicketsCache", this.serviceTicketsCache).toString();
-    }
 
     @Override
     protected void updateTicket(final Ticket ticket) {
@@ -204,45 +152,47 @@ public final class EhCacheTicketRegistry extends AbstractTicketRegistry implemen
         this.supportRegistryState = supportRegistryState;
     }
 
-    @Override
-    public void afterPropertiesSet() throws Exception {
+
+    /**
+     * Init.
+     */
+    @PostConstruct
+    public void init() {
         logger.info("Setting up Ehcache Ticket Registry...");
 
-        if (this.serviceTicketsCache == null || this.ticketGrantingTicketsCache == null) {
-            throw new BeanInstantiationException(this.getClass(),
-                    "Both serviceTicketsCache and ticketGrantingTicketsCache are required properties.");
-        }
-
+        Assert.notNull(this.ehcacheTicketsCache, "Ehcache Tickets cache cannot nbe null");
+        
         if (logger.isDebugEnabled()) {
-            CacheConfiguration config = this.serviceTicketsCache.getCacheConfiguration();
-            logger.debug("serviceTicketsCache.maxElementsInMemory={}", config.getMaxEntriesLocalHeap());
-            logger.debug("serviceTicketsCache.maxElementsOnDisk={}", config.getMaxElementsOnDisk());
-            logger.debug("serviceTicketsCache.isOverflowToDisk={}", config.isOverflowToDisk());
-            logger.debug("serviceTicketsCache.timeToLive={}", config.getTimeToLiveSeconds());
-            logger.debug("serviceTicketsCache.timeToIdle={}", config.getTimeToIdleSeconds());
-            logger.debug("serviceTicketsCache.cacheManager={}", this.serviceTicketsCache.getCacheManager().getName());
-
-            config = this.ticketGrantingTicketsCache.getCacheConfiguration();
-            logger.debug("ticketGrantingTicketsCache.maxElementsInMemory={}", config.getMaxEntriesLocalHeap());
-            logger.debug("ticketGrantingTicketsCache.maxElementsOnDisk={}", config.getMaxElementsOnDisk());
-            logger.debug("ticketGrantingTicketsCache.isOverflowToDisk={}", config.isOverflowToDisk());
-            logger.debug("ticketGrantingTicketsCache.timeToLive={}", config.getTimeToLiveSeconds());
-            logger.debug("ticketGrantingTicketsCache.timeToIdle={}", config.getTimeToIdleSeconds());
-            logger.debug("ticketGrantingTicketsCache.cacheManager={}", this.ticketGrantingTicketsCache.getCacheManager()
-                    .getName());
+            final CacheConfiguration config = this.ehcacheTicketsCache.getCacheConfiguration();
+            logger.debug("TicketCache.maxElementsInMemory={}", config.getMaxEntriesLocalHeap());
+            logger.debug("TicketCache.maxElementsOnDisk={}", config.getMaxElementsOnDisk());
+            logger.debug("TicketCache.isOverflowToDisk={}", config.isOverflowToDisk());
+            logger.debug("TicketCache.timeToLive={}", config.getTimeToLiveSeconds());
+            logger.debug("TicketCache.timeToIdle={}", config.getTimeToIdleSeconds());
+            logger.debug("TicketCache.cacheManager={}", this.ehcacheTicketsCache.getCacheManager().getName());
         }
     }
 
-
-    @Override
-    public int sessionCount() {
-        return BooleanUtils.toInteger(this.supportRegistryState, this.ticketGrantingTicketsCache
-                .getKeysWithExpiryCheck().size(), super.sessionCount());
+    public void setEhcacheTicketsCache(final Cache ehcacheTicketsCache) {
+        this.ehcacheTicketsCache = ehcacheTicketsCache;
     }
 
     @Override
-    public int serviceTicketCount() {
-        return BooleanUtils.toInteger(this.supportRegistryState, this.serviceTicketsCache.getKeysWithExpiryCheck()
-                .size(), super.serviceTicketCount());
+    public long sessionCount() {
+        return getTickets().stream().filter(t -> t instanceof TicketGrantingTicket).count();
+    }
+
+    @Override
+    public long serviceTicketCount() {
+        return getTickets().stream().filter(t -> t instanceof ServiceTicket).count();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .appendSuper(super.toString())
+                .append("ehcacheTicketsCache", ehcacheTicketsCache)
+                .append("supportRegistryState", supportRegistryState)
+                .toString();
     }
 }

--- a/cas-server-integration-ehcache/src/test/resources/ehcache-replicated.xml
+++ b/cas-server-integration-ehcache/src/test/resources/ehcache-replicated.xml
@@ -15,7 +15,7 @@
         <!-- Manual Peer Discovery -->
         <cacheManagerPeerProviderFactory
             class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
-            properties="peerDiscovery=manual,rmiUrls=//localhost:41001/org.jasig.cas.ticket.ServiceTicket|//localhost:41001/org.jasig.cas.ticket.TicketGrantingTicket" />
+            properties="peerDiscovery=manual,rmiUrls=//localhost:41001/org.jasig.cas.ticket.TicketCache" />
         <cacheManagerPeerListenerFactory
             class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
             properties="port=41001,remoteObjectPort=41002" />

--- a/cas-server-integration-ehcache/src/test/resources/ticketRegistry.xml
+++ b/cas-server-integration-ehcache/src/test/resources/ticketRegistry.xml
@@ -7,132 +7,88 @@
                            http://www.springframework.org/schema/context
                            http://www.springframework.org/schema/context/spring-context.xsd
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
-  <description>
-    Configuration for the EhCache TicketRegistry which stores the tickets in a distributed EhCache and cleans
-    them out as specified intervals.
-  </description>
+    <description>
+        Configuration for the EhCache TicketRegistry which stores the tickets in a distributed EhCache and cleans
+        them out as specified intervals.
+    </description>
 
     <context:property-placeholder properties-ref="casProperties"/>
     <util:properties id="casProperties"/>
 
-    <context:component-scan base-package="org.jasig.cas" />
+    <context:component-scan base-package="org.jasig.cas"/>
     <context:annotation-config/>
 
-  <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
-    <property name="configLocation" value="classpath:ehcache-replicated.xml" />
-    <property name="shared" value="false" />
-    <property name="cacheManagerName" value="ticketRegistryCacheManager" />
-  </bean>
+    <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
+        <property name="configLocation" value="classpath:ehcache-replicated.xml"/>
+        <property name="shared" value="false"/>
+        <property name="cacheManagerName" value="ticketRegistryCacheManager"/>
+    </bean>
 
-  <bean id="ticketRegistry" class="org.jasig.cas.ticket.registry.EhCacheTicketRegistry"
-    p:serviceTicketsCache-ref="serviceTicketsCache" p:ticketGrantingTicketsCache-ref="ticketGrantingTicketsCache" />
+    <bean id="ticketRegistry" class="org.jasig.cas.ticket.registry.EhCacheTicketRegistry"
+          p:ehcacheTicketsCache-ref="ehcacheTicketsCache"/>
 
-  <bean id="abstractTicketCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
-    abstract="true">
-    <property name="cacheManager" ref="cacheManager" />
-    <property name="diskExpiryThreadIntervalSeconds" value="0" />
-    <property name="diskPersistent" value="false" />
-    <property name="eternal" value="false" />
-    <property name="maxElementsInMemory" value="10000" />
-    <property name="maxElementsOnDisk" value="0" />
-    <property name="memoryStoreEvictionPolicy" value="LRU" />
-    <property name="overflowToDisk" value="false" />
-    <property name="bootstrapCacheLoader">
-      <ref bean="ticketCacheBootstrapCacheLoader" />
-    </property>
-  </bean>
+    <bean id="abstractTicketCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
+          abstract="true">
+        <property name="cacheManager" ref="cacheManager"/>
+        <property name="diskExpiryThreadIntervalSeconds" value="0"/>
+        <property name="diskPersistent" value="false"/>
+        <property name="eternal" value="false"/>
+        <property name="maxElementsInMemory" value="10000"/>
+        <property name="maxElementsOnDisk" value="0"/>
+        <property name="memoryStoreEvictionPolicy" value="LRU"/>
+        <property name="overflowToDisk" value="false"/>
+        <property name="bootstrapCacheLoader">
+            <ref bean="ticketCacheBootstrapCacheLoader"/>
+        </property>
+    </bean>
 
-  <bean id="serviceTicketsCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
-    parent="abstractTicketCache">
-    <description>
-      Service Tickets (ST) and Proxy Tickets are only valid for short amount of time (default is 10 seconds),
-      and
-      most often are removed from the cache when the ST is validated. The ST cache must be replicated
-      quickly
-      since validation is expected within a few second after its creation. The CAS instance validating the
-      ST may
-      not be one that created the ST, since validation is a back-channel service-to-CAS call that is not
-      aware of
-      user session affinity. Synchronous mode is used to ensure all CAS nodes can validate the ST.
-    </description>
-    <property name="cacheName" value="org.jasig.cas.ticket.ServiceTicket" />
+    <bean id="ehcacheTicketsCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
+          parent="abstractTicketCache">
+        <property name="cacheName" value="org.jasig.cas.ticket.TicketCache"/>
 
-    <property name="cacheEventListeners">
-      <ref bean="ticketRMISynchronousCacheReplicator" />
-    </property>
+        <property name="cacheEventListeners">
+            <ref bean="ticketRMISynchronousCacheReplicator"/>
+        </property>
 
-    <!-- The maximum number of seconds an element can exist in the cache without being accessed. The
-      element expires at this limit and will no longer be returned from the cache. The default value is 0,
-      which means no TTI eviction takes place (infinite lifetime). -->
-    <property name="timeToIdle" value="0" />
+        <!-- The maximum number of seconds an element can exist in the cache without being accessed. The
+          element expires at this limit and will no longer be returned from the cache. The default value is 0,
+          which means no TTI eviction takes place (infinite lifetime). -->
+        <property name="timeToIdle" value="0"/>
 
-    <!-- The maximum number of seconds an element can exist in the cache regardless of use. The element
-      expires at this limit and will no longer be returned from the cache. The default value is 0, which means
-      no TTL eviction takes place (infinite lifetime). -->
-    <property name="timeToLive" value="300" />
-  </bean>
+        <!-- The maximum number of seconds an element can exist in the cache regardless of use. The element
+          expires at this limit and will no longer be returned from the cache. The default value is 0, which means
+          no TTL eviction takes place (infinite lifetime). -->
+        <property name="timeToLive" value="9000"/>
+    </bean>
 
-  <bean id="ticketGrantingTicketsCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean">
-    <description>
-      Ticket Granting Tickets (TGT) are valid for the lifetime of the SSO Session. They become invalid either
-      by expiration policy (default 2 hours idle, 8 hours max) or by explicit user sign off via
-      /cas/login.
-      The TGT cache can be replicated slowly because TGT are only manipulated via web user started
-      operations
-      (mostly grant service ticket) and thus benefit of web session affinity.
-    </description>
 
-    <property name="cacheName" value="org.jasig.cas.ticket.TicketGrantingTicket" />
+    <bean id="ticketRMISynchronousCacheReplicator" class="net.sf.ehcache.distribution.RMISynchronousCacheReplicator">
+        <constructor-arg name="replicatePuts" value="true"/>
+        <constructor-arg name="replicatePutsViaCopy" value="true"/>
+        <constructor-arg name="replicateUpdates" value="true"/>
+        <constructor-arg name="replicateUpdatesViaCopy" value="true"/>
+        <constructor-arg name="replicateRemovals" value="true"/>
+    </bean>
 
-    <property name="cacheEventListeners">
-      <ref bean="ticketRMIAsynchronousCacheReplicator" />
-    </property>
 
-    <!-- The maximum number of seconds an element can exist in the cache regardless of use. The element
-      expires at this limit and will no longer be returned from the cache. The default value is 0, which means
-      no TTL eviction takes place (infinite lifetime). For this sample configuration, 2 hours of inactivity
-      before ticket granting tickets are expired automatically -->
-
-    <property name="timeToIdle" value="7201" />
-
-    <!-- The maximum number of seconds an element can exist in the cache without being accessed. The
-      element expires at this limit and will no longer be returned from the cache. The default value is 0,
-      which means no TTI eviction takes place (infinite lifetime). -->
-    <property name="timeToLive" value="0" />
-  </bean>
-
-  <bean id="ticketRMISynchronousCacheReplicator" class="net.sf.ehcache.distribution.RMISynchronousCacheReplicator">
-    <constructor-arg name="replicatePuts" value="true" />
-    <constructor-arg name="replicatePutsViaCopy" value="true" />
-    <constructor-arg name="replicateUpdates" value="true" />
-    <constructor-arg name="replicateUpdatesViaCopy" value="true" />
-    <constructor-arg name="replicateRemovals" value="true" />
-  </bean>
-
-  <bean id="ticketRMIAsynchronousCacheReplicator" class="net.sf.ehcache.distribution.RMIAsynchronousCacheReplicator"
-    parent="ticketRMISynchronousCacheReplicator">
-    <constructor-arg name="replicationInterval" value="10000" />
-    <constructor-arg name="maximumBatchSize" value="100" />
-  </bean>
-
-  <bean id="ticketCacheBootstrapCacheLoader" class="net.sf.ehcache.distribution.RMIBootstrapCacheLoader">
-    <constructor-arg name="asynchronous" value="true" />
-    <constructor-arg name="maximumChunkSize" value="5000000" />
-  </bean>
+    <bean id="ticketCacheBootstrapCacheLoader" class="net.sf.ehcache.distribution.RMIBootstrapCacheLoader">
+        <constructor-arg name="asynchronous" value="true"/>
+        <constructor-arg name="maximumChunkSize" value="5000000"/>
+    </bean>
 
     <!-- CAS Context Core -->
-    <alias name="defaultPrincipalFactory" alias="principalFactory" />
-    <alias name="defaultPrincipalElectionStrategy" alias="principalElectionStrategy" />
-    <alias name="anyAuthenticationPolicy" alias="authenticationPolicy" />
-    <alias name="inMemoryServiceRegistryDao" alias="serviceRegistryDao" />
+    <alias name="defaultPrincipalFactory" alias="principalFactory"/>
+    <alias name="defaultPrincipalElectionStrategy" alias="principalElectionStrategy"/>
+    <alias name="anyAuthenticationPolicy" alias="authenticationPolicy"/>
+    <alias name="inMemoryServiceRegistryDao" alias="serviceRegistryDao"/>
     <util:map id="authenticationHandlersResolvers"/>
-    <util:list id="authenticationMetadataPopulators" />
-    <util:list id="monitorsList" />
+    <util:list id="authenticationMetadataPopulators"/>
+    <util:list id="monitorsList"/>
     <util:map id="uniqueIdGeneratorsMap"/>
-    <alias name="ticketGrantingTicketExpirationPolicy" alias="grantingTicketExpirationPolicy" />
+    <alias name="ticketGrantingTicketExpirationPolicy" alias="grantingTicketExpirationPolicy"/>
 
-    <util:list id="serviceFactoryList" />
-    <alias name="acceptAnyAuthenticationPolicyFactory" alias="authenticationPolicyFactory" />
+    <util:list id="serviceFactoryList"/>
+    <alias name="acceptAnyAuthenticationPolicyFactory" alias="authenticationPolicyFactory"/>
     <bean id="attributeRepository" class="org.jasig.services.persondir.support.NamedStubPersonAttributeDao"/>
 
 </beans>

--- a/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -53,8 +53,8 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements D
      */
     @PostConstruct
     public void init() {
-        logger.info("Setting up Hazelcast Ticket Registry...");
-        logger.debug("Hazelcast instance: {} with name {}", this.hz, this.registry.getName());
+        logger.info("Setting up Hazelcast Ticket Registry instance {} with name {}",
+                this.hz, this.registry.getName());
     }
 
     @Override
@@ -62,13 +62,11 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements D
         addTicket(ticket);
     }
 
-
     @Override
     protected boolean needsCallback() {
         return false;
     }
     
-
     @Override
     public void addTicket(final Ticket ticket) {
         logger.debug("Adding ticket [{}] with ttl [{}s]", ticket.getId(), ticket.getExpirationPolicy().getTimeToLive());
@@ -83,8 +81,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements D
         final Ticket ticket = decodeTicket(this.registry.get(encTicketId));
         return getProxiedTicketInstance(ticket);
     }
-
-
+    
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
         return this.registry.remove(ticketId) != null;

--- a/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -1,11 +1,8 @@
 package org.jasig.cas.ticket.registry;
 
-import org.jasig.cas.ticket.ServiceTicket;
-import org.jasig.cas.ticket.Ticket;
-import org.jasig.cas.ticket.TicketGrantingTicket;
-
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import org.jasig.cas.ticket.Ticket;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,34 +29,22 @@ import java.util.concurrent.TimeUnit;
 public class HazelcastTicketRegistry extends AbstractTicketRegistry implements DisposableBean {
 
     private final IMap<String, Ticket> registry;
-
-    private final long serviceTicketTimeoutInSeconds;
-
-    private final long ticketGrantingTicketTimeoutInSeconds;
-
+    
     private final HazelcastInstance hz;
 
 
     /**
      * @param hz                                  An instance of {@code HazelcastInstance}
      * @param mapName                             Name of map to use
-     * @param ticketGrantingTicketTimeoutInSeconds TTL for TGT entries
-     * @param serviceTicketTimeoutInSeconds       TTL for ST entries
      */
     @Autowired
     public HazelcastTicketRegistry(
         @Qualifier("hazelcast")
         final HazelcastInstance hz,
         @Value("${hz.mapname:tickets}")
-        final String mapName,
-        @Value("${tgt.maxTimeToLiveInSeconds:28800}")
-        final long ticketGrantingTicketTimeoutInSeconds,
-        @Value("${st.timeToKillInSeconds:10}")
-        final long serviceTicketTimeoutInSeconds) {
+        final String mapName) {
 
         this.registry = hz.getMap(mapName);
-        this.ticketGrantingTicketTimeoutInSeconds = ticketGrantingTicketTimeoutInSeconds;
-        this.serviceTicketTimeoutInSeconds = serviceTicketTimeoutInSeconds;
         this.hz = hz;
     }
 
@@ -70,8 +55,6 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements D
     public void init() {
         logger.info("Setting up Hazelcast Ticket Registry...");
         logger.debug("Hazelcast instance: {} with name {}", this.hz, this.registry.getName());
-        logger.debug("Ticket-granting ticket timeout: [{}s]", this.ticketGrantingTicketTimeoutInSeconds);
-        logger.debug("Service ticket timeout: [{}s]", this.serviceTicketTimeoutInSeconds);
     }
 
     @Override
@@ -84,24 +67,13 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements D
     protected boolean needsCallback() {
         return false;
     }
-
-
+    
 
     @Override
     public void addTicket(final Ticket ticket) {
-        addTicket(ticket, getTimeout(ticket));
-    }
-
-    /**
-     * Adds the ticket to the hazelcast instance.
-     *
-     * @param ticket a ticket
-     * @param ttl    time to live in seconds
-     */
-    private void addTicket(final Ticket ticket, final long ttl) {
-        logger.debug("Adding ticket [{}] with ttl [{}s]", ticket.getId(), ttl);
+        logger.debug("Adding ticket [{}] with ttl [{}s]", ticket.getId(), ticket.getExpirationPolicy().getTimeToLive());
         final Ticket encTicket = encodeTicket(ticket);
-        this.registry.set(encTicket.getId(), encTicket, ttl, TimeUnit.SECONDS);
+        this.registry.set(encTicket.getId(), encTicket, ticket.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS);
     }
 
 
@@ -122,25 +94,6 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements D
     @Override
     public Collection<Ticket> getTickets() {
         return decodeTickets(this.registry.values());
-    }
-
-    /**
-     * A method to get the starting TTL for a ticket based upon type.
-     *
-     * @param t Ticket to get starting TTL for
-     * @return Initial TTL for ticket
-     */
-    private long getTimeout(final Ticket t) {
-        if (t instanceof TicketGrantingTicket) {
-            return this.ticketGrantingTicketTimeoutInSeconds;
-        }
-        if (t instanceof ServiceTicket) {
-            return this.serviceTicketTimeoutInSeconds;
-        }
-
-        throw new IllegalArgumentException(
-            String.format("Invalid ticket type [%s]. Expecting either [TicketGrantingTicket] or [ServiceTicket]",
-                t.getClass().getName()));
     }
 
     /**

--- a/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -196,6 +196,11 @@ public class HazelcastTicketRegistryTests {
         public int getCountOfUses() {
             return 0;
         }
+
+        @Override
+        public ExpirationPolicy getExpirationPolicy() {
+            return new NeverExpiresExpirationPolicy();
+        }
     }
 
     private static class MockSt implements ServiceTicket {
@@ -246,6 +251,11 @@ public class HazelcastTicketRegistryTests {
         @Override
         public int getCountOfUses() {
             return 0;
+        }
+
+        @Override
+        public ExpirationPolicy getExpirationPolicy() {
+            return new NeverExpiresExpirationPolicy();
         }
     }
 }

--- a/cas-server-integration-hazelcast/src/test/resources/HazelcastTicketRegistryTests-context.xml
+++ b/cas-server-integration-hazelcast/src/test/resources/HazelcastTicketRegistryTests-context.xml
@@ -110,16 +110,12 @@
           class="org.jasig.cas.ticket.registry.HazelcastTicketRegistry">
         <constructor-arg name="hz" ref="hzInstance1"/>
         <constructor-arg name="mapName" value="tickets"/>
-        <constructor-arg name="ticketGrantingTicketTimeoutInSeconds" value="10"/>
-        <constructor-arg name="serviceTicketTimeoutInSeconds" value="10"/>
     </bean>
 
     <bean id="hzTicketRegistry2"
           class="org.jasig.cas.ticket.registry.HazelcastTicketRegistry">
         <constructor-arg name="hz" ref="hzInstance2"/>
         <constructor-arg name="mapName" value="tickets"/>
-        <constructor-arg name="ticketGrantingTicketTimeoutInSeconds" value="10"/>
-        <constructor-arg name="serviceTicketTimeoutInSeconds" value="10"/>
     </bean>
 
 </beans>

--- a/cas-server-integration-ignite/src/main/java/org/jasig/cas/config/IgniteTicketRegistryConfiguration.java
+++ b/cas-server-integration-ignite/src/main/java/org/jasig/cas/config/IgniteTicketRegistryConfiguration.java
@@ -12,8 +12,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is {@link IgniteTicketRegistryConfiguration}.
@@ -23,61 +26,40 @@ import java.util.List;
  */
 @Configuration("igniteConfiguration")
 public class IgniteTicketRegistryConfiguration {
-
+    
     /**
      * The Ignite addresses.
      */
     @Value("${ignite.adresses:localhost:47500}")
     private String igniteAddresses;
-
+    
     /**
-     * The St cache name.
+     * The cache name.
      */
-    @Value("${ignite.servicesCache.name:serviceTicketsCache}")
-    private String stCacheName;
+    @Value("${ignite.ticketsCache.name:TicketsCache}")
+    private String cacheName;
 
     /**
-     * The St cache mode.
-     */
-    @Value("${ignite.servicesCache.cacheMode:REPLICATED}")
-    private CacheMode stCacheMode;
-
-    /**
-     * The St atomicity mode.
-     */
-    @Value("${ignite.servicesCache.atomicityMode:TRANSACTIONAL}}")
-    private CacheAtomicityMode stAtomicityMode;
-
-    /**
-     * The St write synchronization mode.
-     */
-    @Value("${ignite.servicesCache.writeSynchronizationMode:FULL_SYNC}")
-    private CacheWriteSynchronizationMode stWriteSynchronizationMode;
-
-    /**
-     * The Tgt cache name.
-     */
-    @Value("${ignite.ticketsCache.name:serviceTicketsCache}")
-    private String tgtCacheName;
-
-    /**
-     * The Tgt cache mode.
+     * The cache mode.
      */
     @Value("${ignite.ticketsCache.cacheMode:REPLICATED}")
-    private CacheMode tgtCacheMode;
+    private CacheMode cacheMode;
 
     /**
-     * The Tgt atomicity mode.
+     * The atomicity mode.
      */
     @Value("${ignite.ticketsCache.atomicityMode:TRANSACTIONAL}}")
-    private CacheAtomicityMode tgtAtomicityMode;
+    private CacheAtomicityMode atomicityMode;
 
     /**
-     * The Tgt write synchronization mode.
+     * The write synchronization mode.
      */
     @Value("${ignite.ticketsCache.writeSynchronizationMode:FULL_SYNC}")
-    private CacheWriteSynchronizationMode tgtWriteSynchronizationMode;
-
+    private CacheWriteSynchronizationMode writeSynchronizationMode;
+    
+    @Value("${ignite.ticketsCache.timeout:" + Integer.MAX_VALUE + "}")
+    private long timeout;
+    
     /**
      * Ignite configuration ignite configuration.
      *
@@ -93,19 +75,14 @@ public class IgniteTicketRegistryConfiguration {
         config.setDiscoverySpi(spi);
 
         final List<CacheConfiguration> configurations = new ArrayList<>();
-        final CacheConfiguration servicesCache = new CacheConfiguration();
-        servicesCache.setName(this.stCacheName);
-        servicesCache.setCacheMode(this.stCacheMode);
-        servicesCache.setAtomicityMode(this.stAtomicityMode);
-        servicesCache.setWriteSynchronizationMode(this.stWriteSynchronizationMode);
 
         final CacheConfiguration ticketsCache = new CacheConfiguration();
-        ticketsCache.setName(this.tgtCacheName);
-        ticketsCache.setCacheMode(this.tgtCacheMode);
-        ticketsCache.setAtomicityMode(this.tgtAtomicityMode);
-        ticketsCache.setWriteSynchronizationMode(this.tgtWriteSynchronizationMode);
+        ticketsCache.setName(this.cacheName);
+        ticketsCache.setCacheMode(this.cacheMode);
+        ticketsCache.setAtomicityMode(this.atomicityMode);
+        ticketsCache.setWriteSynchronizationMode(this.writeSynchronizationMode);
+        ticketsCache.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, this.timeout)));
 
-        configurations.add(servicesCache);
         configurations.add(ticketsCache);
 
         config.setCacheConfiguration(configurations.toArray(new CacheConfiguration[]{}));

--- a/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
+++ b/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
@@ -289,13 +289,13 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public int sessionCount() {
+    public long sessionCount() {
         return BooleanUtils.toInteger(this.supportRegistryState, this.ticketGrantingTicketsCache
             .size(CachePeekMode.ALL), (int) super.sessionCount());
     }
 
     @Override
-    public int serviceTicketCount() {
+    public long serviceTicketCount() {
         return BooleanUtils.toInteger(this.supportRegistryState, this.serviceTicketsCache
             .size(CachePeekMode.ALL), (int) super.serviceTicketCount());
     }

--- a/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
+++ b/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
@@ -1,23 +1,19 @@
 package org.jasig.cas.ticket.registry;
 
-import org.jasig.cas.ticket.ServiceTicket;
-import org.jasig.cas.ticket.Ticket;
-import org.jasig.cas.ticket.TicketGrantingTicket;
-
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteState;
 import org.apache.ignite.Ignition;
-import org.apache.ignite.cache.CachePeekMode;
 import org.apache.ignite.cache.query.QueryCursor;
 import org.apache.ignite.cache.query.ScanQuery;
-import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.lang.IgniteBiPredicate;
 import org.apache.ignite.ssl.SslContextFactory;
+import org.jasig.cas.ticket.ServiceTicket;
+import org.jasig.cas.ticket.Ticket;
+import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,12 +22,9 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.cache.Cache;
-import javax.cache.expiry.CreatedExpiryPolicy;
-import javax.cache.expiry.Duration;
 import javax.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.concurrent.TimeUnit;
 
 /**
  * <p>
@@ -54,12 +47,8 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
 
     @Autowired
     @NotNull
-    @Value("${ignite.ticketsCache.name:serviceTicketsCache}")
-    private String servicesCacheName;
-
-    @NotNull
-    @Value("${ignite.ticketsCache.name:ticketGrantingTicketsCache}")
-    private String ticketsCacheName;
+    @Value("${ignite.ticketsCache.name:TicketsCache}")
+    private String cacheName;
 
     @Value("${ignite.keyStoreType:}")
     private String keyStoreType;
@@ -90,15 +79,8 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
     @Qualifier("igniteConfiguration")
     private IgniteConfiguration igniteConfiguration;
 
-    private IgniteCache<String, ServiceTicket> serviceTicketsCache;
-    private IgniteCache<String, TicketGrantingTicket> ticketGrantingTicketsCache;
-
-    @Value("${tgt.maxTimeToLiveInSeconds:28800}")
-    private long ticketGrantingTicketTimeoutInSeconds = 28800;
-
-    @Value("${st.timeToKillInSeconds:10}")
-    private long serviceTicketTimeoutInSeconds = 10;
-
+    private IgniteCache<String, Ticket> ticketIgniteCache;
+    
     private Ignite ignite;
 
     /**
@@ -115,25 +97,18 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
     @Override
     public void addTicket(final Ticket ticketToAdd) {
         final Ticket ticket = encodeTicket(ticketToAdd);
-        if (ticket instanceof ServiceTicket) {
-            logger.debug("Adding service ticket {} to the cache {}", ticket.getId(), this.serviceTicketsCache.getName());
-            this.serviceTicketsCache.put(ticket.getId(), (ServiceTicket) ticket);
-        } else if (ticket instanceof TicketGrantingTicket) {
-            logger.debug("Adding ticket granting ticket {} to the cache {}", ticket.getId(), this.ticketGrantingTicketsCache.getName());
-            this.ticketGrantingTicketsCache.put(ticket.getId(), (TicketGrantingTicket) ticket);
-        } else {
-            throw new IllegalArgumentException("Invalid ticket type " + ticket);
-        }
+        logger.debug("Adding ticket {} to the cache {}", ticket.getId(), this.ticketIgniteCache.getName());
+        this.ticketIgniteCache.put(ticket.getId(), ticket);
     }
 
 
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
         final Ticket ticket = getTicket(ticketId);
-        if (ticket instanceof ServiceTicket) {
-            return this.serviceTicketsCache.remove(ticketId);
+        if (ticket != null) {
+            return this.ticketIgniteCache.remove(ticket.getId());
         }
-        return this.ticketGrantingTicketsCache.remove(ticketId);
+        return true;
     }
 
     @Override
@@ -143,48 +118,29 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
             return null;
         }
 
-        Ticket ticket = this.serviceTicketsCache.get(ticketId);
-        if (ticket == null) {
-            ticket = this.ticketGrantingTicketsCache.get(ticketId);
-        }
+        final Ticket ticket = this.ticketIgniteCache.get(ticketId);
         if (ticket == null) {
             logger.debug("No ticket by id [{}] is found in the registry", ticketId);
             return null;
         }
 
         final Ticket proxiedTicket = decodeTicket(ticket);
-        ticket = getProxiedTicketInstance(proxiedTicket);
-        return ticket;
+        return getProxiedTicketInstance(proxiedTicket);
     }
 
     @Override
     public Collection<Ticket> getTickets() {
-        final Collection<Cache.Entry<String, Ticket>> serviceTickets;
-        final Collection<Cache.Entry<String, Ticket>> tgtTicketsTickets;
-
         final IgniteBiPredicate<String, Ticket> filter = (IgniteBiPredicate<String, Ticket>) (key, t) -> !t.isExpired();
-
-        QueryCursor<Cache.Entry<String, Ticket>> cursor = ticketGrantingTicketsCache.query(new ScanQuery<>(filter));
-        tgtTicketsTickets = cursor.getAll();
-
-        cursor = serviceTicketsCache.query(new ScanQuery<>(filter));
-        serviceTickets = cursor.getAll();
-
-        final Collection<Ticket> allTickets = new HashSet<>(serviceTickets.size() + tgtTicketsTickets.size());
-
-        serviceTickets.stream().forEach(entry -> allTickets.add(getProxiedTicketInstance(entry.getValue())));
-
-        tgtTicketsTickets.stream().forEach(entry -> allTickets.add(getProxiedTicketInstance(entry.getValue())));
-
+        final QueryCursor<Cache.Entry<String, Ticket>> cursor = this.ticketIgniteCache.query(new ScanQuery<>(filter));
+        final Collection<Cache.Entry<String, Ticket>> cacheTickets = cursor.getAll();
+        
+        final Collection<Ticket> allTickets = new HashSet<>(cacheTickets.size());
+        cacheTickets.stream().forEach(entry -> allTickets.add(getProxiedTicketInstance(entry.getValue())));
         return decodeTickets(allTickets);
     }
 
-    public void setServiceTicketsCache(final IgniteCache<String, ServiceTicket> serviceTicketsCache) {
-        this.serviceTicketsCache = serviceTicketsCache;
-    }
-
-    public void setTicketGrantingTicketsCache(final IgniteCache<String, TicketGrantingTicket> ticketGrantingTicketsCache) {
-        this.ticketGrantingTicketsCache = ticketGrantingTicketsCache;
+    public void setTicketIgniteCache(final IgniteCache<String, Ticket> ticketIgniteCache) {
+        this.ticketIgniteCache = ticketIgniteCache;
     }
 
     public void setIgniteConfiguration(final IgniteConfiguration igniteConfiguration){
@@ -194,12 +150,7 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
     public IgniteConfiguration getIgniteConfiguration(){
         return this.igniteConfiguration;
     }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this).append("ticketGrantingTicketsCache", this.ticketGrantingTicketsCache)
-                .append("serviceTicketsCache", this.serviceTicketsCache).toString();
-    }
+    
 
     @Override
     protected void updateTicket(final Ticket ticket) {
@@ -269,8 +220,6 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
             logger.debug("igniteConfiguration.cacheConfiguration={}", igniteConfiguration.getCacheConfiguration());
             logger.debug("igniteConfiguration.getDiscoverySpi={}", igniteConfiguration.getDiscoverySpi());
             logger.debug("igniteConfiguration.getSslContextFactory={}", igniteConfiguration.getSslContextFactory());
-            logger.debug("Ticket-granting ticket timeout: [{}s]", this.ticketGrantingTicketTimeoutInSeconds);
-            logger.debug("Service ticket timeout: [{}s]", this.serviceTicketTimeoutInSeconds);
         }
 
         if (Ignition.state() == IgniteState.STOPPED) {
@@ -279,25 +228,18 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
             ignite = Ignition.ignite();
         }
 
-        serviceTicketsCache = ignite.getOrCreateCache(servicesCacheName);
-        serviceTicketsCache.getConfiguration(CacheConfiguration.class)
-            .setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, serviceTicketTimeoutInSeconds)));
-
-        ticketGrantingTicketsCache = ignite.getOrCreateCache(ticketsCacheName);
-        ticketGrantingTicketsCache.getConfiguration(CacheConfiguration.class)
-            .setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, ticketGrantingTicketTimeoutInSeconds)));
+        ticketIgniteCache = ignite.getOrCreateCache(cacheName);
+        
     }
 
     @Override
     public long sessionCount() {
-        return BooleanUtils.toInteger(this.supportRegistryState, this.ticketGrantingTicketsCache
-            .size(CachePeekMode.ALL), (int) super.sessionCount());
+        return getTickets().stream().filter(t -> t instanceof TicketGrantingTicket).count();
     }
 
     @Override
     public long serviceTicketCount() {
-        return BooleanUtils.toInteger(this.supportRegistryState, this.serviceTicketsCache
-            .size(CachePeekMode.ALL), (int) super.serviceTicketCount());
+        return getTickets().stream().filter(t -> t instanceof ServiceTicket).count();
     }
 
     /**
@@ -308,19 +250,28 @@ public final class IgniteTicketRegistry extends AbstractTicketRegistry {
         Ignition.stopAll(true);
     }
 
-    public String getTicketsCacheName() {
-        return ticketsCacheName;
+    public String getCacheName() {
+        return cacheName;
     }
 
-    public void setTicketsCacheName(final String cacheName) {
-        this.ticketsCacheName = cacheName;
+    public void setCacheName(final String cacheName) {
+        this.cacheName = cacheName;
     }
 
-    public String getServicesCacheName() {
-        return servicesCacheName;
-    }
-
-    public void setServicesCacheName(final String cacheName) {
-        this.servicesCacheName = cacheName;
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .appendSuper(super.toString())
+                .append("cacheName", cacheName)
+                .append("keyStoreType", keyStoreType)
+                .append("keyStoreFilePath", keyStoreFilePath)
+                .append("keyStorePassword", keyStorePassword)
+                .append("trustStoreType", trustStoreType)
+                .append("protocol", protocol)
+                .append("keyAlgorithm", keyAlgorithm)
+                .append("trustStoreFilePath", trustStoreFilePath)
+                .append("trustStorePassword", trustStorePassword)
+                .append("supportRegistryState", supportRegistryState)
+                .toString();
     }
 }

--- a/cas-server-integration-ignite/src/test/resources/ticketRegistry.xml
+++ b/cas-server-integration-ignite/src/test/resources/ticketRegistry.xml
@@ -32,13 +32,6 @@
         <property name="cacheConfiguration">
             <list>
                 <bean class="org.apache.ignite.configuration.CacheConfiguration">
-                    <property name="name" value="serviceTicketsCache"/>
-                    <property name="cacheMode" value="REPLICATED"/>
-                    <property name="atomicityMode" value="TRANSACTIONAL"/>
-                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
-                </bean>
-
-                <bean class="org.apache.ignite.configuration.CacheConfiguration">
                     <property name="name" value="ticketGrantingTicketsCache"/>
                     <property name="cacheMode" value="REPLICATED"/>
                     <property name="atomicityMode" value="TRANSACTIONAL"/>

--- a/cas-server-integration-infinispan/src/main/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistry.java
+++ b/cas-server-integration-infinispan/src/main/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistry.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -47,7 +48,9 @@ public final class InfinispanTicketRegistry extends AbstractTicketRegistry {
     @Override
     public void addTicket(final Ticket ticketToAdd) {
         final Ticket ticket = encodeTicket(ticketToAdd);
-        this.cache.put(ticket.getId(), ticket);
+        this.cache.put(ticket.getId(), ticket, 
+                ticket.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS,
+                ticket.getExpirationPolicy().getTimeToIdle(), TimeUnit.SECONDS);
     }
 
     /**

--- a/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistry.java
+++ b/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistry.java
@@ -153,7 +153,7 @@ public final class MemCacheTicketRegistry extends AbstractTicketRegistry impleme
      */
     @Override
     public Collection<Ticket> getTickets() {
-        throw new UnsupportedOperationException("getTickets not supported.");
+        throw new UnsupportedOperationException("getTickets() not supported.");
     }
 
     /**

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -271,6 +271,11 @@ public class KryoTranscoderTests {
         }
 
         @Override
+        public ExpirationPolicy getExpirationPolicy() {
+            return new NeverExpiresExpirationPolicy();
+        }
+
+        @Override
         public boolean equals(final Object other) {
             return other instanceof MockServiceTicket && ((MockServiceTicket) other).getId().equals(id);
         }
@@ -405,6 +410,11 @@ public class KryoTranscoderTests {
         @Override
         public int getCountOfUses() {
             return this.usageCount;
+        }
+
+        @Override
+        public ExpirationPolicy getExpirationPolicy() {
+            return new NeverExpiresExpirationPolicy();
         }
 
         @Override

--- a/cas-server-support-couchbase-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/CouchbaseTicketRegistry.java
+++ b/cas-server-support-couchbase-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/CouchbaseTicketRegistry.java
@@ -154,12 +154,12 @@ public final class CouchbaseTicketRegistry extends AbstractTicketRegistry implem
     }
 
     @Override
-    public int sessionCount() {
+    public long sessionCount() {
         return runQuery(TicketGrantingTicket.PREFIX + '-');
     }
 
     @Override
-    public int serviceTicketCount() {
+    public long serviceTicketCount() {
         return runQuery(ServiceTicket.PREFIX + '-');
     }
 

--- a/cas-server-support-couchbase-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/CouchbaseTicketRegistry.java
+++ b/cas-server-support-couchbase-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/CouchbaseTicketRegistry.java
@@ -28,7 +28,7 @@ import java.util.List;
  * A Ticket Registry storage backend which uses the memcached protocol.
  * CouchBase is a multi host NoSQL database with a memcached interface
  * to persistent storage which also is quite usable as a replicated
- * tickage storage engine for multiple front end CAS servers.
+ * ticket storage engine for multiple front end CAS servers.
  *
  * @author Fredrik Jönsson "fjo@kth.se"
  * @author Misagh Moayyed
@@ -47,7 +47,6 @@ public final class CouchbaseTicketRegistry extends AbstractTicketRegistry implem
     });
     private static final String UTIL_DOCUMENT = "statistics";
 
-    /* Couchbase client factory */
     @NotNull
     @Autowired
     @Qualifier("ticketRegistryCouchbaseClientFactory")
@@ -142,7 +141,7 @@ public final class CouchbaseTicketRegistry extends AbstractTicketRegistry implem
 
     @Override
     public Collection<Ticket> getTickets() {
-        throw new UnsupportedOperationException("GetTickets not supported.");
+        throw new UnsupportedOperationException("getTickets() not supported.");
     }
 
     @Override
@@ -180,16 +179,13 @@ public final class CouchbaseTicketRegistry extends AbstractTicketRegistry implem
             return 0;
         }
     }
-
-
-    /**
+    
     @Override
     protected boolean isCleanerSupported() {
         logger.info("{} does not support automatic ticket clean up processes", this.getClass().getName());
         return false;
     }
-     * @param couchbase the client factory to use.
-     */
+    
     public void setCouchbaseClientFactory(final CouchbaseClientFactory couchbase) {
         this.couchbase = couchbase;
     }

--- a/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
@@ -127,14 +127,14 @@ public final class JpaTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public int sessionCount() {
-        return countToInt(entityManager.createQuery(
+    public long sessionCount() {
+        return countToLong(entityManager.createQuery(
                 "select count(t) from TicketGrantingTicketImpl t").getSingleResult());
     }
 
     @Override
-    public int serviceTicketCount() {
-        return countToInt(entityManager.createQuery("select count(t) from ServiceTicketImpl t").getSingleResult());
+    public long serviceTicketCount() {
+        return countToLong(entityManager.createQuery("select count(t) from ServiceTicketImpl t").getSingleResult());
     }
 
     @Override
@@ -206,15 +206,15 @@ public final class JpaTicketRegistry extends AbstractTicketRegistry {
      * @param result the result
      * @return the int
      */
-    private static int countToInt(final Object result) {
-        final int intval;
+    private static long countToLong(final Object result) {
+        final long intval;
         if (result instanceof Long) {
-            intval = ((Long) result).intValue();
+            intval = (Long) result;
         } else if (result instanceof Integer) {
-            intval = (Integer) result;
+            intval = new Long((Integer) result);
         } else {
             // Must be a Number of some kind
-            intval = ((Number) result).intValue();
+            intval = ((Number) result).longValue();
         }
         return intval;
     }

--- a/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
@@ -114,8 +114,7 @@ public final class JpaTicketRegistry extends AbstractTicketRegistry {
                 .createQuery("select s from ServiceTicketImpl s", ServiceTicketImpl.class)
                 .getResultList();
 
-        final List<Ticket> tickets = new ArrayList<>();
-        tickets.addAll(tgts);
+        final List<Ticket> tickets = new ArrayList<>(tgts);
         tickets.addAll(sts);
 
         return tickets;
@@ -140,7 +139,7 @@ public final class JpaTicketRegistry extends AbstractTicketRegistry {
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
         final Ticket ticket = getTicket(ticketId);
-        int failureCount = 0;
+        final int failureCount;
 
         if (ticket instanceof OAuthToken) {
             failureCount = deleteOAuthTokens(ticketId);
@@ -207,16 +206,7 @@ public final class JpaTicketRegistry extends AbstractTicketRegistry {
      * @return the int
      */
     private static long countToLong(final Object result) {
-        final long intval;
-        if (result instanceof Long) {
-            intval = (Long) result;
-        } else if (result instanceof Integer) {
-            intval = new Long((Integer) result);
-        } else {
-            // Must be a Number of some kind
-            intval = ((Number) result).longValue();
-        }
-        return intval;
+        return ((Number) result).longValue();
     }
 
     @Override

--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/util/LdapUtils.java
@@ -52,18 +52,7 @@ public final class LdapUtils {
         }
         return nullValue;
     }
-
-    /**
-     * Reads a Long value from the LdapEntry.
-     *
-     * @param ctx       the ldap entry
-     * @param attribute the attribute name
-     * @return the long value
-     */
-    public static Long getLong(final LdapEntry ctx, final String attribute) {
-        return getLong(ctx, attribute, Long.MIN_VALUE);
-    }
-
+    
     /**
      * Reads a Long value from the LdapEntry.
      *

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/ticket/accesstoken/OAuthAccessTokenExpirationPolicy.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/ticket/accesstoken/OAuthAccessTokenExpirationPolicy.java
@@ -68,12 +68,12 @@ public class OAuthAccessTokenExpirationPolicy extends AbstractCasExpirationPolic
     }
 
     @Override
-    public long getTimeToLive() {
+    public Long getTimeToLive() {
         return this.maxTimeToLiveInMilliSeconds;
     }
 
     @Override
-    public long getTimeToIdle() {
+    public Long getTimeToIdle() {
         return this.timeToKillInMilliSeconds;
     }
 }

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/ticket/accesstoken/OAuthAccessTokenExpirationPolicy.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/ticket/accesstoken/OAuthAccessTokenExpirationPolicy.java
@@ -66,4 +66,14 @@ public class OAuthAccessTokenExpirationPolicy extends AbstractCasExpirationPolic
 
         return false;
     }
+
+    @Override
+    public long getTimeToLive() {
+        return this.maxTimeToLiveInMilliSeconds;
+    }
+
+    @Override
+    public long getTimeToIdle() {
+        return this.timeToKillInMilliSeconds;
+    }
 }

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -22,6 +22,7 @@ import org.jasig.cas.support.oauth.ticket.accesstoken.AccessToken;
 import org.jasig.cas.support.oauth.ticket.code.DefaultOAuthCodeFactory;
 import org.jasig.cas.support.oauth.ticket.code.OAuthCode;
 import org.jasig.cas.support.oauth.validator.OAuthValidator;
+import org.jasig.cas.ticket.support.AlwaysExpiresExpirationPolicy;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -308,7 +309,7 @@ public final class OAuth20AccessTokenControllerTests {
         final Principal principal = org.jasig.cas.authentication.TestUtils.getPrincipal(ID, map);
         final Authentication authentication = getAuthentication(principal);
         final DefaultOAuthCodeFactory expiringOAuthCodeFactory = new DefaultOAuthCodeFactory();
-        expiringOAuthCodeFactory.setExpirationPolicy(state -> true);
+        expiringOAuthCodeFactory.setExpirationPolicy(new AlwaysExpiresExpirationPolicy());
         final Service service = new OAuthWebApplicationService(registeredService);
         final OAuthCode code = expiringOAuthCodeFactory.create(service, authentication);
         oAuth20AccessTokenController.getTicketRegistry().addTicket(code);

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
@@ -14,8 +14,7 @@ import org.jasig.cas.authentication.principal.Principal;
 import org.jasig.cas.support.oauth.OAuthConstants;
 import org.jasig.cas.support.oauth.ticket.accesstoken.AccessTokenImpl;
 import org.jasig.cas.support.oauth.ticket.accesstoken.DefaultAccessTokenFactory;
-import org.jasig.cas.ticket.ExpirationPolicy;
-import org.jasig.cas.ticket.TicketState;
+import org.jasig.cas.ticket.support.AlwaysExpiresExpirationPolicy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,14 +91,7 @@ public final class OAuth20ProfileControllerTests {
         final Principal principal = org.jasig.cas.authentication.TestUtils.getPrincipal(ID, new HashMap<>());
         final Authentication authentication = getAuthentication(principal);
         final DefaultAccessTokenFactory expiringAccessTokenFactory = new DefaultAccessTokenFactory();
-        expiringAccessTokenFactory.setExpirationPolicy(new ExpirationPolicy() {
-            private static final long serialVersionUID = -7954347268375322691L;
-
-            @Override
-            public boolean isExpired(final TicketState ticketState) {
-                return true;
-            }
-        });
+        expiringAccessTokenFactory.setExpirationPolicy(new AlwaysExpiresExpirationPolicy());
         final AccessTokenImpl accessToken = (AccessTokenImpl) expiringAccessTokenFactory.create(TestUtils.getService(), authentication);
         oAuth20ProfileController.getTicketRegistry().addTicket(accessToken);
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -652,12 +652,6 @@ accept.authn.users=casuser::Mellon
 # ehcache.max.elements.disk=0
 # ehcache.eviction.policy=LRU
 # ehcache.overflow.disk=false
-# ehcache.cache.st.name=org.jasig.cas.ticket.ServiceTicket
-# ehcache.cache.st.timeIdle=0
-# ehcache.cache.st.timeAlive=300
-# ehcache.cache.tgt.name=org.jasig.cas.ticket.TicketGrantingTicket
-# ehcache.cache.tgt.timeIdle=7201
-# ehcache.cache.tgt.timeAlive=0
 # ehcache.cache.loader.async=true
 # ehcache.cache.loader.chunksize=5000000
 # ehcache.repl.async.interval=10000
@@ -667,6 +661,9 @@ accept.authn.users=casuser::Mellon
 # ehcache.repl.sync.updates=true
 # ehcache.repl.sync.updatescopy=true
 # ehcache.repl.sync.removals=true
+# ehcache.cache.name=org.jasig.cas.ticket.ServiceTicket
+# ehcache.cache.timeIdle=0
+# ehcache.cache.timeAlive=9000
 
 ##
 # Ehcache Monitoring


### PR DESCRIPTION
Closes #1580 

This patch:

1. Exposes `ticket.getExpirationPolicy()`
2. The `ExpirationPolicy` interface now includes two fields for maxAlive and idle timeouts. 
3. Each ticket registry is configured to use the ticket expiration policy, rather than the static config. 
4. Ehcache and Ignite have been consolidated to follow the same pattern as other registries, in keeping a single cache only. 