### PR TITLE
Log under ERROR when principal id attribute is not found during LDAP AuthN

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
@@ -228,6 +228,9 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
         if (this.principalIdAttribute != null) {
             final LdapAttribute principalAttr = ldapEntry.getAttribute(this.principalIdAttribute);
             if (principalAttr == null || principalAttr.size() == 0) {
+                logger.error("The principal id attribute {} is not found. CAS cannot construct the final authenticated principal "
+                        + "if it's unable to locate the attribute that is designated as the principal id. Attributes available are {}",
+                        this.principalIdAttribute, ldapEntry.getAttributes());
                 throw new LoginException(this.principalIdAttribute + " attribute not found for " + username);
             }
 


### PR DESCRIPTION
When the principal id attribute is not found for LDAP authentication, log an explicit error.  Presently, errors as such are marked under DEBUG to reduce log noise.