### PR TITLE
Let hazelcast handle session and service ticket counts

### DIFF
--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/Ticket.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/Ticket.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 
  * @since 3.0.0
  */
-public interface Ticket extends Serializable {
+public interface Ticket extends Serializable, Comparable<Ticket> {
 
     /**
      * Method to retrieve the id.

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/AbstractTicket.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/AbstractTicket.java
@@ -159,4 +159,9 @@ public abstract class AbstractTicket implements Ticket, TicketState {
     public final String toString() {
         return this.getId();
     }
+
+    @Override
+    public int compareTo(final Ticket o) {
+        return getId().compareTo(o.getId());
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketDelegator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketDelegator.java
@@ -91,4 +91,9 @@ public abstract class AbstractTicketDelegator<T extends Ticket> implements Ticke
     public boolean equals(final Object o) {
         return this.ticket.equals(o);
     }
+
+    @Override
+    public int compareTo(final Ticket o) {
+        return this.ticket.compareTo(o);
+    }
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
@@ -230,7 +230,7 @@ public final class DefaultTicketRegistry extends AbstractTicketRegistry implemen
             final Collection<Ticket> ticketsToRemove = Collections2.filter(this.getTickets(), new Predicate<Ticket>() {
                 @Override
                 public boolean apply(@Nullable final Ticket ticket) {
-                    if (ticket.isExpired()) {
+                    if (ticket != null && ticket.isExpired()) {
                         if (ticket instanceof TicketGrantingTicket) {
                             logger.debug("Cleaning up expired ticket-granting ticket [{}]", ticket.getId());
                             logoutManager.performLogout((TicketGrantingTicket) ticket);
@@ -255,15 +255,17 @@ public final class DefaultTicketRegistry extends AbstractTicketRegistry implemen
     private boolean shouldScheduleCleanerJob() {
         if (this.startDelay > 0 && this.applicationContext.getParent() == null && scheduler != null) {
             if (WebUtils.isCasServletInitializing(this.applicationContext)) {
-                logger.debug("Found CAS servlet application context");
                 final String[] aliases =
                     this.applicationContext.getAutowireCapableBeanFactory().getAliases("defaultTicketRegistry");
 
                 if (aliases.length > 0) {
-                    logger.debug("{} is used as the active current ticket registry", this.getClass().getSimpleName());
+                    logger.debug("{} is used as the active current ticket registry", getClass().getSimpleName());
                     return true;
                 }
+                logger.debug("{} is not the current active ticket registry", getClass().getSimpleName());
                 return false;
+            } else {
+                logger.debug("Could not find CAS servlet application context");
             }
         }
 

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/encrypt/EncodedTicket.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/encrypt/EncodedTicket.java
@@ -81,4 +81,9 @@ public final class EncodedTicket implements Ticket {
         return new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE)
                 .append(this.id).build();
     }
+
+    @Override
+    public int compareTo(final Ticket o) {
+        return this.id.compareTo(o.getId());
+    }
 }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
@@ -3,6 +3,7 @@ package org.jasig.cas.mock;
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.ticket.ExpirationPolicy;
+import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
@@ -80,5 +81,15 @@ public class MockServiceTicket implements ServiceTicket {
     @Override
     public int getCountOfUses() {
         return 0;
+    }
+
+    @Override
+    public int compareTo(final Ticket o) {
+        return this.id.compareTo(o.getId());
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return compareTo((Ticket) obj) == 0;
     }
 }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
@@ -1,6 +1,7 @@
 package org.jasig.cas.mock;
 
 import org.jasig.cas.authentication.Authentication;
+import org.jasig.cas.authentication.Credential;
 import org.jasig.cas.authentication.DefaultAuthenticationBuilder;
 import org.jasig.cas.authentication.BasicCredentialMetaData;
 import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
@@ -8,8 +9,10 @@ import org.jasig.cas.authentication.CredentialMetaData;
 import org.jasig.cas.authentication.DefaultHandlerResult;
 import org.jasig.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler;
 import org.jasig.cas.authentication.principal.Service;
+import org.jasig.cas.services.TestUtils;
 import org.jasig.cas.ticket.ExpirationPolicy;
 import org.jasig.cas.ticket.ServiceTicket;
+import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.UniqueTicketIdGenerator;
 import org.jasig.cas.util.DefaultUniqueTicketIdGenerator;
@@ -45,17 +48,21 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
 
     private final Map<String, Service> services = new HashMap<>();
 
-    public MockTicketGrantingTicket(final String principal) {
+    public MockTicketGrantingTicket(final String principal, final Credential c, final Map attributes) {
         id = ID_GENERATOR.getNewTicketId("TGT");
-        final CredentialMetaData metaData = new BasicCredentialMetaData(
-                org.jasig.cas.authentication.TestUtils.getCredentialsWithSameUsernameAndPassword());
-        authentication = new DefaultAuthenticationBuilder(new DefaultPrincipalFactory().createPrincipal(principal))
-                            .addCredential(metaData)
-                            .addSuccess(SimpleTestUsernamePasswordAuthenticationHandler.class.getName(),
-                            new DefaultHandlerResult(new SimpleTestUsernamePasswordAuthenticationHandler(), metaData))
-                            .build();
+        final CredentialMetaData metaData = new BasicCredentialMetaData(c);
+        authentication = new DefaultAuthenticationBuilder(
+                new DefaultPrincipalFactory().createPrincipal(principal, attributes))
+                .addCredential(metaData)
+                .addSuccess(SimpleTestUsernamePasswordAuthenticationHandler.class.getName(),
+                        new DefaultHandlerResult(new SimpleTestUsernamePasswordAuthenticationHandler(), metaData))
+                .build();
 
         created = new Date();
+    }
+
+    public MockTicketGrantingTicket(final String principal) {
+        this(principal, TestUtils.getCredentialsWithDifferentUsernameAndPassword("uid", "password"), new HashMap());
     }
 
     @Override
@@ -140,5 +147,15 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
     @Override
     public void markTicketExpired() {
         expired = true;
+    }
+
+    @Override
+    public int compareTo(final Ticket o) {
+        return id.compareTo(o.getId());
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return compareTo((Ticket) obj) == 0;
     }
 }

--- a/cas-server-integration-hazelcast/build.gradle
+++ b/cas-server-integration-hazelcast/build.gradle
@@ -1,12 +1,12 @@
-
 description = 'Apereo CAS Hazelcast Integration'
 dependencies {
-	
-	compile project(':cas-server-core-tickets')
-	compile group: 'com.hazelcast', name: 'hazelcast', version:hazelcastVersion
-	testCompile project(path: ":cas-server-core-authentication", configuration: "tests")
-	testCompile project(':cas-server-core-util')
-	testCompile project(':cas-server-core-services')
-	testCompile project(path: ":cas-server-core-services", configuration: "tests")
+
+    compile project(':cas-server-core-tickets')
+    compile group: 'com.hazelcast', name: 'hazelcast', version: hazelcastVersion
+    testCompile project(path: ":cas-server-core-authentication", configuration: "tests")
+    testCompile project(':cas-server-core-util')
+    testCompile project(':cas-server-core-services')
+    testCompile project(path: ":cas-server-core-services", configuration: "tests")
+    testCompile project(path: ":cas-server-core-tickets", configuration: "tests")
 }
 

--- a/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -130,7 +130,7 @@ public class HazelcastTicketRegistry extends AbstractCrypticTicketRegistry imple
         }
 
         logger.debug("Removing ticket [{}] from the registry.", ticket);
-        return (this.registry.remove(encTicketId) != null);
+        return this.registry.remove(encTicketId) != null;
     }
 
     /**
@@ -151,7 +151,31 @@ public class HazelcastTicketRegistry extends AbstractCrypticTicketRegistry imple
             }
         }
     }
+    
+    @Override
+    public int sessionCount() {
+        int count = 0;
+        final Collection<Ticket> collection = getTickets();
+        for (final Ticket ticket : collection) {
+            if (ticket instanceof TicketGrantingTicket) {
+                count++;
+            }
+        }
+        return count;
+    }
 
+    @Override
+    public int serviceTicketCount() {
+        int count = 0;
+        final Collection<Ticket> collection = getTickets();
+        for (final Ticket ticket : collection) {
+            if (ticket instanceof ServiceTicket) {
+                count++;
+            }
+        }
+        return count;
+    }
+    
     @Override
     public Collection<Ticket> getTickets() {
         return decodeTickets(this.registry.values());

--- a/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -2,6 +2,8 @@ package org.jasig.cas.ticket.registry;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.Supplier;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
@@ -178,7 +180,8 @@ public class HazelcastTicketRegistry extends AbstractCrypticTicketRegistry imple
     
     @Override
     public Collection<Ticket> getTickets() {
-        return decodeTickets(this.registry.values());
+        final Collection collection = this.registry.aggregate(Supplier.all(), Aggregations.distinctValues());
+        return decodeTickets(collection);
     }
 
     /**

--- a/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -47,6 +47,16 @@ public class HazelcastTicketRegistryTests {
     }
 
     @Test
+    public void retrieveCollectionOfTickets() {
+        this.hzTicketRegistry1.addTicket(newTestTgt());
+        this.hzTicketRegistry1.addTicket(newTestSt());
+        assertEquals(2, hzTicketRegistry2.getTickets().size());
+        assertEquals(1, hzTicketRegistry2.serviceTicketCount());
+        assertEquals(1, hzTicketRegistry2.sessionCount());
+        
+    }
+    
+    @Test
     public void basicOperationsAndClustering() throws Exception {
         this.hzTicketRegistry1.addTicket(newTestTgt());
 

--- a/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -1,24 +1,21 @@
 package org.jasig.cas.ticket.registry;
 
-import org.jasig.cas.authentication.Authentication;
-
 import org.jasig.cas.authentication.principal.Service;
+import org.jasig.cas.mock.MockServiceTicket;
+import org.jasig.cas.mock.MockTicketGrantingTicket;
 import org.jasig.cas.services.TestUtils;
-import org.jasig.cas.ticket.ExpirationPolicy;
-import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 import org.jasig.cas.ticket.ServiceTicket;
+import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
-import org.jasig.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.jasig.cas.ticket.TicketGrantingTicketImpl;
-
+import org.jasig.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Collection;
 
 import static org.junit.Assert.*;
 
@@ -48,26 +45,38 @@ public class HazelcastTicketRegistryTests {
 
     @Test
     public void retrieveCollectionOfTickets() {
-        this.hzTicketRegistry1.addTicket(newTestTgt());
-        this.hzTicketRegistry1.addTicket(newTestSt());
-        assertEquals(2, hzTicketRegistry2.getTickets().size());
+        Collection<Ticket> col = this.hzTicketRegistry1.getTickets();
+        for (final Ticket ticket : col) {
+            this.hzTicketRegistry1.deleteTicket(ticket.getId());
+        }
+
+        col = hzTicketRegistry2.getTickets();
+        assertEquals(0, col.size());
+
+        final TicketGrantingTicket tgt = newTestTgt();
+        this.hzTicketRegistry1.addTicket(tgt);
+
+        this.hzTicketRegistry1.addTicket(newTestSt(tgt));
+
+        col = hzTicketRegistry2.getTickets();
+        assertEquals(2, col.size());
         assertEquals(1, hzTicketRegistry2.serviceTicketCount());
         assertEquals(1, hzTicketRegistry2.sessionCount());
-        
     }
     
     @Test
     public void basicOperationsAndClustering() throws Exception {
-        this.hzTicketRegistry1.addTicket(newTestTgt());
+        final TicketGrantingTicket tgt = newTestTgt();
+        this.hzTicketRegistry1.addTicket(tgt);
 
-        assertNotNull(this.hzTicketRegistry1.getTicket("TGT-TEST"));
-        assertNotNull(this.hzTicketRegistry2.getTicket("TGT-TEST"));
-        assertTrue(this.hzTicketRegistry2.deleteTicket("TGT-TEST"));
-        assertFalse(this.hzTicketRegistry1.deleteTicket("TGT-TEST"));
-        assertNull(this.hzTicketRegistry1.getTicket("TGT-TEST"));
-        assertNull(this.hzTicketRegistry2.getTicket("TGT-TEST"));
+        assertNotNull(this.hzTicketRegistry1.getTicket(tgt.getId()));
+        assertNotNull(this.hzTicketRegistry2.getTicket(tgt.getId()));
+        assertTrue(this.hzTicketRegistry2.deleteTicket(tgt.getId()));
+        assertFalse(this.hzTicketRegistry1.deleteTicket(tgt.getId()));
+        assertNull(this.hzTicketRegistry1.getTicket(tgt.getId()));
+        assertNull(this.hzTicketRegistry2.getTicket(tgt.getId()));
 
-        final ServiceTicket st = newTestSt();
+        final ServiceTicket st = newTestSt(tgt);
         this.hzTicketRegistry2.addTicket(st);
 
         assertNotNull(this.hzTicketRegistry1.getTicket("ST-TEST"));
@@ -97,157 +106,26 @@ public class HazelcastTicketRegistryTests {
         this.hzTicketRegistry1.addTicket(st2);
         this.hzTicketRegistry1.addTicket(st3);
 
-        assertNotNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.hzTicketRegistry1.getTicket(tgt.getId(), TicketGrantingTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
 
         this.hzTicketRegistry1.deleteTicket(tgt.getId());
 
-        assertNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket(tgt.getId(), TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
     }
 
     private TicketGrantingTicket newTestTgt() {
-        return new MockTgt();
+        return new MockTicketGrantingTicket("casuser");
     }
 
-    private ServiceTicket newTestSt() {
-        return new MockSt();
+    private ServiceTicket newTestSt(final TicketGrantingTicket tgt) {
+        return new MockServiceTicket("ST-TEST", TestUtils.getService(), tgt);
     }
 
-    private static class MockTgt implements TicketGrantingTicket {
 
-        @Override
-        public Service getProxiedBy() {
-            return null;
-        }
-
-        @Override
-        public Authentication getAuthentication() {
-            return null;
-        }
-
-        @Override
-        public List<Authentication> getSupplementalAuthentications() {
-            return null;
-        }
-
-        @Override
-        public ServiceTicket grantServiceTicket(final String id,
-                                                final Service service,
-                                                final ExpirationPolicy expirationPolicy,
-                                                final boolean credentialsProvided,
-                                                final boolean onlyTrackMostRecentSession) {
-            return null;
-        }
-
-        @Override
-        public Map<String, Service> getServices() {
-            return null;
-        }
-
-        @Override
-        public void removeAllServices() {
-
-        }
-
-        @Override
-        public void markTicketExpired() {
-
-        }
-
-        @Override
-        public boolean isRoot() {
-            return false;
-        }
-
-        @Override
-        public TicketGrantingTicket getRoot() {
-            return null;
-        }
-
-        @Override
-        public List<Authentication> getChainedAuthentications() {
-            return null;
-        }
-
-        @Override
-        public String getId() {
-            return "TGT-TEST";
-        }
-
-        @Override
-        public boolean isExpired() {
-            return false;
-        }
-
-        @Override
-        public TicketGrantingTicket getGrantingTicket() {
-            return this;
-        }
-
-        @Override
-        public long getCreationTime() {
-            return 0;
-        }
-
-        @Override
-        public int getCountOfUses() {
-            return 0;
-        }
-    }
-
-    private static class MockSt implements ServiceTicket {
-        private static final long serialVersionUID = -761672450629794769L;
-
-        @Override
-        public Service getService() {
-            return null;
-        }
-
-        @Override
-        public boolean isFromNewLogin() {
-            return false;
-        }
-
-        @Override
-        public boolean isValidFor(final Service service) {
-            return false;
-        }
-
-        @Override
-        public ProxyGrantingTicket grantProxyGrantingTicket(final String id,
-                                                            final Authentication authentication,
-                                                            final ExpirationPolicy expirationPolicy) {
-            return null;
-        }
-
-        @Override
-        public String getId() {
-            return "ST-TEST";
-        }
-
-        @Override
-        public boolean isExpired() {
-            return false;
-        }
-
-        @Override
-        public TicketGrantingTicket getGrantingTicket() {
-            return null;
-        }
-
-        @Override
-        public long getCreationTime() {
-            return 0;
-        }
-
-        @Override
-        public int getCountOfUses() {
-            return 0;
-        }
-    }
 }

--- a/cas-server-integration-hazelcast/src/test/resources/HazelcastTicketRegistryTests-context.xml
+++ b/cas-server-integration-hazelcast/src/test/resources/HazelcastTicketRegistryTests-context.xml
@@ -111,6 +111,7 @@
         <constructor-arg name="mapName" value="tickets"/>
         <constructor-arg name="ticketGrantingTicketTimeoutInSeconds" value="10"/>
         <constructor-arg name="serviceTicketTimeoutInSeconds" value="10"/>
+        <constructor-arg name="pageSize" value="100"/>
     </bean>
 
     <bean id="hzTicketRegistry2"
@@ -119,6 +120,7 @@
         <constructor-arg name="mapName" value="tickets"/>
         <constructor-arg name="ticketGrantingTicketTimeoutInSeconds" value="10"/>
         <constructor-arg name="serviceTicketTimeoutInSeconds" value="10"/>
+        <constructor-arg name="pageSize" value="100"/>
     </bean>
 
 </beans>

--- a/cas-server-integration-memcached/build.gradle
+++ b/cas-server-integration-memcached/build.gradle
@@ -1,46 +1,46 @@
-
 description = 'Apereo CAS Memcached Integration'
 dependencies {
-  compile(group: 'org.springframework', name: 'spring-core', version:springVersion) {
-    exclude(group: 'commons-logging', module: 'commons-logging')
-  }
-  compile group: 'org.springframework', name: 'spring-beans', version:springVersion
-  compile group: 'org.springframework', name: 'spring-context-support', version:springVersion
-  compile group: 'org.springframework', name: 'spring-context', version:springVersion
-  
-  compile project(':cas-server-core-logging')
-  compile project(':cas-server-core-tickets')
-  compile project(':cas-server-core-services')
-  compile group: 'net.spy', name: 'spymemcached', version:spymemcachedVersion
-  compile(group: 'com.esotericsoftware', name: 'kryo', version:kryoVersion) {
-    exclude(group: 'net.spy', module: 'spymemcached')
-  }
-  compile(group: 'de.javakaffee', name: 'kryo-serializers', version:kryoSerializersVersion) {
-    exclude(group: 'com.esotericsoftware.kryo', module: 'kryo')
-  }
-  testCompile project(':cas-server-core-util')
-  testCompile(group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.memcached', version:memcachedEmbeddedVersion) {
-    exclude(group: 'org.apache.commons', module: 'commons-lang3')  
-    exclude(group: 'net.spy', module: 'spymemcached')
-    exclude(group: 'org.slf4j', module: 'slf4j-api')
-  }
-  testCompile project(path: ":cas-server-core-authentication", configuration: "tests")
-  testCompile project(path: ":cas-server-core-services", configuration: "tests")
-  testCompile(group: 'org.hibernate', name: 'hibernate-validator', version:hibernateValidatorVersion) {
-    exclude(group: 'org.slf4j', module: 'slf4j-api')
-    exclude(group: 'org.jboss.logging', module: 'jboss-logging')
-  }
-  testCompile(group: 'com.ryantenney.metrics', name: 'metrics-spring', version:dropwizardMetricsVersion) {
-    exclude(group: 'org.slf4j', module: 'slf4j-api')
-    exclude(group: 'org.springframework', module: 'spring-core')
-    exclude(group: 'org.springframework', module: 'spring-beans')
-    exclude(group: 'org.springframework', module: 'spring-context-support')
-    exclude(group: 'org.springframework', module: 'spring-aop')
-  }
-  provided(project(':cas-server-support-saml')) {
-    exclude(group: 'xml-apis', module: 'xml-apis')
-  }
-  provided project(':cas-server-support-saml-googleapps')
+    compile(group: 'org.springframework', name: 'spring-core', version: springVersion) {
+        exclude(group: 'commons-logging', module: 'commons-logging')
+    }
+    compile group: 'org.springframework', name: 'spring-beans', version: springVersion
+    compile group: 'org.springframework', name: 'spring-context-support', version: springVersion
+    compile group: 'org.springframework', name: 'spring-context', version: springVersion
+
+    compile project(':cas-server-core-logging')
+    compile project(':cas-server-core-tickets')
+    compile project(':cas-server-core-services')
+    compile group: 'net.spy', name: 'spymemcached', version: spymemcachedVersion
+    compile(group: 'com.esotericsoftware', name: 'kryo', version: kryoVersion) {
+        exclude(group: 'net.spy', module: 'spymemcached')
+    }
+    compile(group: 'de.javakaffee', name: 'kryo-serializers', version: kryoSerializersVersion) {
+        exclude(group: 'com.esotericsoftware.kryo', module: 'kryo')
+    }
+    testCompile project(':cas-server-core-util')
+    testCompile(group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.memcached', version: memcachedEmbeddedVersion) {
+        exclude(group: 'org.apache.commons', module: 'commons-lang3')
+        exclude(group: 'net.spy', module: 'spymemcached')
+        exclude(group: 'org.slf4j', module: 'slf4j-api')
+    }
+    testCompile project(path: ":cas-server-core-authentication", configuration: "tests")
+    testCompile project(path: ":cas-server-core-services", configuration: "tests")
+    testCompile project(path: ":cas-server-core-tickets", configuration: "tests")
+    testCompile(group: 'org.hibernate', name: 'hibernate-validator', version: hibernateValidatorVersion) {
+        exclude(group: 'org.slf4j', module: 'slf4j-api')
+        exclude(group: 'org.jboss.logging', module: 'jboss-logging')
+    }
+    testCompile(group: 'com.ryantenney.metrics', name: 'metrics-spring', version: dropwizardMetricsVersion) {
+        exclude(group: 'org.slf4j', module: 'slf4j-api')
+        exclude(group: 'org.springframework', module: 'spring-core')
+        exclude(group: 'org.springframework', module: 'spring-beans')
+        exclude(group: 'org.springframework', module: 'spring-context-support')
+        exclude(group: 'org.springframework', module: 'spring-aop')
+    }
+    provided(project(':cas-server-support-saml')) {
+        exclude(group: 'xml-apis', module: 'xml-apis')
+    }
+    provided project(':cas-server-support-saml-googleapps')
 }
 
 

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -3,43 +3,34 @@ package org.jasig.cas.ticket.registry.support.kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import net.spy.memcached.CachedData;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jasig.cas.authentication.AcceptUsersAuthenticationHandler;
-import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.AuthenticationBuilder;
 import org.jasig.cas.authentication.AuthenticationHandler;
 import org.jasig.cas.authentication.BasicCredentialMetaData;
 import org.jasig.cas.authentication.Credential;
-import org.jasig.cas.authentication.CredentialMetaData;
 import org.jasig.cas.authentication.DefaultAuthenticationBuilder;
 import org.jasig.cas.authentication.DefaultHandlerResult;
 import org.jasig.cas.authentication.HttpBasedServiceCredential;
 import org.jasig.cas.authentication.PreventedException;
-import org.jasig.cas.authentication.RememberMeCredential;
 import org.jasig.cas.authentication.UsernamePasswordCredential;
 import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
-import org.jasig.cas.authentication.principal.PrincipalFactory;
-import org.jasig.cas.authentication.principal.Service;
+import org.jasig.cas.mock.MockServiceTicket;
+import org.jasig.cas.mock.MockTicketGrantingTicket;
 import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.TestUtils;
-import org.jasig.cas.ticket.ExpirationPolicy;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.TicketGrantingTicketImpl;
-import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 import org.jasig.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
 import javax.security.auth.login.AccountNotFoundException;
-import javax.security.auth.login.FailedLoginException;
-import javax.validation.constraints.NotNull;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -121,12 +112,12 @@ public class KryoTranscoderTests {
 
     @Test
     public void verifyEncodeDecode() throws Exception {
-        final ServiceTicket expectedST =
-                new MockServiceTicket(ST_ID);
+        final TicketGrantingTicket tgt = new MockTicketGrantingTicket(USERNAME);
+        final ServiceTicket expectedST = new MockServiceTicket(ST_ID, TestUtils.getService(), tgt);
         assertEquals(expectedST, transcoder.decode(transcoder.encode(expectedST)));
 
         final Credential userPassCredential = new UsernamePasswordCredential(USERNAME, PASSWORD);
-        final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(TGT_ID, userPassCredential, this.principalAttributes);
+        final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(USERNAME);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
         assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
 
@@ -136,7 +127,7 @@ public class KryoTranscoderTests {
 
     private void internalProxyTest(final String proxyUrl) throws MalformedURLException {
         final Credential proxyCredential = new HttpBasedServiceCredential(new URL(proxyUrl), TestUtils.getRegisteredService("https://.+"));
-        final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(TGT_ID, proxyCredential, this.principalAttributes);
+        final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(USERNAME);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
         assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
     }
@@ -216,214 +207,6 @@ public class KryoTranscoderTests {
     public void verifyEncodeDecodeRegisteredService() throws Exception {
         final RegisteredService service = TestUtils.getRegisteredService("helloworld");
         assertEquals(service, transcoder.decode(transcoder.encode(service)));
-    }
-
-    private static class MockServiceTicket implements ServiceTicket {
-
-        private static final long serialVersionUID = -206395373480723831L;
-        private String id;
-
-        MockServiceTicket() { /* for serialization */ }
-
-        MockServiceTicket(final String id) {
-            this.id = id;
-        }
-
-        @Override
-        public Service getService() {
-            return null;
-        }
-
-        @Override
-        public boolean isFromNewLogin() {
-            return false;
-        }
-
-        @Override
-        public boolean isValidFor(final Service service) {
-            return false;
-        }
-
-        @Override
-        public ProxyGrantingTicket grantProxyGrantingTicket(final String id, final Authentication authentication,
-                                                            final ExpirationPolicy expirationPolicy) {
-            return null;
-        }
-
-        @Override
-        public String getId() {
-            return id;
-        }
-
-        @Override
-        public boolean isExpired() {
-            return false;
-        }
-
-        @Override
-        public TicketGrantingTicket getGrantingTicket() {
-            return null;
-        }
-
-        @Override
-        public long getCreationTime() {
-            return 0;
-        }
-
-        @Override
-        public int getCountOfUses() {
-            return 0;
-        }
-
-        @Override
-        public boolean equals(final Object other) {
-            return other instanceof MockServiceTicket && ((MockServiceTicket) other).getId().equals(id);
-        }
-
-        @Override
-        public int hashCode() {
-            final HashCodeBuilder bldr = new HashCodeBuilder(17, 33);
-            return bldr.append(this.id)
-                       .toHashCode();
-        }
-    }
-
-    private static class MockTicketGrantingTicket implements TicketGrantingTicket {
-
-        private static final long serialVersionUID = 4829406617873497061L;
-
-        private final String id;
-
-        private int usageCount;
-
-        private Service proxiedBy;
-
-        private final Date creationDate = new Date();
-
-        private final Authentication authentication;
-
-        /** Factory to create the principal type. **/
-        @NotNull
-        private final PrincipalFactory principalFactory = new DefaultPrincipalFactory();
-
-        /** Constructor for serialization support. */
-        MockTicketGrantingTicket() {
-            this.id = null;
-            this.authentication = null;
-        }
-
-        MockTicketGrantingTicket(final String id, final Credential credential, final Map<String, Object> principalAttributes) {
-            this.id = id;
-            final CredentialMetaData credentialMetaData = new BasicCredentialMetaData(credential);
-            final AuthenticationBuilder builder = new DefaultAuthenticationBuilder();
-            builder.setPrincipal(this.principalFactory.createPrincipal(USERNAME, principalAttributes));
-            builder.setAuthenticationDate(new DateTime());
-            builder.addCredential(credentialMetaData);
-            builder.addAttribute(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, Boolean.TRUE);
-            final AuthenticationHandler handler = new MockAuthenticationHandler();
-            try {
-                builder.addSuccess(handler.getName(), handler.authenticate(credential));
-            } catch (final Exception e) {
-                throw new RuntimeException(e);
-            }
-            builder.addFailure(handler.getName(), FailedLoginException.class);
-            this.authentication = builder.build();
-        }
-
-        @Override
-        public Authentication getAuthentication() {
-            return this.authentication;
-        }
-
-        @Override
-        public List<Authentication> getSupplementalAuthentications() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public ServiceTicket grantServiceTicket(
-                final String id,
-                final Service service,
-                final ExpirationPolicy expirationPolicy,
-                final boolean credentialsProvided,
-                final boolean onlyTrackMostRecentSession) {
-            this.usageCount++;
-            return new MockServiceTicket(id);
-        }
-
-        @Override
-        public Service getProxiedBy() {
-            return proxiedBy;
-        }
-
-        @Override
-        public Map<String, Service> getServices() {
-            return Collections.emptyMap();
-        }
-
-        @Override
-        public void removeAllServices() {}
-
-        @Override
-        public void markTicketExpired() {}
-
-        @Override
-        public boolean isRoot() {
-            return true;
-        }
-
-        @Override
-        public TicketGrantingTicket getRoot() {
-            return this;
-        }
-
-        @Override
-        public List<Authentication> getChainedAuthentications() {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public String getId() {
-            return this.id;
-        }
-
-        @Override
-        public boolean isExpired() {
-            return false;
-        }
-
-        @Override
-        public TicketGrantingTicket getGrantingTicket() {
-            return this;
-        }
-
-        @Override
-        public long getCreationTime() {
-            return this.creationDate.getTime();
-        }
-
-        @Override
-        public int getCountOfUses() {
-            return this.usageCount;
-        }
-
-        @Override
-        public boolean equals(final Object other) {
-            return other instanceof MockTicketGrantingTicket
-                    && ((MockTicketGrantingTicket) other).getId().equals(this.id)
-                    && ((MockTicketGrantingTicket) other).getCountOfUses() == this.usageCount
-                    && ((MockTicketGrantingTicket) other).getCreationTime() == this.creationDate.getTime()
-                    && ((MockTicketGrantingTicket) other).getAuthentication().equals(this.authentication);
-        }
-
-        @Override
-        public int hashCode() {
-            final HashCodeBuilder bldr = new HashCodeBuilder(17, 33);
-            return bldr.append(this.id)
-                        .append(this.usageCount)
-                        .append(this.creationDate.getTime())
-                        .append(this.authentication).toHashCode();
-        }
     }
 
     private static class MockAuthenticationHandler implements AuthenticationHandler {

--- a/cas-server-webapp-validation/src/main/java/org/jasig/cas/web/view/Cas30JsonResponseView.java
+++ b/cas-server-webapp-validation/src/main/java/org/jasig/cas/web/view/Cas30JsonResponseView.java
@@ -43,7 +43,7 @@ public class Cas30JsonResponseView extends Cas30ResponseView {
      */
     public Cas30JsonResponseView() {
         super(createDelegatedView());
-        logger.debug("Rendering {}", this.getClass().getSimpleName());
+        logger.debug("Initialized {}", this.getClass().getSimpleName());
     }
 
     private static MappingJackson2JsonView createDelegatedView() {

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/monitoring/viewSsoSessions.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/monitoring/viewSsoSessions.jsp
@@ -134,10 +134,7 @@ principalAttributes(d.principal_attributes) +
             var factory = {};
             factory.httpHeaders = {};
             factory.messages = {};
-            factory.httpHeaders[ $("meta[name='_csrf_header']").attr("content") ] = $("meta[name='_csrf']").attr("content");
-
             factory.ticketId = ticketId;
-
 
             if (ticketId && (ticketId == 'ALL' || ticketId == 'PROXIED' || ticketId == 'DIRECT' ) ) {
                 factory.url = '/cas/statistics/ssosessions/destroySsoSessions';

--- a/gradle.properties
+++ b/gradle.properties
@@ -68,7 +68,7 @@ jradiusVersion=jradius-1.1.5
 
 httpclientVersion=4.5.1
 
-hazelcastVersion=3.6
+hazelcastVersion=3.6.2
 
 memcachedEmbeddedVersion=1.06.2
 spymemcachedVersion=2.12.0


### PR DESCRIPTION
Allow Hazelcast ticket registry to support session/service ticket count operations. 

Also fixed an issue with the sso sessions report where ops could not be completed due to missing CSRF settings.

this will be selectively ported forward to master. 
