### PR TITLE
Deprecate Supplemental Authentications

### DIFF
--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
@@ -28,12 +28,14 @@ public interface TicketGrantingTicket extends Ticket {
     Authentication getAuthentication();
 
     /**
+     * @deprecated As of 4.2.x
      * Gets a list of supplemental authentications associated with this ticket.
      * A supplemental authentication is one other than the one used to create the ticket,
      * for example, a forced authentication that happens after the beginning of a CAS SSO session.
      *
      * @return Non-null list of supplemental authentications.
      */
+    @Deprecated
     List<Authentication> getSupplementalAuthentications();
 
     /**

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/TicketGrantingTicketDelegator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/TicketGrantingTicketDelegator.java
@@ -23,9 +23,9 @@ public class TicketGrantingTicketDelegator<T extends TicketGrantingTicket> exten
     /**
      * Instantiates a new ticket granting ticket delegator.
      *
-     * @param ticketRegistry the ticket registry
+     * @param ticketRegistry       the ticket registry
      * @param ticketGrantingTicket the ticket granting ticket
-     * @param callback the callback
+     * @param callback             the callback
      */
     TicketGrantingTicketDelegator(final AbstractDistributedTicketRegistry ticketRegistry,
                                   final T ticketGrantingTicket, final boolean callback) {
@@ -42,7 +42,6 @@ public class TicketGrantingTicketDelegator<T extends TicketGrantingTicket> exten
         return getTicket().getProxiedBy();
     }
     
-    @Deprecated
     @Override
     public List<Authentication> getSupplementalAuthentications() {
         return getTicket().getSupplementalAuthentications();

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/TicketGrantingTicketDelegator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/TicketGrantingTicketDelegator.java
@@ -41,7 +41,8 @@ public class TicketGrantingTicketDelegator<T extends TicketGrantingTicket> exten
     public Service getProxiedBy() {
         return getTicket().getProxiedBy();
     }
-
+    
+    @Deprecated
     @Override
     public List<Authentication> getSupplementalAuthentications() {
         return getTicket().getSupplementalAuthentications();

--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -184,6 +184,16 @@ public final class CentralAuthenticationServiceImpl extends AbstractCentralAuthe
         return serviceTicket;
     }
 
+    /**
+     * Always keep track of a single authentication object,
+     * as opposed to keeping a history of all. This helps with
+     * memory consumption. Note that supplemental authentications
+     * are to be removed.
+     * @param context authentication context
+     * @param ticketGrantingTicket the tgt
+     * @return the processed authentication in the current context
+     * @throws MixedPrincipalException in case there is a principal mismatch between TGT and the current authN. 
+     */
     private static Authentication evaluatePossibilityOfMixedPrincipals(final AuthenticationContext context,
                                                                 final TicketGrantingTicket ticketGrantingTicket)
             throws MixedPrincipalException {
@@ -196,6 +206,7 @@ public final class CentralAuthenticationServiceImpl extends AbstractCentralAuthe
                     throw new MixedPrincipalException(
                             currentAuthentication, currentAuthentication.getPrincipal(), original.getPrincipal());
                 }
+                ticketGrantingTicket.getSupplementalAuthentications().clear();
                 ticketGrantingTicket.getSupplementalAuthentications().add(currentAuthentication);
             }
         }


### PR DESCRIPTION
Closes #1714

Keeps a single authN instance in history. 