### PR TITLE
Closes #1652: "RegisteredServiceImpl_Properties" is too long for Oracle.

### DIFF
--- a/cas-server-core-services/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
@@ -123,7 +123,7 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
     private RegisteredServicePublicKey publicKey;
 
     @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-    @JoinTable(name="RegisteredServiceImpl_Properties")
+    @JoinTable(name="RegisteredServiceImpl_Props")
     private Map<String, DefaultRegisteredServiceProperty> properties = new HashMap<>();
 
     @Override


### PR DESCRIPTION
Closes #1652. Simply rename the table slightly to avoid the identifier being too long. Since
we rely on Hibernate to create/update our database objects, there isn't a good way to migrate
existing tables. However, since there already isn't a good way to migrate any existing data,
this doesn't seem like a big deal.
