### PR TITLE
Let RegisteredServiceThemeBasedViewResolver be default

### DIFF
--- a/cas-server-documentation/installation/User-Interface-Customization.md
+++ b/cas-server-documentation/installation/User-Interface-Customization.md
@@ -276,30 +276,25 @@ Note that support for themes comes with the following components:
 | `RegisteredServiceThemeBasedViewResolver` | If there is a need to present an entirely new set of views for a given service, such that the structure and layout of the page needs an overhaul with additional icons, images, text, etc then this component` needs to be configured. This component will have the ability to resolve a new set of views that may entirely be different from the default JSPs. The `theme` property of a given registered service in the Service Registry will still need to be configured to note the set of views that are to be loaded.
 
 
-### `ServiceThemeResolver`
+### Dynamic
 Configuration of service-specific themes is backed by the Spring framework and provided by the following component:
 
-Furthermore, deployers may be able to use the functionality provided by the `ThemeChangeInterceptor` of Spring framework to provide theme configuration per each request.
+Furthermore, deployers may be able to use the functionality provided by the `ThemeChangeInterceptor` of 
+Spring framework to provide theme configuration per each request.
 
 #### Configuration
-- Add another theme properties file, which must be placed to the root of `/WEB-INF/classes` folder, name it as `theme_name.properties`. Contents of this file should match the `cas-theme-default.properties` file.
+- Add another theme properties file, which must be placed to the root of `/WEB-INF/classes` folder, name it as `theme_name.properties`. 
+Contents of this file should match the `cas-theme-default.properties` file.
 - Add the location of related styling files, such as CSS and Javascript in the file above.
 - Specify the name of your theme for the service definition under the `theme` property.
 
-### `RegisteredServiceThemeBasedViewResolver`
-`RegisteredServiceThemeBasedViewResolver` is an alternate Spring View Resolver that utilizes a service's
-associated theme to selectively choose which set of UI views will be used to generate the standard views (`casLoginView.jsp`, etc). This is specially useful in cases where the set of pages for a theme that are targeted
+### Per Application
+Alternatively, CAS utilizes a service's
+associated theme to selectively choose which set of UI views will be used to generate the standard views (`casLoginView.jsp`, etc). 
+This is specially useful in cases where the set of pages for a theme that are targeted
 for a different type of audience are entirely different structurally that simply
-using the `ServiceThemeResolver` is not practical to augment the default views. In such cases, new view pages may be required.
+using the dynamic mode is not practical to augment the default views. In such cases, new view pages may be required.
 
-Views associated with a particular theme by default are expected to be found at: `/WEB-INF/view/jsp/<theme-id>/ui/`
-
-```html
-<bean id="internalViewResolver" class="org.jasig.cas.services.web.RegisteredServiceThemeBasedViewResolver"
-        c:servicesManager-ref="servicesManager"
-        p:prefix="${cas.themeResolver.pathprefix:/WEB-INF/view/jsp/}"
-        p:order="2001"/>
-```
 
 #### Configuration
 - Clone the default set of view pages into a new directory based on the theme id (i.e. `/WEB-INF/view/jsp/<theme-id>/ui/`).

--- a/cas-server-documentation/installation/Webflow-Customization.md
+++ b/cas-server-documentation/installation/Webflow-Customization.md
@@ -8,7 +8,8 @@ title: CAS - Webflow Customization
 CAS uses [Spring Web Flow](projects.spring.io/spring-webflow) to do "script" processing of login and logout protocols. 
 Spring Web Flow builds on Spring MVC and allows implementing the "flows" of a web application. A flow encapsulates a sequence 
 of steps that guide a user through the execution of some business task. It spans multiple HTTP requests, has state, deals with
- transactional data, is reusable, and may be dynamic and long-running in nature. Each flow may contain among many other settings the following major elements:
+transactional data, is reusable, and may be dynamic and long-running in nature. Each flow may contain among many other 
+settings the following major elements:
 
 - Actions: components that describe an executable task and return back a result
 - Transitions: Routing the flow from one state to another; Transitions may be global to the entire flow.

--- a/cas-server-webapp-themes/src/main/java/org/jasig/cas/services/web/RegisteredServiceThemeBasedViewResolver.java
+++ b/cas-server-webapp-themes/src/main/java/org/jasig/cas/services/web/RegisteredServiceThemeBasedViewResolver.java
@@ -129,4 +129,7 @@ public final class RegisteredServiceThemeBasedViewResolver extends InternalResou
         super.setCache(false);
     }
 
+    public void setResourceLoader(final ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
 }

--- a/cas-server-webapp-themes/src/main/java/org/jasig/cas/services/web/RegisteredServiceThemeBasedViewResolver.java
+++ b/cas-server-webapp-themes/src/main/java/org/jasig/cas/services/web/RegisteredServiceThemeBasedViewResolver.java
@@ -7,6 +7,9 @@ import org.jasig.cas.web.support.WebUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.view.AbstractUrlBasedView;
 import org.springframework.web.servlet.view.InternalResourceView;
@@ -40,11 +43,10 @@ public final class RegisteredServiceThemeBasedViewResolver extends InternalResou
     private static final Logger LOGGER = LoggerFactory.getLogger(RegisteredServiceThemeBasedViewResolver.class);
     private static final String THEME_LOCATION_PATTERN = "%s/%s/ui/";
 
-    /**
-     * The ServiceRegistry to look up the service.
-     */
     private final ServicesManager servicesManager;
 
+    @Autowired
+    private ResourceLoader resourceLoader;
 
     /**
      * The {@link RegisteredServiceThemeBasedViewResolver} constructor.
@@ -90,7 +92,11 @@ public final class RegisteredServiceThemeBasedViewResolver extends InternalResou
             LOGGER.debug("Prefix [{}] set for service [{}] with theme [{}]", themePrefix, service,
                 registeredService.getTheme());
             final String viewUrl = themePrefix + viewName + getSuffix();
-            view.setUrl(viewUrl);
+
+            final Resource resource = this.resourceLoader.getResource(viewUrl);
+            if (resource.exists()) {
+                view.setUrl(viewUrl);
+            }
 
         }
 

--- a/cas-server-webapp-themes/src/test/java/org/jasig/cas/services/web/RegisteredServiceThemeBasedViewResolverTests.java
+++ b/cas-server-webapp-themes/src/test/java/org/jasig/cas/services/web/RegisteredServiceThemeBasedViewResolverTests.java
@@ -8,6 +8,8 @@ import org.jasig.cas.services.RegisteredServiceImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockRequestContext;
 
@@ -46,6 +48,7 @@ public class RegisteredServiceThemeBasedViewResolverTests {
 
         this.registeredServiceThemeBasedViewResolver = new RegisteredServiceThemeBasedViewResolver(this.servicesManager);
         this.registeredServiceThemeBasedViewResolver.setPrefix("/WEB-INF/view/jsp");
+
     }
 
     @Test
@@ -55,6 +58,13 @@ public class RegisteredServiceThemeBasedViewResolverTests {
 
         final WebApplicationService webApplicationService = new WebApplicationServiceFactory().createService("myServiceId");
         requestContext.getFlowScope().put("service", webApplicationService);
+
+        final ResourceLoader loader = mock(ResourceLoader.class);
+        final Resource resource = mock(Resource.class);
+        when(resource.exists()).thenReturn(true);
+        when(loader.getResource(anyString())).thenReturn(resource);
+
+        this.registeredServiceThemeBasedViewResolver.setResourceLoader(loader);
 
         assertEquals("/WEB-INF/view/jsp/myTheme/ui/casLoginView",
                 this.registeredServiceThemeBasedViewResolver.buildView("casLoginView").getUrl());

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -35,13 +35,6 @@
           p:suffix=".jsp"
           p:order="2000"/>
 
-    <!--
-    <bean id="internalViewResolver" class="org.jasig.cas.services.web.RegisteredServiceThemeBasedViewResolver"
-            c:servicesManager-ref="servicesManager"
-            p:prefix="${cas.themeResolver.pathprefix:/WEB-INF/view/jsp}"
-            p:order="2001"/>
-    -->
-
     <!-- Locale Resolver -->
     <bean id="localeResolver" class="org.springframework.web.servlet.i18n.CookieLocaleResolver"
           p:defaultLocale="${locale.default:en}"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/webflowContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/webflowContext.xml
@@ -59,11 +59,10 @@
         </property>
     </bean>
 
-    <bean id="internalViewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver"
-          p:viewClass="org.springframework.web.servlet.view.JstlView"
-          p:prefix="${cas.themeResolver.pathprefix:/WEB-INF/view/jsp}/default/ui/"
+    <bean id="internalViewResolver" class="org.jasig.cas.services.web.RegisteredServiceThemeBasedViewResolver"
+          c:servicesManager-ref="servicesManager"
           p:suffix=".jsp"
+          p:prefix="${cas.themeResolver.pathprefix:/WEB-INF/view/jsp}"
           p:order="10000"/>
-
 
 </beans>


### PR DESCRIPTION
This patch allows the deployer to automatically create theme-specific views without having to configure the actual resolver configuration. By default, CAS native views are used. If a theme is found with views that exist, those are rendered instead. 

Once the views are selected and rendered, the `theme` parameter may also be used to decorate settings by CSS, etc. 
