### PR TITLE
Fix integer overflow when using long term (rememberme) sessions

### DIFF
--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
@@ -30,11 +30,11 @@ public final class TicketGrantingTicketExpirationPolicy extends AbstractCasExpir
     private static final Logger LOGGER = LoggerFactory.getLogger(TicketGrantingTicketExpirationPolicy.class);
 
     /** Maximum time this ticket is valid.  */
-    @Value("#{${tgt.maxTimeToLiveInSeconds:28800}*1000}")
+    @Value("#{${tgt.maxTimeToLiveInSeconds:28800}*1000L}")
     private long maxTimeToLiveInMilliSeconds;
 
     /** Time to kill in milliseconds. */
-    @Value("#{${tgt.timeToKillInSeconds:7200}*1000}")
+    @Value("#{${tgt.timeToKillInSeconds:7200}*1000L}")
     private long timeToKillInMilliSeconds;
 
     private TicketGrantingTicketExpirationPolicy() {}


### PR DESCRIPTION
If you are specifying values of over (roughly) 24 days in seconds (in `cas.properties`) the expression will result in negative integer values being assigned to the long fields.

```
# does not work, overflows to negative integer
tgt.maxTimeToLiveInSeconds=7776000

# works
tgt.maxTimeToLiveInSeconds=7776000L
```

This is a bit unexpected. There might be other cases where this is used, I'm really really pressed for time right now, so I'm only offering this bit, sorry.
