### PR TITLE
Fix generics on `TicketRegistry.getTicket()` and `CentralAuthenticationService.getTicket()`

### DIFF
--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/registry/TicketRegistry.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/registry/TicketRegistry.java
@@ -36,7 +36,7 @@ public interface TicketRegistry {
      * @param <T> the generic ticket type to return that extends {@link Ticket}
      * @return the requested ticket.
      */
-    <T extends Ticket> T getTicket(String ticketId, Class<? extends Ticket> clazz);
+    <T extends Ticket> T getTicket(String ticketId, Class<T> clazz);
 
     /**
      * Retrieve a ticket from the registry.

--- a/cas-server-core-api/src/main/java/org/jasig/cas/CentralAuthenticationService.java
+++ b/cas-server-core-api/src/main/java/org/jasig/cas/CentralAuthenticationService.java
@@ -68,7 +68,7 @@ public interface CentralAuthenticationService {
      * @throws InvalidTicketException the invalid ticket exception
      * @since 4.1.0
      */
-    <T extends Ticket> T getTicket(@NotNull String ticketId, @NotNull Class<? extends Ticket> clazz)
+    <T extends Ticket> T getTicket(@NotNull String ticketId, @NotNull Class<T> clazz)
             throws InvalidTicketException;
 
     /**

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketDelegator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketDelegator.java
@@ -73,7 +73,7 @@ public abstract class AbstractTicketDelegator<T extends Ticket> implements Ticke
             return old;
         }
 
-        return this.ticketRegistry.getTicket(old.getId(), Ticket.class);
+        return this.ticketRegistry.getTicket(old.getId(), TicketGrantingTicket.class);
     }
 
     @Override

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -103,7 +103,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
      * @return specified ticket from the registry
      */
     @Override
-    public final <T extends Ticket> T getTicket(final String ticketId, final Class<? extends Ticket> clazz) {
+    public final <T extends Ticket> T getTicket(final String ticketId, final Class<T> clazz) {
         Assert.notNull(clazz, "clazz cannot be null");
 
         final Ticket ticket = this.getTicket(ticketId);

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/MockOnlyOneTicketRegistry.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/MockOnlyOneTicketRegistry.java
@@ -30,7 +30,7 @@ public final class MockOnlyOneTicketRegistry implements TicketRegistry {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends Ticket> T getTicket(final String ticketId, final Class<? extends Ticket> clazz) {
+    public <T extends Ticket> T getTicket(final String ticketId, final Class<T> clazz) {
         return (T) this.ticket;
     }
 

--- a/cas-server-core/src/main/java/org/jasig/cas/AbstractCentralAuthenticationService.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/AbstractCentralAuthenticationService.java
@@ -161,7 +161,7 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
     @Metered(name = "GET_TICKET_METER")
     @Counted(name="GET_TICKET_COUNTER", monotonic=true)
     @Override
-    public final <T extends Ticket> T getTicket(final String ticketId, final Class<? extends Ticket> clazz)
+    public final <T extends Ticket> T getTicket(final String ticketId, final Class<T> clazz)
             throws InvalidTicketException {
         Assert.notNull(ticketId, "ticketId cannot be null");
         final Ticket ticket = this.ticketRegistry.getTicket(ticketId, clazz);


### PR DESCRIPTION
I ran into an issue where this code
```
centralAuthenticationService.getTicket(tgtId, TicketGrantingTicket.class).getAuthentication();
```
didn't work without an explicit cast that should have been unnecessary.

This addresses that issue by being able to pick up the return ticket class from the provided class parameter.