### PR TITLE
Allow host.name to be auto-detected if left undefined

### DIFF
--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/util/DefaultUniqueTicketIdGenerator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/util/DefaultUniqueTicketIdGenerator.java
@@ -4,9 +4,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jasig.cas.ticket.UniqueTicketIdGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 /**
  * Default implementation of {@link UniqueTicketIdGenerator}. Implementation
@@ -21,13 +18,19 @@ import org.springframework.stereotype.Component;
  */
 public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
 
-    /** The logger instance. */
+    /**
+     * The logger instance.
+     */
     protected final transient Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    /** The numeric generator to generate the static part of the id. */
+    /**
+     * The numeric generator to generate the static part of the id.
+     */
     private NumericGenerator numericGenerator;
 
-    /** The RandomStringGenerator to generate the secure random part of the id. */
+    /**
+     * The RandomStringGenerator to generate the secure random part of the id.
+     */
     private RandomStringGenerator randomStringGenerator;
 
     /**
@@ -50,7 +53,7 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
      * maximum length for the random portion.
      *
      * @param maxLength the maximum length of the random string used to generate
-     * the id.
+     *                  the id.
      */
     public DefaultUniqueTicketIdGenerator(final int maxLength) {
         this(maxLength, null);
@@ -62,9 +65,9 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
      * maximum length for the random portion.
      *
      * @param maxLength the maximum length of the random string used to generate
-     * the id.
-     * @param suffix the value to append at the end of the unique id to ensure
-     * uniqueness across JVMs.
+     *                  the id.
+     * @param suffix    the value to append at the end of the unique id to ensure
+     *                  uniqueness across JVMs.
      */
     public DefaultUniqueTicketIdGenerator(final int maxLength, final String suffix) {
         setMaxLength(maxLength);
@@ -75,10 +78,10 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
      * Creates an instance of DefaultUniqueTicketIdGenerator with a specified
      * maximum length for the random portion.
      *
-     * @param numericGenerator the numeric generator
+     * @param numericGenerator      the numeric generator
      * @param randomStringGenerator the random string generator
-     * @param suffix the value to append at the end of the unique id to ensure
-     * uniqueness across JVMs.
+     * @param suffix                the value to append at the end of the unique id to ensure
+     *                              uniqueness across JVMs.
      * @since 4.1.0
      */
     public DefaultUniqueTicketIdGenerator(final NumericGenerator numericGenerator,
@@ -93,8 +96,8 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
     public final String getNewTicketId(final String prefix) {
         final String number = this.numericGenerator.getNextNumberAsString();
         final StringBuilder buffer = new StringBuilder(prefix.length() + 2
-            + (StringUtils.isNotBlank(this.suffix) ? this.suffix.length() : 0) + this.randomStringGenerator.getMaxLength()
-            + number.length());
+                + (StringUtils.isNotBlank(this.suffix) ? this.suffix.length() : 0) + this.randomStringGenerator.getMaxLength()
+                + number.length());
 
         buffer.append(prefix);
         buffer.append('-');
@@ -122,78 +125,5 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
         this.randomStringGenerator = new DefaultRandomStringGenerator(maxLength);
         this.numericGenerator = new DefaultLongNumericGenerator(1);
     }
-
-    /**
-     * The type Ticket granting ticket id generator.
-     */
-    @Component("ticketGrantingTicketUniqueIdGenerator")
-    public static class TicketGrantingTicketIdGenerator extends DefaultUniqueTicketIdGenerator {
-        @Autowired
-        @Override
-        public void setSuffix(@Value("${host.name:cas01.example.org}") final String suffix) {
-            super.setSuffix(suffix);
-        }
-
-        @Autowired
-        @Override
-        public void setMaxLength(@Value("${tgt.ticket.maxlength:50}") final int maxLength) {
-            super.setMaxLength(maxLength);
-        }
-    }
-
-    /**
-     * The type Service ticket id generator.
-     */
-    @Component("serviceTicketUniqueIdGenerator")
-    public static class ServiceTicketIdGenerator extends DefaultUniqueTicketIdGenerator {
-        @Autowired
-        @Override
-        public void setSuffix(@Value("${host.name:cas01.example.org}") final String suffix) {
-            super.setSuffix(suffix);
-        }
-
-        @Autowired
-        @Override
-        public void setMaxLength(@Value("${st.ticket.maxlength:20}") final int maxLength) {
-            super.setMaxLength(maxLength);
-        }
-    }
-
-    /**
-     * The type Login ticket id generator.
-     */
-    @Component("loginTicketUniqueIdGenerator")
-    public static class LoginTicketIdGenerator extends DefaultUniqueTicketIdGenerator {
-        @Autowired
-        @Override
-        public void setSuffix(@Value("${host.name:cas01.example.org}") final String suffix) {
-            super.setSuffix(suffix);
-        }
-
-        @Autowired
-        @Override
-        public void setMaxLength(@Value("${lt.ticket.maxlength:20}") final int maxLength) {
-            super.setMaxLength(maxLength);
-        }
-    }
-
-    /**
-     * The type Proxy ticket id generator.
-     */
-    @Component("proxy20TicketUniqueIdGenerator")
-    public static class ProxyTicketIdGenerator extends DefaultUniqueTicketIdGenerator {
-        @Autowired
-        @Override
-        public void setSuffix(@Value("${host.name:cas01.example.org}") final String suffix) {
-            super.setSuffix(suffix);
-        }
-
-        @Autowired
-        @Override
-        public void setMaxLength(@Value("${pgt.ticket.maxlength:50}") final int maxLength) {
-            super.setMaxLength(maxLength);
-        }
-    }
-
-
+    
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/util/HostNameBasedUniqueTicketIdGenerator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/util/HostNameBasedUniqueTicketIdGenerator.java
@@ -1,12 +1,17 @@
 package org.jasig.cas.util;
 
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 /**
  * An implementation of {@link org.jasig.cas.ticket.UniqueTicketIdGenerator} that is able auto-configure
  * the suffix based on the underlying host name.
- *
+ * <p>
  * <p>In order to assist with multi-node deployments, in scenarios where CAS configuration
  * and specially {@code cas.properties} file is externalized, it would be ideal to simply just have one set
  * of configuration files for all nodes, such that there would for instance be one {@code cas.properties} file
@@ -17,17 +22,19 @@ import java.net.UnknownHostException;
  * and diagnostics. To provide a remedy, this ticket generator is able to retrieve the {@code host.name} value directly from
  * the actual node name, rather than relying on the configuration, only if one isn't specified in
  * the {@code cas.properties} file. </p>
+ *
  * @author Misagh Moayyed
  * @since 4.1.0
  */
-public final class HostNameBasedUniqueTicketIdGenerator extends DefaultUniqueTicketIdGenerator {
+public class HostNameBasedUniqueTicketIdGenerator extends DefaultUniqueTicketIdGenerator {
     /**
      * Instantiates a new Host name based unique ticket id generator.
      *
      * @param maxLength the max length
+     * @param suffix    the suffix
      */
-    public HostNameBasedUniqueTicketIdGenerator(final int maxLength) {
-        super(maxLength, determineTicketSuffixByHostName());
+    public HostNameBasedUniqueTicketIdGenerator(final int maxLength, final String suffix) {
+        super(maxLength, determineTicketSuffixByHostName(suffix));
     }
 
     /**
@@ -40,11 +47,17 @@ public final class HostNameBasedUniqueTicketIdGenerator extends DefaultUniqueTic
      * <li>If the CAS node name is {@code cas-01} then, the suffix
      * determined would just be {@code cas-01}</li>
      * </ul>
+     *
+     * @param suffix the suffix
      * @return the shortened ticket suffix based on the hostname
      * @since 4.1.0
      */
-    private static String determineTicketSuffixByHostName() {
+    private static String determineTicketSuffixByHostName(final String suffix) {
         try {
+            if (StringUtils.isNotBlank(suffix)) {
+                return suffix;
+            }
+
             final String hostName = InetAddress.getLocalHost().getCanonicalHostName();
             final int index = hostName.indexOf('.');
             if (index > 0) {
@@ -53,6 +66,89 @@ public final class HostNameBasedUniqueTicketIdGenerator extends DefaultUniqueTic
             return hostName;
         } catch (final UnknownHostException e) {
             throw new RuntimeException("Host name could not be determined automatically for the ticket suffix.", e);
+        }
+    }
+
+    /**
+     * The type Ticket granting ticket id generator.
+     */
+    @Component("ticketGrantingTicketUniqueIdGenerator")
+    public static class TicketGrantingTicketIdGenerator extends HostNameBasedUniqueTicketIdGenerator {
+
+        /**
+         * Instantiates a new Ticket granting ticket id generator.
+         *
+         * @param maxLength the max length
+         * @param suffix    the suffix
+         */
+        @Autowired
+        public TicketGrantingTicketIdGenerator(@Value("${tgt.ticket.maxlength:50}")
+                                               final int maxLength,
+                                               @Value("${host.name:cas01.example.org}")
+                                               final String suffix) {
+            super(maxLength, suffix);
+        }
+    }
+
+    /**
+     * The type Service ticket id generator.
+     */
+    @Component("serviceTicketUniqueIdGenerator")
+    public static class ServiceTicketIdGenerator extends HostNameBasedUniqueTicketIdGenerator {
+
+        /**
+         * Instantiates a new Service ticket id generator.
+         *
+         * @param maxLength the max length
+         * @param suffix    the suffix
+         */
+        @Autowired
+        public ServiceTicketIdGenerator(@Value("${st.ticket.maxlength:20}")
+                                        final int maxLength,
+                                        @Value("${host.name:cas01.example.org}")
+                                        final String suffix) {
+            super(maxLength, suffix);
+        }
+    }
+
+    /**
+     * The type Proxy ticket id generator.
+     */
+    @Component("proxy20TicketUniqueIdGenerator")
+    public static class ProxyTicketIdGenerator extends HostNameBasedUniqueTicketIdGenerator {
+        /**
+         * Instantiates a new Proxy ticket id generator.
+         *
+         * @param maxLength the max length
+         * @param suffix    the suffix
+         */
+        @Autowired
+        public ProxyTicketIdGenerator(@Value("${pgt.ticket.maxlength:50}")
+                                      final int maxLength,
+                                      @Value("${host.name:cas01.example.org}")
+                                      final String suffix) {
+            super(maxLength, suffix);
+        }
+    }
+
+    /**
+     * The type Login ticket id generator.
+     */
+    @Component("loginTicketUniqueIdGenerator")
+    public static class LoginTicketIdGenerator extends HostNameBasedUniqueTicketIdGenerator {
+
+        /**
+         * Instantiates a new Login ticket id generator.
+         *
+         * @param maxLength the max length
+         * @param suffix    the suffix
+         */
+        @Autowired
+        public LoginTicketIdGenerator(@Value("${lt.ticket.maxlength:20}")
+                                      final int maxLength,
+                                      @Value("${host.name:cas01.example.org}")
+                                      final String suffix) {
+            super(maxLength, suffix);
         }
     }
 }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/util/HostNameBasedUniqueTicketIdGeneratorTests.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/util/HostNameBasedUniqueTicketIdGeneratorTests.java
@@ -13,7 +13,7 @@ public class HostNameBasedUniqueTicketIdGeneratorTests {
 
     @Test
     public void verifyUniqueGenerationOfTicketIds() throws Exception {
-        final HostNameBasedUniqueTicketIdGenerator generator = new HostNameBasedUniqueTicketIdGenerator(10);
+        final HostNameBasedUniqueTicketIdGenerator generator = new HostNameBasedUniqueTicketIdGenerator(10, "");
         final String id1 = generator.getNewTicketId("TEST");
         final String id2 = generator.getNewTicketId("TEST");
         assertNotSame(id1, id2);

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -23,12 +23,11 @@ server.prefix=${server.name}/cas
 # security configuration based on IP address to access the /status and /statistics pages
 # cas.securityContext.adminpages.ip=127\.0\.0\.1
 
-
 ##
 # Unique CAS node name
 # host.name is used to generate unique Service Ticket IDs and SAMLArtifacts.  This is usually set to the specific
 # hostname of the machine running the CAS node, but it could be any label so long as it is unique in the cluster.
-host.name=cas01.example.org
+# host.name=
 
 ##
 # JPA Ticket Registry Database Configuration


### PR DESCRIPTION
In order to reduce the noise in `cas.properties` in clustered deployments, allow `host.name` to be calculated automatically, if left undefined. 