### PR TITLE
Add note about ticketreg.database.ddl.auto options to doco

### DIFF
--- a/cas-server-documentation/installation/JPA-Ticket-Registry.md
+++ b/cas-server-documentation/installation/JPA-Ticket-Registry.md
@@ -56,6 +56,14 @@ The following settings are expected:
 # ticketreg.database.pool.connectionHealthQuery=select 1
 ```
 
+Note that the default value for `ticketreg.database.ddl.auto` is `create-drop`
+which may not be appropriate for use in production. Setting the value to
+`validate` may be more desirable, but any of the following options can be used:
+
+* `validate` - validate the schema, but make no changes to the database.
+* `update` - update the schema.
+* `create` - create the schema, destroying previous data.
+* `create-drop` - drop the schema at the end of the session.
 
 ## TicketGrantingTicket Locking
 


### PR DESCRIPTION
The default value of 'create-drop' is probably not desirable for use in production, so provide a note in the documentation for other option values that can be used.

Includes the information referenced in #1647 