### PR TITLE
IgniteTicketRegistryConfiguration bean references itself

### DIFF
--- a/cas-server-integration-ignite/src/main/java/org/jasig/cas/config/IgniteTicketRegistryConfiguration.java
+++ b/cas-server-integration-ignite/src/main/java/org/jasig/cas/config/IgniteTicketRegistryConfiguration.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  * @author Misagh Moayyed
  * @since 5.0.0
  */
-@Configuration("igniteConfiguration")
+@Configuration("igniteTicketRegistryConfiguration")
 public class IgniteTicketRegistryConfiguration {
     
     /**

--- a/cas-server-integration-ignite/src/main/java/org/jasig/cas/config/IgniteTicketRegistryConfiguration.java
+++ b/cas-server-integration-ignite/src/main/java/org/jasig/cas/config/IgniteTicketRegistryConfiguration.java
@@ -66,7 +66,7 @@ public class IgniteTicketRegistryConfiguration {
      * @return the ignite configuration
      */
     @Bean(name = "igniteConfiguration")
-    private IgniteConfiguration igniteConfiguration() {
+    public IgniteConfiguration igniteConfiguration() {
         final IgniteConfiguration config = new IgniteConfiguration();
         final TcpDiscoverySpi spi = new TcpDiscoverySpi();
         final TcpDiscoveryVmIpFinder finder = new TcpDiscoveryVmIpFinder();


### PR DESCRIPTION
changes the name of the configuration bean since it contains another bean with the same name.

igniteConfiguration -> igniteTicketRegistryConfiguration
