### PR TITLE
Allow the service username attribute to be retrieved as a principal attribute

### DIFF
--- a/cas-server-core-services/src/main/java/org/jasig/cas/services/PrincipalAttributeRegisteredServiceUsernameProvider.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/services/PrincipalAttributeRegisteredServiceUsernameProvider.java
@@ -51,6 +51,7 @@ public class PrincipalAttributeRegisteredServiceUsernameProvider implements Regi
     @Override
     public String resolveUsername(final Principal principal, final Service service) {
         String principalId = principal.getId();
+        final Map<String, Object> originalPrincipalAttributes = principal.getAttributes();
         final Map<String, Object> attributes = getPrincipalAttributes(principal, service);
 
         logger.debug("Principal attributes available for selection of username attribute [{}] are [{}].",
@@ -58,6 +59,13 @@ public class PrincipalAttributeRegisteredServiceUsernameProvider implements Regi
 
         if (attributes.containsKey(this.usernameAttribute)) {
             principalId = attributes.get(this.usernameAttribute).toString();
+        } else if (originalPrincipalAttributes.containsKey(this.usernameAttribute)) {
+            logger.warn("The selected username attribute [{}] was retrieved as a direct "
+                       + "principal attributes and not through the attribute release policy for service [{}]. "
+                       + "CAS is unable to detect new attribute values for [{}] after authentication unless the attribute "
+                       + "is explicitly authorized for release via the service attribute release policy.", 
+                    this.usernameAttribute, service, this.usernameAttribute);
+            principalId = originalPrincipalAttributes.get(this.usernameAttribute).toString();
         } else {
             logger.warn("Principal [{}] does not have an attribute [{}] among attributes [{}] so CAS cannot "
                     + "provide the user attribute the service expects. "


### PR DESCRIPTION
Closes #1738 

Today, if a username attribute is selected for a service definition in CAS, that attribute must also be authorized via the service attribute policy, such that goes through the attribute repository to retrieve, cache and update the value and then return it. If the attribute is not authorized, the service is not able to use it even though it may already be available as a simple principal attribute. 

This pull allows CAS to fallback and selects the username attribute value from the collection of principal attributes as they are. The attribute repository is tried first and if the attribute is not authorized for release, the fallback scenario is activated and a log message is generated. 