### PR TITLE
Correctly name ticketreg.database hibernate options

### DIFF
--- a/cas-server-documentation/installation/JPA-Ticket-Registry.md
+++ b/cas-server-documentation/installation/JPA-Ticket-Registry.md
@@ -38,8 +38,8 @@ The following settings are expected:
 
 ```properties
 # ticketreg.database.ddl.auto=create-drop
-# ticketreg.database.hibernate.dialect=org.hibernate.dialect.OracleDialect|MySQLInnoDBDialect|HSQLDialect
-# ticketreg.database.hibernate.batchSize=10
+# ticketreg.database.dialect=org.hibernate.dialect.OracleDialect|MySQLInnoDBDialect|HSQLDialect
+# ticketreg.database.batchSize=10
 # ticketreg.database.driverClass=org.hsqldb.jdbcDriver
 # ticketreg.database.url=jdbc:hsqldb:mem:cas-ticket-registry
 # ticketreg.database.user=sa

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -14,8 +14,8 @@ host.name=cas01.example.org
 # JPA Ticket Registry Database Configuration
 #
 # ticketreg.database.ddl.auto=create-drop
-# ticketreg.database.hibernate.dialect=org.hibernate.dialect.OracleDialect|MySQLInnoDBDialect|HSQLDialect
-# ticketreg.database.hibernate.batchSize=10
+# ticketreg.database.dialect=org.hibernate.dialect.OracleDialect|MySQLInnoDBDialect|HSQLDialect
+# ticketreg.database.batchSize=10
 # ticketreg.database.driverClass=org.hsqldb.jdbcDriver
 # ticketreg.database.url=jdbc:hsqldb:mem:cas-ticket-registry
 # ticketreg.database.user=sa


### PR DESCRIPTION
The abstractJpaEntityManagerFactory bean in jpaTicketRegistryContext.xml expects these options to be:

    ticketreg.database.dialect
    ticketreg.database.batchSize